### PR TITLE
OP-16: MediaPipe wheel spike 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,17 @@ Computer Vision: OpenCV
 Development Environment: Jupyter Notebook
 
 ## Contributors
+
+The original capstone was built by:
+
 1. [Michael Nweke](https://github.com/m-nweke)
 2. [Ally Ryan](https://github.com/aerc4d)
 3. [Parisha Rathod](https://github.com/parisha8994)
+
+**Ally and Parisha contributed to v1 only.** Their work is preserved in the git history and in
+`docs/archive/`, and their copyright stands, but they are not involved in the v2 rewrite — it is
+maintained solely by Michael Nweke. Please do not direct v2 issues, questions, or review requests
+to them.
 
 ---
 
@@ -163,7 +171,8 @@ second with no model, no Docker and no database. It is enforced by
 
 ## License
 
-[MIT](LICENSE), © 2024-2026 Michael Nweke, Ally Ryan, Parisha Rathod.
+[MIT](LICENSE), © 2024-2026 Michael Nweke, Ally Ryan, Parisha Rathod. Ally Ryan and Parisha Rathod
+hold copyright for their v1 contributions; v2 is authored by Michael Nweke ([Contributors](#contributors)).
 
 `docs/archive/legacy-openpose/` vendors a third-party Keras implementation of CMU OpenPose under its
 own MIT licence (© 2020 Vinay Varma), preserved as audit evidence and imported by nothing. The Keras

--- a/docs/adr/0002-mediapipe-pose.md
+++ b/docs/adr/0002-mediapipe-pose.md
@@ -2,7 +2,8 @@
 
 **Status:** Accepted
 **Date:** 2026-07-26
-**Ticket:** OP-15, recording the OP-16 (B1) spike results
+**Ticket:** OP-15, recording the OP-16 (B1) spike results — spike executed and this ADR corrected
+under OP-16 on 2026-07-26
 **Supersedes nothing. Descopes OP-22 (B7, ONNX MoveNet fallback) — see "The gated risk".**
 
 This is the platform bet the whole pipeline rests on, so it is recorded in more detail than the
@@ -124,28 +125,79 @@ as it turns out — left again. Because an Apple Silicon dev machine and arm64 c
 scope, this was the one risk capable of invalidating the decision, so OP-16 gated it *before* any
 rules code was written.
 
-**Findings, verified against PyPI on 2026-07-26:**
+Executed 2026-07-26 on Docker 29.5.2, Apple Silicon host — `linux/arm64` natively and
+`linux/amd64` under emulation — against `python:3.12-slim` (Python 3.12.13).
 
-- **Linux aarch64 wheels were dropped after `0.10.18`.** `0.10.18` publishes
-  `manylinux_2_17_aarch64` for cp39–cp312. There is no `0.10.19`; **`0.10.20` is the first release
-  with zero linux-aarch64 wheels**, and the current release `0.10.35` publishes only
-  `manylinux_2_28_x86_64`, `win_amd64`, `win_arm64` and `macosx_11_0_arm64`. macOS arm64 survives;
-  Linux arm64 does not.
-- Both acceptance commands pass under `python:3.12-slim` on `linux/arm64` and `linux/amd64`, with
-  `--only-binary=:all:`, importing `mediapipe.tasks.python.vision.PoseLandmarker`.
-- **Therefore no ONNX MoveNet fallback is needed, and OP-22 (B7) is descoped.**
-- Transitive ceilings `0.10.18` imposes on the entire workspace: **`numpy<2`** and
-  **`protobuf<5,>=4.25.3`**. Co-installation with FastAPI 0.140, SQLAlchemy 2.0.51 and Pydantic
-  2.13 verified clean; `pip check` reports no broken requirements.
-- **Image size.** A default install is **857 MB** — `jaxlib` alone is 299 MB, `scipy` 146 MB, plus
-  `matplotlib` and `sentencepiece`, none of which pose inference uses. Installing `--no-deps` with
-  a hand-picked runtime set plus `opencv-python-headless` yields **311 MB** with `PoseLandmarker`
-  working. This matters against the <600 MB API image budget in OP-112.
-- **Correction to the plan's stated "container gotcha".** `0.10.18` hard-depends on
-  `opencv-contrib-python` — the *non-headless* build — so a default install genuinely needs
-  `libgl1` and `libglib2.0-0` in the image. Swapping to `opencv-python-headless` requires the
-  `--no-deps` route above; it is not a matter of overriding one requirement. Both options are
-  recorded because the choice is a size/complexity tradeoff, not a correctness one.
+**Finding 1: the wheel situation, verified against the live PyPI index.**
+
+| version | linux aarch64 | linux x86_64 |
+| --- | --- | --- |
+| `0.10.15` | yes | yes |
+| **`0.10.18`** | **yes** | **yes** |
+| `0.10.20` | **no** | yes |
+| `0.10.35` (current) | **no** | yes |
+
+`0.10.18` publishes `manylinux_2_17_aarch64` for cp39–cp312 (33 MB) and `manylinux_2_17_x86_64`
+(36 MB). There is no `0.10.19`; **`0.10.20` is the first release with zero linux-aarch64 wheels**,
+and `0.10.35` publishes only `manylinux_2_28_x86_64`, `win_amd64`, `win_arm64` and
+`macosx_11_0_arm64`. macOS arm64 survives; Linux arm64 does not.
+
+The wheel *installs* cleanly on both platforms with `--only-binary=:all:`, which is the question
+the spike existed to answer. **Therefore no ONNX MoveNet fallback is needed, and OP-22 (B7) is
+descoped.**
+
+**Finding 2: installing the wheel is not the same as importing it.** The acceptance command as
+originally written — `pip install` followed by `python -c 'import mediapipe'` on a bare
+`python:3.12-slim` — **fails, on both architectures identically**:
+
+```
+  File ".../mediapipe/python/solutions/drawing_utils.py", line 20, in <module>
+    import cv2
+ImportError: libGL.so.1: cannot open shared object file: No such file or directory
+```
+
+This is not an architecture problem and does not affect the decision. `0.10.18` hard-depends on
+`opencv-contrib-python` — the *non-headless* OpenCV build — which needs system OpenGL that the
+slim image does not ship. It is recorded here because an earlier revision of this ADR claimed both
+commands passed as written; they do not, and anyone re-running the spike would hit this first.
+
+**Finding 3: two install routes work, and they are not interchangeable.**
+
+| route | arm64 | amd64 | site-packages |
+| --- | --- | --- | --- |
+| **A.** default install + `apt-get install libgl1 libglib2.0-0` | pass | pass | 857 MB / 959 MB |
+| **B.** `mediapipe` + `opencv-python-headless`, no system packages | **fail** | **fail** | — |
+| **C.** `--no-deps` pinned runtime set + headless | pass | pass | 324 MB / 414 MB |
+
+**Route B is the trap, and it had already been committed.** Adding `opencv-python-headless`
+alongside mediapipe does *not* replace `opencv-contrib-python`. They are separate distributions
+that install into the same `cv2` namespace, so both land and the non-headless one wins the import
+— identical `libGL.so.1` failure. `pose-backends` declared exactly this pairing, with a comment
+asserting it "avoids that system dependency entirely." It does not. Fixed in the same change as
+this correction.
+
+**Route C is the image strategy**, recorded in `packages/pose-backends/requirements-mediapipe.txt`
+and consumed by the API image build. `--no-deps` cannot be expressed in `pyproject.toml`, which is
+why it is a separate pinned file rather than an extra. The `mediapipe` extra remains for local
+development and CI, where route A's system packages cost nothing.
+
+Two corrections to the earlier slim-install estimate. It recorded **311 MB**; the reproducible
+figures are **324 MB on arm64 and 414 MB on amd64**. And **`matplotlib` is not droppable** —
+`drawing_utils` imports `matplotlib.pyplot` at module scope alongside `cv2`, so it and its whole
+chain (contourpy, cycler, fonttools, kiwisolver, pillow, pyparsing, packaging, python-dateutil,
+six) must be named explicitly; omitting it fails with `No module named 'PIL'`. The savings come
+from dropping **`jax`, `jaxlib` and `scipy`** alone, which pose inference genuinely never imports.
+
+Against OP-112's <600 MB API image budget, 414 MB is site-packages *before* the base image, the
+model `.task` file and application code. That is a real constraint, not a comfortable margin.
+
+**Finding 4: no dependency conflict with the web stack.** Transitive ceilings `0.10.18` imposes on
+the entire workspace are **`numpy<2`** and **`protobuf<5,>=4.25.3`**. Co-installing the pin with an
+unpinned FastAPI/SQLAlchemy/Pydantic and letting the resolver choose yields FastAPI 0.140.0,
+SQLAlchemy 2.0.51, Pydantic 2.13.4, Starlette 1.3.1, uvicorn 0.51.0, with `numpy 1.26.4` and
+`protobuf 4.25.9` intact. `pip check` reports no broken requirements and all of it imports together
+in one interpreter alongside `PoseLandmarker`. The contingency of running the pose backend as its
+own compose service over HTTP is therefore not needed.
 
 ## Alternatives considered
 
@@ -177,6 +229,12 @@ in `posture-core` or `apps/api` moves.
   pure package has, now with a ceiling set by a package it must never import. An irony worth
   noticing, but not a violation: the constraint is on the resolved environment, not on
   `posture-core`'s own declared dependencies.
+- **Two install routes, deliberately.** The `mediapipe` extra in `pose-backends` pulls the full
+  dependency closure and needs `libgl1` + `libglib2.0-0`; that is fine for local dev and CI. The
+  API image installs `requirements-mediapipe.txt` with `--no-deps` instead. Because `--no-deps`
+  disables all consistency checking, every version in that file is pinned exactly and a bad
+  transitive bump would surface as an ImportError at container start rather than at install time —
+  regenerating it means re-verifying on both architectures.
 - The adapter owns the `NECK` derivation and all landmark renaming. Rules code sees canonical named
   keypoints and never an integer index.
 - Choosing a 3 M-parameter model over 52.3 M is a deliberate accuracy-for-latency trade. It is the

--- a/packages/pose-backends/pyproject.toml
+++ b/packages/pose-backends/pyproject.toml
@@ -13,13 +13,21 @@ dependencies = ["posture-core"]
 # used — without pulling a 300 MB inference stack. CI installs the base package only.
 #
 # mediapipe is pinned to 0.10.18: it is the LAST release publishing a PyPI linux aarch64 wheel.
-# 0.10.19+ ship manylinux x86_64 only, which would kill the local Docker demo on Apple Silicon.
-# Verified on linux/arm64 and linux/amd64 under python:3.12-slim by the OP-16 spike. See ADR-0002.
+# 0.10.20+ ship manylinux x86_64 only (there is no 0.10.19), which would kill the local Docker
+# demo on Apple Silicon. Verified against the PyPI index and by installing on both linux/arm64
+# and linux/amd64 under python:3.12-slim — OP-16 spike, see ADR-0002.
+#
+# NOTE: this extra installs mediapipe's own dependency closure, which includes
+# `opencv-contrib-python` — the NON-headless OpenCV build. It therefore requires libgl1 and
+# libglib2.0-0 to be present, and weighs ~857 MB (arm64) / ~959 MB (amd64) of site-packages.
+# That is acceptable for local development and CI, where a few apt packages cost nothing.
+#
+# It is NOT what the API image should install. Adding `opencv-python-headless` here does not
+# help: it is a separate distribution sharing the `cv2` namespace, so both builds land and the
+# non-headless one wins the import — the exact failure OP-16 reproduced on both architectures.
+# For the image, use the --no-deps route in `requirements-mediapipe.txt` instead.
 mediapipe = [
     "mediapipe==0.10.18",
-    # headless: mediapipe pulls opencv-contrib-python (non-headless) by default, which needs
-    # libgl1 present in the image. Headless avoids that system dependency entirely.
-    "opencv-python-headless>=4.10,<5",
 ]
 
 [build-system]

--- a/packages/pose-backends/requirements-mediapipe.txt
+++ b/packages/pose-backends/requirements-mediapipe.txt
@@ -1,0 +1,72 @@
+# Fully-resolved runtime set for the MediaPipe pose backend, for `pip install --no-deps`.
+#
+# WHY THIS FILE EXISTS INSTEAD OF A pyproject EXTRA
+# -------------------------------------------------
+# mediapipe 0.10.18 hard-depends on `opencv-contrib-python` — the NON-headless OpenCV build,
+# which needs libGL.so.1 and libglib2.0 present in the image. Declaring `opencv-python-headless`
+# alongside it does NOT swap the two: they are separate distributions that both install into the
+# same `cv2` namespace, so you get both, and the contrib build wins the import. Verified failing
+# on linux/arm64 AND linux/amd64 by the OP-16 spike.
+#
+# The only way to get a genuinely headless cv2 is to bypass mediapipe's dependency resolution
+# entirely with `--no-deps` and name every runtime import ourselves — which is what this file is.
+# `--no-deps` cannot be expressed in pyproject.toml, hence a separate pinned file.
+#
+# Consumed by the API image build (Epic D):
+#     pip install --no-deps --only-binary=:all: -r requirements-mediapipe.txt
+#
+# WHAT IS DELIBERATELY ABSENT
+# ---------------------------
+# jax, jaxlib and scipy. mediapipe declares them but pose inference never imports them, and they
+# are the bulk of the 857 MB default install. Dropping them yields 324 MB (arm64) / 414 MB
+# (amd64) of site-packages. See docs/adr/0002-mediapipe-pose.md.
+#
+# WHAT LOOKS DROPPABLE BUT IS NOT
+# -------------------------------
+# matplotlib and its entire dependency chain. `import mediapipe` reaches
+# mediapipe/python/solutions/drawing_utils.py, which imports `matplotlib.pyplot` at module scope
+# alongside cv2. Omitting it fails at import with `ModuleNotFoundError: No module named 'PIL'`.
+# Nothing in OpenPosture draws with it; it is an unavoidable import-time cost of the package.
+#
+# MAINTENANCE
+# -----------
+# Every version here is pinned exactly because `--no-deps` means pip does no consistency checking
+# whatsoever — a silently-resolved incompatible transitive dep would surface as an ImportError at
+# container start, not at install time. Regenerate by installing this set and running `pip freeze`,
+# then re-verify BOTH architectures. Do not bump mediapipe: 0.10.18 is the last release publishing
+# a linux aarch64 wheel (Dependabot is configured to ignore it).
+#
+# Verified 2026-07-26 on python:3.12-slim, linux/arm64 and linux/amd64: `import mediapipe` and
+# `from mediapipe.tasks.python.vision import PoseLandmarker` both succeed with no system packages
+# installed beyond the base image.
+
+mediapipe==0.10.18
+
+# Transitive ceilings mediapipe imposes on the whole workspace. Mirrored in posture-core's
+# `numpy>=1.26,<2` and in the Dependabot ignore list.
+numpy==1.26.4
+protobuf==4.25.9
+
+# Headless OpenCV — the entire point of the --no-deps route.
+opencv-python-headless==4.13.0.92
+
+# mediapipe's own direct imports.
+absl-py==2.5.0
+attrs==26.1.0
+flatbuffers==25.12.19
+sentencepiece==0.2.2
+sounddevice==0.5.5
+cffi==2.1.0
+pycparser==3.0
+
+# Pulled in only because drawing_utils imports matplotlib.pyplot at module scope (see above).
+matplotlib==3.11.1
+contourpy==1.3.3
+cycler==0.12.1
+fonttools==4.63.0
+kiwisolver==1.5.0
+pillow==12.3.0
+pyparsing==3.3.2
+packaging==26.2
+python-dateutil==2.9.0.post0
+six==1.17.0

--- a/uv.lock
+++ b/uv.lock
@@ -871,23 +871,6 @@ wheels = [
 ]
 
 [[package]]
-name = "opencv-python-headless"
-version = "4.11.0.86"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/36/2f/5b2b3ba52c864848885ba988f24b7f105052f68da9ab0e693cc7c25b0b30/opencv-python-headless-4.11.0.86.tar.gz", hash = "sha256:996eb282ca4b43ec6a3972414de0e2331f5d9cda2b41091a49739c19fb843798", size = 95177929, upload-time = "2025-01-16T13:53:40.22Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/53/2c50afa0b1e05ecdb4603818e85f7d174e683d874ef63a6abe3ac92220c8/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_arm64.whl", hash = "sha256:48128188ade4a7e517237c8e1e11a9cdf5c282761473383e77beb875bb1e61ca", size = 37326460, upload-time = "2025-01-16T13:52:57.015Z" },
-    { url = "https://files.pythonhosted.org/packages/3b/43/68555327df94bb9b59a1fd645f63fafb0762515344d2046698762fc19d58/opencv_python_headless-4.11.0.86-cp37-abi3-macosx_13_0_x86_64.whl", hash = "sha256:a66c1b286a9de872c343ee7c3553b084244299714ebb50fbdcd76f07ebbe6c81", size = 56723330, upload-time = "2025-01-16T13:55:45.731Z" },
-    { url = "https://files.pythonhosted.org/packages/45/be/1438ce43ebe65317344a87e4b150865c5585f4c0db880a34cdae5ac46881/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6efabcaa9df731f29e5ea9051776715b1bdd1845d7c9530065c7951d2a2899eb", size = 29487060, upload-time = "2025-01-16T13:51:59.625Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/5c/c139a7876099916879609372bfa513b7f1257f7f1a908b0bdc1c2328241b/opencv_python_headless-4.11.0.86-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0e0a27c19dd1f40ddff94976cfe43066fbbe9dfbb2ec1907d66c19caef42a57b", size = 49969856, upload-time = "2025-01-16T13:53:29.654Z" },
-    { url = "https://files.pythonhosted.org/packages/95/dd/ed1191c9dc91abcc9f752b499b7928aacabf10567bb2c2535944d848af18/opencv_python_headless-4.11.0.86-cp37-abi3-win32.whl", hash = "sha256:f447d8acbb0b6f2808da71fddd29c1cdd448d2bc98f72d9bb78a7a898fc9621b", size = 29324425, upload-time = "2025-01-16T13:52:49.048Z" },
-    { url = "https://files.pythonhosted.org/packages/86/8a/69176a64335aed183529207ba8bc3d329c2999d852b4f3818027203f50e6/opencv_python_headless-4.11.0.86-cp37-abi3-win_amd64.whl", hash = "sha256:6c304df9caa7a6a5710b91709dd4786bf20a74d57672b3c31f7033cc638174ca", size = 39402386, upload-time = "2025-01-16T13:52:56.418Z" },
-]
-
-[[package]]
 name = "openposture"
 version = "0.0.0"
 source = { virtual = "." }
@@ -1059,13 +1042,11 @@ dependencies = [
 [package.optional-dependencies]
 mediapipe = [
     { name = "mediapipe" },
-    { name = "opencv-python-headless" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "mediapipe", marker = "extra == 'mediapipe'", specifier = "==0.10.18" },
-    { name = "opencv-python-headless", marker = "extra == 'mediapipe'", specifier = ">=4.10,<5" },
     { name = "posture-core", editable = "packages/posture-core" },
 ]
 provides-extras = ["mediapipe"]


### PR DESCRIPTION
This pull request makes significant improvements to the documentation and dependency management for the MediaPipe pose backend, clarifying the installation process for different environments and correcting earlier ADR findings. The main changes include a detailed explanation of the MediaPipe dependency situation, a new requirements file for headless installs, and clear separation of development and production dependency strategies.

**Dependency management and installation strategy:**
- Added `requirements-mediapipe.txt` with a fully-pinned, minimal runtime set for production API image builds, using `--no-deps` to avoid unnecessary packages and system dependencies. This ensures a headless OpenCV install and reduces image size, with detailed maintenance notes and verification steps.
- Updated `pyproject.toml` to clarify that the `mediapipe` extra is for development/CI only, documents the pitfalls of mixing OpenCV builds, and directs production installs to use the new requirements file.

**Documentation and ADR corrections:**
- Overhauled ADR-0002 (`0002-mediapipe-pose.md`) with corrected and expanded findings from the OP-16 spike, including the full wheel situation, import-time dependency traps, and reproducible install strategies for both architectures. [[1]](diffhunk://#diff-b35b781102d4fada8bce37c89093b830cb0db523a6dac77d531632b3b5eaf074L5-R6) [[2]](diffhunk://#diff-b35b781102d4fada8bce37c89093b830cb0db523a6dac77d531632b3b5eaf074L127-R200)
- Added explicit documentation of the two supported install routes and their tradeoffs in the ADR, emphasizing the need for exact pinning and verification when using `--no-deps`.

**Project and contributor attribution:**
- Updated `README.md` to clarify project authorship for v2, crediting v1 contributors and specifying maintenance responsibilities for v2. Copyright and contributor sections were revised accordingly. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R52-R63) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L166-R175)