### PR TITLE
OP-17: Canonical keypoint types and PoseBackend Protocol

### DIFF
--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -15,6 +15,8 @@ that inversion is what keeps the core installable and testable with no inference
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from pose_backends.base import ImageBGR, PoseBackend
+
+__all__ = ["ImageBGR", "PoseBackend", "__version__"]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/base.py
+++ b/packages/pose-backends/src/pose_backends/base.py
@@ -1,0 +1,74 @@
+"""The seam between inference and everything else.
+
+One Protocol, three members. That narrowness is the asset: it is what lets a real model, a
+deterministic fake, and — if the platform bet in ADR-0002 ever goes bad — an entirely different
+inference runtime be swapped for one another without a single line changing in ``posture_core``
+or ``apps/api``.
+
+A ``Protocol`` rather than an ABC because conformance is then structural. Nothing has to import
+this class or inherit from it to satisfy it, so a test double can be a five-line class defined in
+the test that needs it, and mypy still checks it against the real contract. Inheriting from an
+ABC would make the fake depend on the package it exists to avoid.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeAlias, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from posture_core import PoseFrame
+
+__all__ = ["ImageBGR", "PoseBackend"]
+
+ImageBGR: TypeAlias = NDArray[np.uint8]
+"""An ``(H, W, 3)`` uint8 array in **BGR** channel order.
+
+BGR, not RGB, because that is what ``cv2.imread`` returns and OpenCV is what decodes uploads on
+the API path. Naming the convention in the type is cheap insurance: a silent channel swap does
+not crash, it just quietly degrades detection accuracy in a way no test would obviously catch.
+Adapters that need RGB convert internally — that is adapter business, not the caller's.
+"""
+
+
+@runtime_checkable
+class PoseBackend(Protocol):
+    """What every pose estimator must offer, and nothing more."""
+
+    @property
+    def name(self) -> str:
+        """Short stable identifier, stamped onto every :class:`~posture_core.PoseFrame`.
+
+        Declared as a read-only property rather than a bare ``name: str`` attribute so that both
+        forms conform: an implementation may expose a plain class attribute or a computed
+        property. A mutable attribute in the Protocol would reject the property form.
+        """
+        ...
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        """Find one person and return their skeleton, or ``None`` if there is nobody there.
+
+        **``None`` is the no-pose answer, not an exception.** An image with no person in it is an
+        ordinary outcome of a posture app — the user photographed their desk — and raising for it
+        would push every caller into a ``try/except`` around the happy path. Exceptions are
+        reserved for the backend being *broken*: a missing model file, an unreadable frame.
+
+        That distinction is what stops ``except Exception`` from reappearing. The legacy engine
+        swallowed failures and returned ``None``, and the caller rendered ``None`` as "Straight
+        back position" (FINDINGS §2.5) — so "no person" and "inference exploded" were reported to
+        the user identically, and both were reported as good posture.
+        """
+        ...
+
+    def warmup(self) -> None:
+        """Run one throwaway inference so the first real request does not pay for initialisation.
+
+        Called once at API startup (OP-40), where the cost is invisible. ``RUNDOWN.md``'s open
+        items flagged exactly this on the legacy engine — "a cold load is slow, per-request
+        loading would be unusable" — and never resolved it, because the model lived in a module
+        global built under a ``__main__`` guard and there was no startup hook to move it to.
+
+        Must be idempotent and must never raise on a healthy backend.
+        """
+        ...

--- a/packages/pose-backends/tests/test_base.py
+++ b/packages/pose-backends/tests/test_base.py
@@ -1,0 +1,114 @@
+"""Conformance tests for the `PoseBackend` Protocol.
+
+The Protocol is checked two ways, and both are needed because they catch different things:
+
+* **statically** — the `_assert_conforms` helper below assigns an implementation to a
+  `PoseBackend`-typed variable, so mypy --strict verifies signatures, argument types and return
+  types. This is the check that catches a `detect` returning `PoseFrame` instead of
+  `PoseFrame | None`.
+* **at runtime** — `isinstance`, which only sees whether the members exist. Weak on its own, but
+  it is what proves `@runtime_checkable` is actually usable for the config-driven backend
+  selection in OP-19.
+
+A missing method is caught by both. A wrong *signature* is caught only by mypy, which is why the
+static half is not redundant.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pose_backends import ImageBGR, PoseBackend
+from posture_core import KeypointName, Landmark, PoseFrame
+
+
+class MinimalBackend:
+    """The smallest thing that satisfies the Protocol.
+
+    Note what it does *not* do: import `PoseBackend`, inherit from it, or register with it. That
+    is the whole argument for a Protocol over an ABC — a test double is a local class, and mypy
+    still checks it against the real contract.
+    """
+
+    name = "minimal"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        height, width = image_bgr.shape[:2]
+        return PoseFrame(
+            landmarks={KeypointName.NOSE: Landmark(x=0.5, y=0.5, visibility=1.0, presence=1.0)},
+            image_width=width,
+            image_height=height,
+            backend=self.name,
+            inference_ms=0.0,
+        )
+
+    def warmup(self) -> None:
+        return None
+
+
+class ComputedNameBackend:
+    """`name` as a property, not an attribute — the reason the Protocol declares it as one.
+
+    Had the Protocol said `name: str`, mypy would reject this class: a read-only property does not
+    satisfy a mutable attribute. Both forms are legitimate, so the Protocol accommodates both.
+    """
+
+    @property
+    def name(self) -> str:
+        return "computed"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        return None
+
+    def warmup(self) -> None:
+        return None
+
+
+class MissingWarmup:
+    name = "incomplete"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        return None
+
+
+def _assert_conforms(backend: PoseBackend) -> str:
+    """Static conformance: mypy --strict checks the argument at every call site below."""
+    return backend.name
+
+
+def test_minimal_implementation_conforms_statically_and_at_runtime() -> None:
+    backend = MinimalBackend()
+    assert _assert_conforms(backend) == "minimal"
+    assert isinstance(backend, PoseBackend)
+
+
+def test_name_may_be_a_property() -> None:
+    backend = ComputedNameBackend()
+    assert _assert_conforms(backend) == "computed"
+    assert isinstance(backend, PoseBackend)
+
+
+def test_incomplete_implementation_is_rejected_at_runtime() -> None:
+    """A backend missing `warmup` must not pass as one — OP-40 calls it unconditionally."""
+    assert not isinstance(MissingWarmup(), PoseBackend)
+
+
+def test_detect_returns_a_frame_stamped_with_the_backend_and_image_size() -> None:
+    """Provenance travels with the data rather than being logged beside it."""
+    image: ImageBGR = np.zeros((480, 640, 3), dtype=np.uint8)
+    frame = MinimalBackend().detect(image)
+    assert frame is not None
+    assert frame.backend == "minimal"
+    assert (frame.image_width, frame.image_height) == (640, 480)
+
+
+def test_none_is_a_legitimate_detect_result() -> None:
+    """No person in the photo is an ordinary outcome, not an error.
+
+    This is the single most important line of the contract. The legacy engine returned `None` for
+    *both* "nobody there" and "inference failed", and the caller rendered `None` as "Straight back
+    position" (FINDINGS §2.5) — so a crash and a photo of an empty desk both told the user their
+    posture was fine. Here `None` means exactly one thing, and breakage raises.
+    """
+    image: ImageBGR = np.zeros((16, 16, 3), dtype=np.uint8)
+    assert ComputedNameBackend().detect(image) is None

--- a/packages/posture-core/src/posture_core/__init__.py
+++ b/packages/posture-core/src/posture_core/__init__.py
@@ -19,6 +19,8 @@ posture was fine whenever the system had failed to assess them at all.
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from posture_core.keypoints import KeypointName, Landmark, PoseFrame
+
+__all__ = ["KeypointName", "Landmark", "PoseFrame", "__version__"]
 
 __version__ = "0.1.0"

--- a/packages/posture-core/src/posture_core/keypoints.py
+++ b/packages/posture-core/src/posture_core/keypoints.py
@@ -1,0 +1,223 @@
+"""The canonical skeleton: the vocabulary every other module in the project speaks.
+
+These types live in ``posture_core`` — the package that depends on nothing heavier than numpy —
+and *not* in ``pose_backends``, which is where the inference libraries live. That inversion is
+deliberate and it is the load-bearing idea of the whole architecture:
+
+    the rules engine defines the contract, and inference adapters conform to it
+
+Put the types next to MediaPipe instead and the dependency arrow flips. ``posture_core`` would
+then need an inference stack installed just to describe a shoulder, its test suite would need a
+model, and swapping backends would mean editing rules. Defining them here means a backend is a
+file you add and a file you delete.
+
+Nothing in this module knows that MediaPipe exists. ``KeypointName`` members are project-owned
+names, not MediaPipe indices and not COCO indices. The integer mapping is private to whichever
+adapter needs one, and lives in ``pose_backends`` alongside it. Rules code never sees a magic
+number — which is precisely how the legacy engine's ear-index inversion (FINDINGS §2.1) became
+possible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterator, Mapping
+from enum import StrEnum
+from types import MappingProxyType
+
+__all__ = ["KeypointName", "Landmark", "PoseFrame"]
+
+
+class KeypointName(StrEnum):
+    """Every point the canonical skeleton can carry.
+
+    A ``StrEnum`` rather than a plain ``Enum`` so members serialise to readable JSON without a
+    custom encoder — ``"left_shoulder"``, not ``"KeypointName.LEFT_SHOULDER"``. The CLI (OP-21),
+    the golden fixtures (OP-43) and the API response all get that for free.
+
+    The set is the 33 landmarks MediaPipe produces, plus :attr:`NECK`, which no backend provides
+    directly. Members a given backend cannot supply are simply *absent* from a
+    :class:`PoseFrame`'s mapping — absence is the honest representation, and it is what lets a
+    17-point backend (the ONNX MoveNet escape hatch in ADR-0002) conform to the same schema
+    without inventing coordinates it never measured.
+    """
+
+    # --- head -------------------------------------------------------------------------------
+    NOSE = "nose"
+    LEFT_EYE_INNER = "left_eye_inner"
+    LEFT_EYE = "left_eye"
+    LEFT_EYE_OUTER = "left_eye_outer"
+    RIGHT_EYE_INNER = "right_eye_inner"
+    RIGHT_EYE = "right_eye"
+    RIGHT_EYE_OUTER = "right_eye_outer"
+    LEFT_EAR = "left_ear"
+    RIGHT_EAR = "right_ear"
+    MOUTH_LEFT = "mouth_left"
+    MOUTH_RIGHT = "mouth_right"
+
+    # --- upper body -------------------------------------------------------------------------
+    LEFT_SHOULDER = "left_shoulder"
+    RIGHT_SHOULDER = "right_shoulder"
+    LEFT_ELBOW = "left_elbow"
+    RIGHT_ELBOW = "right_elbow"
+    LEFT_WRIST = "left_wrist"
+    RIGHT_WRIST = "right_wrist"
+    LEFT_PINKY = "left_pinky"
+    RIGHT_PINKY = "right_pinky"
+    LEFT_INDEX = "left_index"
+    RIGHT_INDEX = "right_index"
+    LEFT_THUMB = "left_thumb"
+    RIGHT_THUMB = "right_thumb"
+
+    # --- lower body -------------------------------------------------------------------------
+    LEFT_HIP = "left_hip"
+    RIGHT_HIP = "right_hip"
+    LEFT_KNEE = "left_knee"
+    RIGHT_KNEE = "right_knee"
+    LEFT_ANKLE = "left_ankle"
+    RIGHT_ANKLE = "right_ankle"
+    LEFT_HEEL = "left_heel"
+    RIGHT_HEEL = "right_heel"
+    LEFT_FOOT_INDEX = "left_foot_index"
+    RIGHT_FOOT_INDEX = "right_foot_index"
+
+    # --- derived ----------------------------------------------------------------------------
+    NECK = "neck"
+    """Midpoint of the two shoulders. **Derived in the adapter, never in a rule.**
+
+    MediaPipe has no neck landmark, and neither did the legacy engine really: COCO keypoint 1 was
+    itself synthesised from the two shoulders. Deriving it once, in the adapter, is what makes
+    every backend present the same skeleton — and making the derivation explicit is what exposed
+    FINDINGS §2.2, where ``evaluate_neck_posture`` compared the shoulder midpoint's *y* against
+    the shoulder midpoint's *y* and could therefore only ever return one answer.
+    """
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Landmark:
+    """One measured point on the body.
+
+    Two coordinate systems, and the difference between them is the reason this project changed
+    models at all (ADR-0002, ADR-0005):
+
+    * :attr:`x` / :attr:`y` are **image space**, normalised to the frame's width and height. Good
+      for drawing an overlay; useless for a threshold, because the same posture photographed from
+      twice the distance produces half the pixel distances. That is FINDINGS §2.6 — the legacy
+      engine's central defect.
+    * :attr:`x_world` / :attr:`y_world` / :attr:`z_world` are **metres**, origin at the hip
+      midpoint. An angle computed from these is invariant to resolution and subject distance by
+      construction, so scale invariance stops being a normalisation problem and becomes a choice
+      of coordinate system.
+
+    Normalised coordinates are deliberately **not** range-validated. MediaPipe emits values
+    outside ``[0, 1]`` for joints it has extrapolated past the frame edge, and that is real
+    information — clamping or rejecting it here would destroy the signal the ``OUT_OF_FRAME``
+    keypoint status (OP-25) is built on.
+    """
+
+    x: float
+    """Horizontal position in image space, normalised by frame width. May fall outside [0, 1]."""
+
+    y: float
+    """Vertical position in image space, normalised by frame height, origin top-left."""
+
+    visibility: float
+    """[0, 1] — confidence the point is *visible*, i.e. not occluded by the body or an object."""
+
+    presence: float
+    """[0, 1] — confidence the point is *in frame at all*.
+
+    Independent of :attr:`visibility`, and the pairing is the point: low visibility with high
+    presence means occluded, low presence means out of frame. The legacy engine had no confidence
+    signal whatsoever, which is why a failed assessment surfaced as "Straight back position"
+    (FINDINGS §2.5) rather than as an honest "I could not see your knees".
+    """
+
+    x_world: float | None = None
+    """Metres, hip-midpoint origin. ``None`` on backends that produce no metric 3D."""
+
+    y_world: float | None = None
+    z_world: float | None = None
+
+    def __post_init__(self) -> None:
+        # World coordinates are all-or-nothing. A backend either reconstructs metric 3D or it does
+        # not; a half-populated triple could only come from an adapter bug, and letting it through
+        # would surface much later as a nonsensical angle rather than as an obviously bad frame.
+        world = (self.x_world, self.y_world, self.z_world)
+        if any(c is None for c in world) and any(c is not None for c in world):
+            raise ValueError(
+                "world coordinates must be all present or all absent, "
+                f"got x_world={self.x_world!r}, y_world={self.y_world!r}, "
+                f"z_world={self.z_world!r}"
+            )
+
+    @property
+    def has_world(self) -> bool:
+        """Whether this landmark carries metric 3D, and so whether world-space rules may use it."""
+        return self.x_world is not None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PoseFrame:
+    """One person's skeleton, detected in one image, by one backend.
+
+    This is the entire surface between inference and rules. Everything downstream — metrics,
+    findings, the report, the API response, the canvas overlay — is a pure function of a
+    ``PoseFrame``, which is what lets the rules engine be tested with hand-built skeletons and no
+    model installed (OP-33, OP-40).
+
+    :attr:`backend` and :attr:`inference_ms` travel *with* the data rather than being logged
+    beside it, so a stored report can always answer "which engine produced this, and how long did
+    it take" — the raw material for the legacy-vs-new comparison in ``docs/evaluation.md``.
+    """
+
+    landmarks: Mapping[KeypointName, Landmark]
+    """Detected points only.
+
+    A missing key means "this backend did not report this point", never "confidence zero". Callers
+    must handle absence; :meth:`get` and ``in`` are the intended way to do it.
+    """
+
+    image_width: int
+    image_height: int
+    backend: str
+    """Identifier of the adapter that produced this frame, e.g. ``"mediapipe"`` or ``"fake"``."""
+
+    inference_ms: float
+    """Wall-clock time spent inside ``detect()``, for the CLI table and latency diagnostics."""
+
+    def __post_init__(self) -> None:
+        # A frozen dataclass freezes the *attribute binding*, not the object bound to it — without
+        # this, `frame.landmarks[NECK] = ...` would mutate a "frozen" frame quite happily. Copying
+        # into a MappingProxyType makes the mapping genuinely read-only and detaches it from the
+        # dict the adapter built, which the adapter is otherwise free to keep mutating.
+        object.__setattr__(self, "landmarks", MappingProxyType(dict(self.landmarks)))
+
+        if self.image_width <= 0 or self.image_height <= 0:
+            raise ValueError(
+                f"image dimensions must be positive, got {self.image_width}x{self.image_height}"
+            )
+
+    def get(self, name: KeypointName) -> Landmark | None:
+        """The landmark for ``name``, or ``None`` if this backend did not report it."""
+        return self.landmarks.get(name)
+
+    def __contains__(self, name: KeypointName) -> bool:
+        return name in self.landmarks
+
+    def __iter__(self) -> Iterator[KeypointName]:
+        return iter(self.landmarks)
+
+    def __len__(self) -> int:
+        return len(self.landmarks)
+
+    @property
+    def has_world_landmarks(self) -> bool:
+        """Whether every reported landmark carries metric 3D.
+
+        The switch ADR-0005 turns on: ``True`` means angular metrics may be computed in world
+        space and are scale-invariant for free; ``False`` means falling back to image space with
+        torso-length normalisation, with the accuracy loss that implies. An empty frame is
+        ``False`` — no evidence is not evidence of world coordinates.
+        """
+        return bool(self.landmarks) and all(lm.has_world for lm in self.landmarks.values())

--- a/packages/posture-core/tests/test_keypoints.py
+++ b/packages/posture-core/tests/test_keypoints.py
@@ -1,0 +1,237 @@
+"""Tests for the canonical skeleton types.
+
+These are cheap tests of a cheap module, and worth writing anyway: every metric, every rule and
+every API response is built on these three types, so an invariant that leaks here is one that
+leaks everywhere. In particular the immutability tests below guard something a reader would
+reasonably assume `frozen=True` already gave them, and which it does not.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from posture_core import KeypointName, Landmark, PoseFrame
+
+
+def make_landmark(**overrides: float | None) -> Landmark:
+    defaults: dict[str, float | None] = {"x": 0.5, "y": 0.5, "visibility": 0.9, "presence": 0.9}
+    defaults.update(overrides)
+    return Landmark(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------------------------
+# KeypointName
+# ---------------------------------------------------------------------------------------------
+
+
+def test_covers_all_33_mediapipe_landmarks_plus_derived_neck() -> None:
+    """The count is the contract OP-18 and OP-21 are written against.
+
+    MediaPipe reports 33 points; NECK is derived by the adapter and brings the canonical skeleton
+    to 34. The CLI's landmark table and the adapter's "25 or more landmarks detected" acceptance
+    criterion both assume this, so pinning the number here makes an accidental addition or
+    deletion a test failure rather than a puzzling off-by-one in a downstream assertion.
+    """
+    assert len(KeypointName) == 34
+
+
+def test_members_serialise_as_readable_strings() -> None:
+    """StrEnum, so JSON needs no custom encoder. The CLI and golden fixtures depend on this.
+
+    `str(member)` rather than `member == "..."`: mypy --strict rejects the direct comparison as
+    non-overlapping even though StrEnum makes it true at runtime. Asserting on the rendered string
+    is the property that actually matters anyway — it is what lands in JSON.
+    """
+    assert str(KeypointName.LEFT_SHOULDER) == "left_shoulder"
+    assert f"{KeypointName.NECK}" == "neck"
+    assert json.dumps([KeypointName.NECK]) == '["neck"]'
+
+
+def test_values_are_unique() -> None:
+    """Two names sharing a value would silently alias — StrEnum resolves the second to the first.
+
+    That is not hypothetical here: the members are hand-written and several differ by one word.
+    A duplicated value would make one keypoint permanently unreachable with no error anywhere.
+    """
+    assert len({member.value for member in KeypointName}) == len(KeypointName)
+
+
+def test_laterality_is_symmetric() -> None:
+    """Every LEFT_* has a RIGHT_* twin and vice versa.
+
+    Worth asserting because the legacy engine's defining bug was a laterality mix-up: `API/config`
+    declared 16=left ear, the code commented it the other way round, and the resulting flag made
+    spine classification backwards for one facing direction (FINDINGS §2.1). Named landmarks make
+    that class of bug impossible — provided the names themselves are complete.
+    """
+    left = {name.value.removeprefix("left_") for name in KeypointName if name.startswith("left_")}
+    right = {
+        name.value.removeprefix("right_") for name in KeypointName if name.startswith("right_")
+    }
+    assert left == right
+
+
+# ---------------------------------------------------------------------------------------------
+# Landmark
+# ---------------------------------------------------------------------------------------------
+
+
+def test_landmark_is_immutable() -> None:
+    landmark = make_landmark()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        landmark.x = 0.1  # type: ignore[misc]
+
+
+def test_landmark_uses_slots() -> None:
+    """No `__dict__`: a typo'd attribute cannot be silently attached to an instance.
+
+    There is one Landmark per keypoint per frame — 34 per detection — so the memory saving is
+    real, but the typo-catching is the reason. Asserting on `__dict__`'s absence rather than
+    trying an assignment because on a `frozen=True, slots=True` dataclass an unknown attribute
+    raises from the frozen `__setattr__` first, which would make this test pass for the wrong
+    reason on a class that had slots removed.
+    """
+    assert not hasattr(make_landmark(), "__dict__")
+    assert Landmark.__slots__ == (
+        "x",
+        "y",
+        "visibility",
+        "presence",
+        "x_world",
+        "y_world",
+        "z_world",
+    )
+
+
+def test_world_coordinates_default_to_absent() -> None:
+    landmark = make_landmark()
+    assert landmark.has_world is False
+    assert (landmark.x_world, landmark.y_world, landmark.z_world) == (None, None, None)
+
+
+def test_world_coordinates_are_recognised_when_present() -> None:
+    landmark = make_landmark(x_world=0.1, y_world=-0.4, z_world=0.02)
+    assert landmark.has_world is True
+
+
+@pytest.mark.parametrize(
+    "partial",
+    [
+        {"x_world": 0.1},
+        {"x_world": 0.1, "y_world": 0.2},
+        {"z_world": 0.3},
+        {"y_world": 0.2, "z_world": 0.3},
+    ],
+)
+def test_partial_world_coordinates_are_rejected(partial: dict[str, float]) -> None:
+    """All-or-nothing: a backend either reconstructs metric 3D or it does not.
+
+    A half-populated triple can only be an adapter bug, and if it were allowed through it would
+    surface much later as a nonsensical angle rather than as an obviously malformed frame.
+    """
+    with pytest.raises(ValueError, match="all present or all absent"):
+        make_landmark(**partial)
+
+
+@pytest.mark.parametrize("coordinate", [-0.2, 1.4])
+def test_out_of_frame_coordinates_are_allowed(coordinate: float) -> None:
+    """Deliberately not range-validated.
+
+    MediaPipe extrapolates joints past the frame edge and reports normalised values outside
+    [0, 1]. That is real information — it is the evidence the OUT_OF_FRAME keypoint status (OP-25)
+    is built on — so clamping or rejecting it here would destroy the signal.
+    """
+    assert make_landmark(x=coordinate).x == coordinate
+
+
+# ---------------------------------------------------------------------------------------------
+# PoseFrame
+# ---------------------------------------------------------------------------------------------
+
+
+def make_frame(
+    landmarks: dict[KeypointName, Landmark] | None = None, **overrides: object
+) -> PoseFrame:
+    kwargs: dict[str, object] = {
+        "landmarks": landmarks if landmarks is not None else {KeypointName.NOSE: make_landmark()},
+        "image_width": 640,
+        "image_height": 480,
+        "backend": "test",
+        "inference_ms": 1.5,
+    }
+    kwargs.update(overrides)
+    return PoseFrame(**kwargs)  # type: ignore[arg-type]
+
+
+def test_frame_is_immutable() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        make_frame().backend = "other"  # type: ignore[misc]
+
+
+def test_landmark_mapping_cannot_be_mutated_through_the_frame() -> None:
+    """The one that `frozen=True` does *not* give you.
+
+    Freezing a dataclass freezes the attribute *binding*, not the object bound to it — so without
+    the MappingProxyType wrapper in `__post_init__`, `frame.landmarks[NECK] = ...` would mutate a
+    supposedly frozen frame without complaint.
+    """
+    frame = make_frame()
+    with pytest.raises(TypeError):
+        frame.landmarks[KeypointName.NECK] = make_landmark()  # type: ignore[index]
+
+
+def test_frame_is_detached_from_the_dict_it_was_built_from() -> None:
+    """An adapter reusing its scratch dict between calls must not retroactively edit past frames."""
+    scratch = {KeypointName.NOSE: make_landmark()}
+    frame = make_frame(scratch)
+    scratch[KeypointName.LEFT_EAR] = make_landmark()
+    assert KeypointName.LEFT_EAR not in frame
+    assert len(frame) == 1
+
+
+@pytest.mark.parametrize(("width", "height"), [(0, 480), (640, 0), (-1, 480), (640, -1)])
+def test_non_positive_image_dimensions_are_rejected(width: int, height: int) -> None:
+    """Guards a divide-by-zero in every image-space normalisation downstream."""
+    with pytest.raises(ValueError, match="dimensions must be positive"):
+        make_frame(image_width=width, image_height=height)
+
+
+def test_missing_landmark_reads_as_absent_not_as_zero_confidence() -> None:
+    """Absence and low confidence are different facts and must stay distinguishable.
+
+    Collapsing them is how you end up asserting on a keypoint the backend never reported.
+    """
+    frame = make_frame({KeypointName.NOSE: make_landmark()})
+    assert frame.get(KeypointName.LEFT_KNEE) is None
+    assert KeypointName.LEFT_KNEE not in frame
+    assert frame.get(KeypointName.NOSE) is not None
+
+
+def test_frame_is_iterable_over_reported_keypoints() -> None:
+    frame = make_frame({KeypointName.NOSE: make_landmark(), KeypointName.NECK: make_landmark()})
+    assert set(frame) == {KeypointName.NOSE, KeypointName.NECK}
+    assert len(frame) == 2
+
+
+def test_has_world_landmarks_requires_every_reported_point_to_carry_metric_3d() -> None:
+    """The ADR-0005 switch: world-space geometry, or image space with torso normalisation.
+
+    A partially-world frame must read as False. Answering True would let a metric silently mix
+    metres and normalised pixels in one calculation.
+    """
+    world = make_landmark(x_world=0.0, y_world=0.0, z_world=0.0)
+    assert make_frame({KeypointName.NOSE: world}).has_world_landmarks is True
+    assert (
+        make_frame(
+            {KeypointName.NOSE: world, KeypointName.NECK: make_landmark()}
+        ).has_world_landmarks
+        is False
+    )
+
+
+def test_empty_frame_has_no_world_landmarks() -> None:
+    """`all()` over nothing is True, which would be exactly the wrong answer here."""
+    assert make_frame({}).has_world_landmarks is False


### PR DESCRIPTION
Closes OP-17. Base: `main`.

Adds the backend-independent skeleton types and the inference Protocol.

## Changes
- `posture_core.keypoints`: `KeypointName` (the 33 MediaPipe landmarks plus a derived `NECK`), `Landmark`, `PoseFrame`. All frozen with slots.
- `pose_backends.base`: `PoseBackend` Protocol — `name`, `detect(image_bgr) -> PoseFrame | None`, `warmup()`. Runtime-checkable.

## Notes
- The types live in `posture-core` rather than beside the inference library so the rules engine defines the contract and adapters conform to it. `posture-core` stays installable and testable with no inference stack present.
- `NECK` is derived in the adapter as the shoulder midpoint; MediaPipe reports no neck landmark. Legacy COCO keypoint 1 was itself synthesised the same way (FINDINGS §2.2).
- Normalised coordinates are not range-validated. MediaPipe emits values outside `[0, 1]` for joints extrapolated past the frame edge; OP-25 uses that as evidence for `OUT_OF_FRAME`.
- `PoseFrame.__post_init__` copies the landmark mapping into a `MappingProxyType`. `frozen=True` freezes the attribute binding, not the dict, so the mapping would otherwise remain mutable.
- `detect()` returns `None` only for "no person detected". Backend failures raise (errors land in OP-18).
- `PoseBackend.name` is declared as a read-only property so both a plain attribute and a computed property satisfy it.

## Tests
44 tests, 100% coverage on the new modules. Protocol conformance is checked statically (a conforming class assigned to a `PoseBackend`-typed parameter, so mypy validates signatures) and at runtime (`isinstance`).
