### PR TITLE
OP-18: Implement MediaPipeBackend

### DIFF
--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -16,7 +16,25 @@ that inversion is what keeps the core installable and testable with no inference
 from __future__ import annotations
 
 from pose_backends.base import ImageBGR, PoseBackend
+from pose_backends.errors import (
+    BackendUnavailableError,
+    InvalidImageError,
+    ModelLoadError,
+    ModelNotFoundError,
+    PoseBackendError,
+)
+from pose_backends.mediapipe_backend import MediaPipeBackend
 
-__all__ = ["ImageBGR", "PoseBackend", "__version__"]
+__all__ = [
+    "BackendUnavailableError",
+    "ImageBGR",
+    "InvalidImageError",
+    "MediaPipeBackend",
+    "ModelLoadError",
+    "ModelNotFoundError",
+    "PoseBackend",
+    "PoseBackendError",
+    "__version__",
+]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/errors.py
+++ b/packages/pose-backends/src/pose_backends/errors.py
@@ -1,0 +1,67 @@
+"""What "the backend is broken" looks like, as opposed to "there is nobody in the photo".
+
+That distinction is the whole reason this module exists. ``detect()`` returns ``None`` for the
+ordinary case of an image with no person in it; it raises one of these when the backend itself
+cannot do its job. Collapsing the two is precisely the legacy engine's most damaging behaviour —
+a swallowed exception and an empty desk both became ``None``, and the caller rendered ``None`` as
+"Straight back position" (FINDINGS §2.5).
+
+Every exception here carries a message a human can act on. "Model file not found at
+/app/models/x.task — run `make fetch-model`" is a bug report someone can fix; an
+``AttributeError`` from four frames inside a vendored C++ binding is not.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "BackendUnavailableError",
+    "InvalidImageError",
+    "ModelLoadError",
+    "ModelNotFoundError",
+    "PoseBackendError",
+]
+
+
+class PoseBackendError(RuntimeError):
+    """Base for every backend failure.
+
+    One base class so callers that genuinely want to treat all backend breakage alike — the API's
+    problem+json handler (OP-39) — can catch this and nothing else. That is the alternative to
+    ``except Exception``, which the project bans outright: a narrow catch of a type we defined
+    still lets a genuine programming error propagate.
+    """
+
+
+class BackendUnavailableError(PoseBackendError):
+    """The inference library is not installed.
+
+    Its own error rather than letting ``ImportError`` escape, because the fix is specific and
+    non-obvious: ``mediapipe`` is an *optional* extra (ADR-0002), so that ``pose-backends`` can be
+    installed — and ``FakePoseBackend`` used — without a 300 MB inference stack. Someone hitting
+    this has almost certainly installed the base package and expected the real backend.
+    """
+
+
+class ModelNotFoundError(PoseBackendError):
+    """No model file at the configured path.
+
+    Distinct from :class:`ModelLoadError` because the remedies differ: this one means fetch the
+    weights, that one means the weights you fetched are wrong.
+    """
+
+
+class ModelLoadError(PoseBackendError):
+    """A file is there, but the inference runtime would not accept it.
+
+    Truncated download, wrong model variant, corrupted checkout. The checksum pin in OP-20 exists
+    to turn most of these into a loud failure at fetch time instead of a puzzling one at startup.
+    """
+
+
+class InvalidImageError(PoseBackendError):
+    """The array handed to ``detect()`` is not an image this backend can work with.
+
+    A programming error at the call site rather than a bad photo — an empty array, a greyscale
+    frame, a channel count that is not 3. Raising is right here: unlike "no person detected", there
+    is no sensible result to return and no user-facing story to tell.
+    """

--- a/packages/pose-backends/src/pose_backends/mediapipe_backend.py
+++ b/packages/pose-backends/src/pose_backends/mediapipe_backend.py
@@ -1,0 +1,413 @@
+"""The real inference adapter: MediaPipe Pose Landmarker behind the ``PoseBackend`` Protocol.
+
+This module is where the one heavy, platform-fragile dependency in the project is quarantined.
+Everything MediaPipe-specific — the 33 integer landmark indices, the Tasks API, the RGB channel
+order, the vendored C++ binding — stops here. Rules code sees canonical named keypoints.
+
+## The two-layer split, and why it is not over-engineering
+
+``MediaPipeBackend`` does the *translation*: timing, colour conversion, index-to-name mapping,
+``NECK`` derivation, ``PoseFrame`` construction. ``_TasksDetector`` does the *inference*, and is
+the only thing in the file that imports ``mediapipe``.
+
+The seam between them is :class:`RawPoseDetector`. It buys the thing the ticket asks for: the
+mapping tests run against a stub detector, with **no model file and no mediapipe installed**, in
+required CI. A transposed landmark index is exactly the class of bug that made the legacy engine
+wrong (FINDINGS §2.1) and it is invisible without a test — so that test must be cheap enough to
+run on every pull request, which means it cannot need 300 MB of wheels and a model download.
+
+Real-model tests exist too, marked ``pytest.mark.model``, and run on demand (OP-21).
+
+## Legacy defects this design forecloses
+
+* **No module-global model.** The legacy engine built its model at import time from a
+  cwd-relative config, so neither ``process()`` function was importable and the whole thing only
+  ran from inside ``API/``. Here the model is an instance attribute loaded in ``__init__``, and
+  the path is a constructor argument.
+* **No laterality flag.** MediaPipe returns named LEFT and RIGHT landmarks. The hand-rolled ``f``
+  flag that made spine classification backwards for one facing direction has nothing to key off.
+* **No cwd dependency.** ``model_path`` is resolved to an absolute path on construction.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, Protocol, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pose_backends.errors import (
+    BackendUnavailableError,
+    InvalidImageError,
+    ModelLoadError,
+    ModelNotFoundError,
+)
+from posture_core import KeypointName, Landmark, PoseFrame
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pose_backends.base import ImageBGR
+
+__all__ = [
+    "MEDIAPIPE_INDEX_TO_KEYPOINT",
+    "MediaPipeBackend",
+    "RawDetection",
+    "RawLandmark",
+    "RawPoseDetector",
+]
+
+ImageRGB: TypeAlias = NDArray[np.uint8]
+
+BACKEND_NAME: Final = "mediapipe"
+
+# The complete MediaPipe Pose Landmarker schema, index -> canonical name. Transcribed from the
+# landmark table in docs/adr/0002-mediapipe-pose.md, which also records the legacy COCO-18
+# correspondence. NECK (index-less, derived below) is deliberately absent: no backend reports it.
+#
+# Written out in full rather than generated from the enum's declaration order. Ordering is not a
+# contract of an enum, and tying a wire format to it would make an innocuous reordering of the
+# members silently remap every landmark.
+MEDIAPIPE_INDEX_TO_KEYPOINT: Final[Mapping[int, KeypointName]] = {
+    0: KeypointName.NOSE,
+    1: KeypointName.LEFT_EYE_INNER,
+    2: KeypointName.LEFT_EYE,
+    3: KeypointName.LEFT_EYE_OUTER,
+    4: KeypointName.RIGHT_EYE_INNER,
+    5: KeypointName.RIGHT_EYE,
+    6: KeypointName.RIGHT_EYE_OUTER,
+    7: KeypointName.LEFT_EAR,
+    8: KeypointName.RIGHT_EAR,
+    9: KeypointName.MOUTH_LEFT,
+    10: KeypointName.MOUTH_RIGHT,
+    11: KeypointName.LEFT_SHOULDER,
+    12: KeypointName.RIGHT_SHOULDER,
+    13: KeypointName.LEFT_ELBOW,
+    14: KeypointName.RIGHT_ELBOW,
+    15: KeypointName.LEFT_WRIST,
+    16: KeypointName.RIGHT_WRIST,
+    17: KeypointName.LEFT_PINKY,
+    18: KeypointName.RIGHT_PINKY,
+    19: KeypointName.LEFT_INDEX,
+    20: KeypointName.RIGHT_INDEX,
+    21: KeypointName.LEFT_THUMB,
+    22: KeypointName.RIGHT_THUMB,
+    23: KeypointName.LEFT_HIP,
+    24: KeypointName.RIGHT_HIP,
+    25: KeypointName.LEFT_KNEE,
+    26: KeypointName.RIGHT_KNEE,
+    27: KeypointName.LEFT_ANKLE,
+    28: KeypointName.RIGHT_ANKLE,
+    29: KeypointName.LEFT_HEEL,
+    30: KeypointName.RIGHT_HEEL,
+    31: KeypointName.LEFT_FOOT_INDEX,
+    32: KeypointName.RIGHT_FOOT_INDEX,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RawLandmark:
+    """One point as the inference runtime reports it, before any canonical naming.
+
+    Deliberately a plain value object rather than MediaPipe's own type, so that the stub in the
+    tests can produce these without importing mediapipe. ``z`` is normalised depth in the image
+    result and metres in the world result; the adapter only uses the latter.
+    """
+
+    x: float
+    y: float
+    z: float
+    visibility: float
+    presence: float
+
+
+@dataclass(frozen=True, slots=True)
+class RawDetection:
+    """One detected person: the image-space landmarks, and the world-space ones if available."""
+
+    landmarks: Sequence[RawLandmark]
+    world_landmarks: Sequence[RawLandmark] | None = None
+
+
+class RawPoseDetector(Protocol):
+    """The narrow seam that keeps mediapipe out of the mapping tests."""
+
+    def detect(self, image_rgb: ImageRGB) -> RawDetection | None:
+        """Landmarks for the most prominent person, or ``None`` if there is nobody."""
+        ...
+
+    def close(self) -> None:
+        """Release the native inference graph. Must be idempotent."""
+        ...
+
+
+class MediaPipeBackend:
+    """Pose estimation via MediaPipe Pose Landmarker, pinned to ``mediapipe==0.10.18``.
+
+    The pin is load-bearing, not incidental: 0.10.18 is the last release publishing a PyPI
+    ``linux aarch64`` wheel, and bumping it kills the local Docker demo on Apple Silicon. See
+    ADR-0002 for the spike that established this.
+    """
+
+    name: Final = BACKEND_NAME
+
+    def __init__(
+        self,
+        model_path: Path | str,
+        *,
+        min_pose_detection_confidence: float = 0.5,
+        detector_factory: Callable[[Path, float], RawPoseDetector] | None = None,
+    ) -> None:
+        """Load the model **once**, here, and keep it for the life of the instance.
+
+        The API constructs exactly one of these in its ``lifespan`` hook (OP-40) and reuses it for
+        every request. Loading per request would be unusable — which is what ``RUNDOWN.md``'s open
+        items flagged about the legacy engine and never resolved.
+
+        ``detector_factory`` is the test seam. Left at ``None`` it builds the real MediaPipe Tasks
+        detector; the mapping tests pass a stub and never touch a model file.
+        """
+        self._model_path = Path(model_path).expanduser().resolve()
+        factory = detector_factory if detector_factory is not None else _create_tasks_detector
+        self._detector = factory(self._model_path, min_pose_detection_confidence)
+        self._closed = False
+
+    @property
+    def model_path(self) -> Path:
+        """Absolute path to the loaded weights — reported by the CLI and the health endpoint."""
+        return self._model_path
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        _validate_image(image_bgr)
+        height, width = image_bgr.shape[:2]
+
+        # BGR -> RGB. cv2 decodes to BGR, MediaPipe expects RGB, and getting this wrong does not
+        # crash — it silently degrades detection in a way no assertion would obviously catch.
+        # `ascontiguousarray` because the reversed view has a negative stride and the native
+        # binding needs a contiguous buffer.
+        image_rgb: ImageRGB = np.ascontiguousarray(image_bgr[:, :, ::-1])
+
+        started = time.perf_counter()
+        raw = self._detector.detect(image_rgb)
+        inference_ms = (time.perf_counter() - started) * 1000.0
+
+        if raw is None or not raw.landmarks:
+            # An ordinary outcome — the user photographed their desk. Not an error.
+            return None
+
+        return PoseFrame(
+            landmarks=self._to_canonical(raw),
+            image_width=width,
+            image_height=height,
+            backend=self.name,
+            inference_ms=inference_ms,
+        )
+
+    def warmup(self) -> None:
+        """Run one throwaway inference at startup, on a frame nobody is waiting for.
+
+        **Measured caveat, 2026-07-26** (Apple M5, ``pose_landmarker_full``, 1280x720): with
+        ``mediapipe==0.10.18`` in ``RunningMode.IMAGE`` this saves nothing measurable. The graph is
+        built eagerly inside ``create_from_options``, so construction costs ~31 ms and every
+        inference afterwards costs ~23 ms — the first one included. The plan assumed a lazily-built
+        graph. It is not one.
+
+        Kept anyway, and not as dead code. The guarantee the API needs is "no request ever pays an
+        initialisation cost", and that should not silently rest on an implementation detail of one
+        pinned library version. One synthetic frame at startup is a trivial price for a contract
+        that still holds if a future release defers work — and the ONNX escape hatch in ADR-0002
+        would genuinely need it.
+        """
+        self.detect(np.zeros((256, 256, 3), dtype=np.uint8))
+
+    def close(self) -> None:
+        """Release the native graph. Idempotent; safe to call from a lifespan shutdown.
+
+        The guard is here rather than left to the detector. :class:`RawPoseDetector` asks
+        implementors for idempotence, but the real one wraps a vendored C++ object whose own
+        ``close()`` makes no such promise — and a second call raising during shutdown would turn
+        an orderly stop into a stack trace. Tracking the state costs a boolean.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        self._detector.close()
+
+    # -- translation ---------------------------------------------------------------------------
+
+    def _to_canonical(self, raw: RawDetection) -> dict[KeypointName, Landmark]:
+        """MediaPipe's indexed arrays -> the canonical named skeleton."""
+        world = raw.world_landmarks
+        # A world array of a different length than the image array can only be a runtime change we
+        # have not accounted for. Pairing them by index anyway would attach one landmark's metres
+        # to another landmark's pixels — wrong answers, no error. Drop world instead.
+        if world is not None and len(world) != len(raw.landmarks):
+            world = None
+
+        landmarks: dict[KeypointName, Landmark] = {}
+        for index, raw_landmark in enumerate(raw.landmarks):
+            name = MEDIAPIPE_INDEX_TO_KEYPOINT.get(index)
+            if name is None:
+                # A future model variant reporting extra points. Ignoring them is correct: the
+                # canonical schema is the project's, not MediaPipe's.
+                continue
+            world_landmark = world[index] if world is not None else None
+            landmarks[name] = Landmark(
+                x=raw_landmark.x,
+                y=raw_landmark.y,
+                visibility=raw_landmark.visibility,
+                presence=raw_landmark.presence,
+                x_world=None if world_landmark is None else world_landmark.x,
+                y_world=None if world_landmark is None else world_landmark.y,
+                z_world=None if world_landmark is None else world_landmark.z,
+            )
+
+        neck = _derive_neck(landmarks)
+        if neck is not None:
+            landmarks[KeypointName.NECK] = neck
+        return landmarks
+
+
+def _derive_neck(landmarks: Mapping[KeypointName, Landmark]) -> Landmark | None:
+    """``NECK`` as the midpoint of the two shoulders — the one real schema change (ADR-0002).
+
+    Derived **here, in the adapter**, so every backend presents the same skeleton and no rule ever
+    has to know that MediaPipe lacks a neck landmark. Note this is not an innovation: legacy COCO
+    keypoint 1 was itself synthesised from the two shoulders. Making the derivation explicit is
+    what exposed FINDINGS §2.2, where ``evaluate_neck_posture`` compared the shoulder midpoint's
+    *y* against the shoulder midpoint's *y* — a point against itself, one possible answer.
+
+    Confidence is the **minimum** of the two shoulders, not the mean. A derived point cannot be
+    more trustworthy than the least trustworthy thing it was derived from, and averaging would let
+    one confidently-seen shoulder launder an unseen one into a plausible-looking neck.
+    """
+    left = landmarks.get(KeypointName.LEFT_SHOULDER)
+    right = landmarks.get(KeypointName.RIGHT_SHOULDER)
+    if left is None or right is None:
+        return None
+
+    has_world = left.has_world and right.has_world
+
+    def midpoint(a: float | None, b: float | None) -> float | None:
+        return None if a is None or b is None else (a + b) / 2.0
+
+    return Landmark(
+        x=(left.x + right.x) / 2.0,
+        y=(left.y + right.y) / 2.0,
+        visibility=min(left.visibility, right.visibility),
+        presence=min(left.presence, right.presence),
+        x_world=midpoint(left.x_world, right.x_world) if has_world else None,
+        y_world=midpoint(left.y_world, right.y_world) if has_world else None,
+        z_world=midpoint(left.z_world, right.z_world) if has_world else None,
+    )
+
+
+def _validate_image(image: ImageBGR) -> None:
+    """Reject arrays that are not images, loudly, at the call site that produced them."""
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise InvalidImageError(
+            f"expected an (H, W, 3) BGR image, got an array of shape {image.shape}"
+        )
+    if image.shape[0] == 0 or image.shape[1] == 0:
+        raise InvalidImageError(f"image has a zero dimension: {image.shape}")
+
+
+# ---------------------------------------------------------------------------------------------
+# The only part of the file that knows MediaPipe exists.
+# ---------------------------------------------------------------------------------------------
+
+
+def _create_tasks_detector(
+    model_path: Path, min_pose_detection_confidence: float
+) -> RawPoseDetector:
+    """Build the real detector, turning each failure mode into an actionable error.
+
+    The import is function-local by necessity, not by style: ``mediapipe`` is an optional extra
+    (ADR-0002), and a module-scope import would make ``import pose_backends`` fail for everyone
+    running the fake backend — which is most of CI.
+    """
+    if not model_path.is_file():
+        raise ModelNotFoundError(
+            f"pose model not found at {model_path}. Run `make fetch-model`, or set MODEL_PATH "
+            "to an existing pose_landmarker .task file."
+        )
+
+    try:
+        from mediapipe.tasks import python as mp_python
+        from mediapipe.tasks.python import vision
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra installed
+        raise BackendUnavailableError(
+            "mediapipe is not installed. It is an optional extra so that the fake backend can "
+            "run without a 300 MB inference stack: install `pose-backends[mediapipe]`, or set "
+            "POSE_BACKEND=fake."
+        ) from exc
+
+    try:
+        options = vision.PoseLandmarkerOptions(
+            base_options=mp_python.BaseOptions(model_asset_path=str(model_path)),
+            running_mode=vision.RunningMode.IMAGE,
+            num_poses=1,
+            min_pose_detection_confidence=min_pose_detection_confidence,
+            # Segmentation masks cost time and memory and nothing in this project draws one.
+            output_segmentation_masks=False,
+        )
+        landmarker = vision.PoseLandmarker.create_from_options(options)
+    except (RuntimeError, ValueError, OSError) as exc:
+        # The file exists but the runtime rejected it: truncated download, wrong variant, or a
+        # corrupted checkout. The checksum pin in OP-20 is what turns most of these into a loud
+        # failure at fetch time rather than a puzzling one at startup.
+        raise ModelLoadError(
+            f"mediapipe could not load the model at {model_path}: {exc}. Verify its SHA256 with "
+            "`make fetch-model`."
+        ) from exc
+
+    return _TasksDetector(landmarker)
+
+
+class _TasksDetector:
+    """Thin wrapper over a MediaPipe ``PoseLandmarker``, normalising its result shape."""
+
+    def __init__(self, landmarker: object) -> None:
+        self._landmarker = landmarker
+
+    def detect(self, image_rgb: ImageRGB) -> RawDetection | None:
+        import mediapipe as mp
+
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=image_rgb)
+        result = self._landmarker.detect(mp_image)  # type: ignore[attr-defined]
+
+        # MediaPipe returns lists-of-lists, one inner list per detected person. `num_poses=1`
+        # means at most one, and an empty outer list means nobody was found.
+        if not result.pose_landmarks:
+            return None
+
+        world = result.pose_world_landmarks[0] if result.pose_world_landmarks else None
+        return RawDetection(
+            landmarks=[_to_raw(lm) for lm in result.pose_landmarks[0]],
+            world_landmarks=None if world is None else [_to_raw(lm) for lm in world],
+        )
+
+    def close(self) -> None:
+        close = getattr(self._landmarker, "close", None)
+        if callable(close):
+            close()
+
+
+def _to_raw(landmark: object) -> RawLandmark:
+    """MediaPipe landmark -> :class:`RawLandmark`.
+
+    ``visibility`` and ``presence`` are read defensively because MediaPipe leaves them unset on
+    *world* landmarks. Defaulting to 0.0 there is right: the canonical landmark takes its
+    confidence from the image-space point, which does carry both.
+    """
+    return RawLandmark(
+        x=float(landmark.x),  # type: ignore[attr-defined]
+        y=float(landmark.y),  # type: ignore[attr-defined]
+        z=float(landmark.z),  # type: ignore[attr-defined]
+        visibility=float(getattr(landmark, "visibility", 0.0) or 0.0),
+        presence=float(getattr(landmark, "presence", 0.0) or 0.0),
+    )

--- a/packages/pose-backends/tests/test_mediapipe_backend.py
+++ b/packages/pose-backends/tests/test_mediapipe_backend.py
@@ -1,0 +1,379 @@
+"""Adapter tests for `MediaPipeBackend`, run against a stub detector.
+
+**No model file, no mediapipe installed, no download.** That is the point: a transposed landmark
+index is exactly the class of bug that made the legacy engine wrong (FINDINGS §2.1) and it is
+invisible without a test, so the test has to be cheap enough to run on every pull request. The
+`detector_factory` seam is what makes that possible.
+
+Real-model tests live in `test_mediapipe_model.py`, marked `pytest.mark.model`, and are
+deselected in required CI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import InvalidImageError, MediaPipeBackend, ModelNotFoundError
+from pose_backends.mediapipe_backend import (
+    MEDIAPIPE_INDEX_TO_KEYPOINT,
+    RawDetection,
+    RawLandmark,
+)
+from posture_core import KeypointName
+
+MODEL = "/nonexistent/pose_landmarker_full.task"
+
+
+class StubDetector:
+    """Stands in for the MediaPipe Tasks graph, and records what it was handed."""
+
+    def __init__(self, detection: RawDetection | None) -> None:
+        self.detection = detection
+        self.calls: list[NDArray[np.uint8]] = []
+        self.closed = 0
+
+    def detect(self, image_rgb: NDArray[np.uint8]) -> RawDetection | None:
+        self.calls.append(image_rgb)
+        return self.detection
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def raw(index: int, *, visibility: float = 0.9, presence: float = 0.95) -> RawLandmark:
+    """A landmark whose coordinates encode its index, so a mis-mapping is legible in a failure."""
+    return RawLandmark(
+        x=index / 100.0,
+        y=index / 200.0,
+        z=index / 400.0,
+        visibility=visibility,
+        presence=presence,
+    )
+
+
+def full_detection(*, world: bool = True) -> RawDetection:
+    landmarks = [raw(i) for i in range(33)]
+    world_landmarks = (
+        [RawLandmark(x=i, y=-i, z=i / 2, visibility=0.0, presence=0.0) for i in range(33)]
+        if world
+        else None
+    )
+    return RawDetection(landmarks=landmarks, world_landmarks=world_landmarks)
+
+
+def make_backend(detection: RawDetection | None) -> tuple[MediaPipeBackend, StubDetector]:
+    stub = StubDetector(detection)
+    backend = MediaPipeBackend(MODEL, detector_factory=lambda _path, _conf: stub)
+    return backend, stub
+
+
+def image(width: int = 640, height: int = 480) -> NDArray[np.uint8]:
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------------------------
+# The mapping table itself
+# ---------------------------------------------------------------------------------------------
+
+
+def test_mapping_covers_every_mediapipe_index_exactly_once() -> None:
+    assert sorted(MEDIAPIPE_INDEX_TO_KEYPOINT) == list(range(33))
+    assert len(set(MEDIAPIPE_INDEX_TO_KEYPOINT.values())) == 33
+
+
+def test_mapping_covers_every_canonical_keypoint_except_the_derived_neck() -> None:
+    """NECK is the only canonical name no backend reports; everything else must be reachable.
+
+    An unreachable name would be a keypoint the rules engine can ask for and never receive — a
+    metric that silently abstains forever, for a reason nobody would think to look for here.
+    """
+    mapped = set(MEDIAPIPE_INDEX_TO_KEYPOINT.values())
+    assert set(KeypointName) - mapped == {KeypointName.NECK}
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        # The landmarks the rules engine actually uses, pinned individually against ADR-0002's
+        # table. Spot-checking a handful is not enough here: the legacy bug was one inverted pair.
+        (0, KeypointName.NOSE),
+        (7, KeypointName.LEFT_EAR),
+        (8, KeypointName.RIGHT_EAR),
+        (11, KeypointName.LEFT_SHOULDER),
+        (12, KeypointName.RIGHT_SHOULDER),
+        (13, KeypointName.LEFT_ELBOW),
+        (14, KeypointName.RIGHT_ELBOW),
+        (15, KeypointName.LEFT_WRIST),
+        (16, KeypointName.RIGHT_WRIST),
+        (23, KeypointName.LEFT_HIP),
+        (24, KeypointName.RIGHT_HIP),
+        (25, KeypointName.LEFT_KNEE),
+        (26, KeypointName.RIGHT_KNEE),
+        (27, KeypointName.LEFT_ANKLE),
+        (28, KeypointName.RIGHT_ANKLE),
+        (29, KeypointName.LEFT_HEEL),
+        (30, KeypointName.RIGHT_HEEL),
+        (31, KeypointName.LEFT_FOOT_INDEX),
+        (32, KeypointName.RIGHT_FOOT_INDEX),
+    ],
+)
+def test_index_maps_to_the_keypoint_adr_0002_says_it_does(
+    index: int, expected: KeypointName
+) -> None:
+    assert MEDIAPIPE_INDEX_TO_KEYPOINT[index] is expected
+
+
+def test_landmarks_are_placed_under_the_name_matching_their_index() -> None:
+    """End-to-end version of the table test: a transposition inside `_to_canonical` fails here.
+
+    `raw()` encodes the index into the coordinates, so the assertion checks placement rather than
+    merely presence.
+    """
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    for index, name in MEDIAPIPE_INDEX_TO_KEYPOINT.items():
+        landmark = frame.get(name)
+        assert landmark is not None
+        assert landmark.x == pytest.approx(index / 100.0)
+        assert landmark.y == pytest.approx(index / 200.0)
+
+
+# ---------------------------------------------------------------------------------------------
+# NECK derivation
+# ---------------------------------------------------------------------------------------------
+
+
+def test_neck_is_the_midpoint_of_the_two_shoulders() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    left = frame.get(KeypointName.LEFT_SHOULDER)
+    right = frame.get(KeypointName.RIGHT_SHOULDER)
+    neck = frame.get(KeypointName.NECK)
+    assert left is not None and right is not None and neck is not None
+    assert neck.x == pytest.approx((left.x + right.x) / 2)
+    assert neck.y == pytest.approx((left.y + right.y) / 2)
+    assert left.x_world is not None and right.x_world is not None
+    assert neck.x_world == pytest.approx((left.x_world + right.x_world) / 2)
+
+
+def test_neck_takes_the_minimum_confidence_of_its_two_shoulders() -> None:
+    """Not the mean.
+
+    A derived point cannot be more trustworthy than the least trustworthy thing it came from.
+    Averaging would let one confidently-seen shoulder launder an unseen one into a plausible neck
+    — which is how a metric ends up reported with confidence it has not earned.
+    """
+    landmarks = [raw(i) for i in range(33)]
+    landmarks[11] = raw(11, visibility=0.2, presence=0.3)
+    landmarks[12] = raw(12, visibility=0.95, presence=0.99)
+    backend, _ = make_backend(RawDetection(landmarks=landmarks))
+
+    frame = backend.detect(image())
+    assert frame is not None
+    neck = frame.get(KeypointName.NECK)
+    assert neck is not None
+    assert neck.visibility == pytest.approx(0.2)
+    assert neck.presence == pytest.approx(0.3)
+
+
+def test_neck_is_absent_when_a_shoulder_is_missing() -> None:
+    """Absent, not guessed. A one-shoulder neck would be an invented measurement."""
+    backend, _ = make_backend(RawDetection(landmarks=[raw(i) for i in range(12)]))  # 0..11 only
+    frame = backend.detect(image())
+    assert frame is not None
+    assert KeypointName.LEFT_SHOULDER in frame
+    assert KeypointName.RIGHT_SHOULDER not in frame
+    assert KeypointName.NECK not in frame
+
+
+# ---------------------------------------------------------------------------------------------
+# Passthrough
+# ---------------------------------------------------------------------------------------------
+
+
+def test_world_landmarks_visibility_and_presence_pass_through() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    hip = frame.get(KeypointName.LEFT_HIP)
+    assert hip is not None
+    assert (hip.x_world, hip.y_world, hip.z_world) == (23.0, -23.0, 11.5)
+    assert hip.visibility == pytest.approx(0.9)
+    assert hip.presence == pytest.approx(0.95)
+    assert frame.has_world_landmarks is True
+
+
+def test_absent_world_landmarks_leave_the_frame_in_image_space() -> None:
+    """The ADR-0005 fallback path, and it must be detectable rather than silently zero-filled."""
+    backend, _ = make_backend(full_detection(world=False))
+    frame = backend.detect(image())
+    assert frame is not None
+    assert frame.has_world_landmarks is False
+    nose = frame.get(KeypointName.NOSE)
+    assert nose is not None and nose.x_world is None
+
+
+def test_mismatched_world_array_length_drops_world_rather_than_pairing_by_index() -> None:
+    """Silently wrong beats loudly wrong is never the trade here.
+
+    Pairing arrays of different lengths by index attaches one landmark's metres to another's
+    pixels: no exception, no warning, just angles that are quietly incorrect.
+    """
+    detection = RawDetection(
+        landmarks=[raw(i) for i in range(33)],
+        world_landmarks=[raw(i) for i in range(20)],
+    )
+    backend, _ = make_backend(detection)
+    frame = backend.detect(image())
+    assert frame is not None
+    assert frame.has_world_landmarks is False
+
+
+def test_unknown_landmark_indices_are_ignored() -> None:
+    """A future variant reporting extra points must not widen the canonical schema."""
+    detection = RawDetection(landmarks=[raw(i) for i in range(40)])
+    backend, _ = make_backend(detection)
+    frame = backend.detect(image())
+    assert frame is not None
+    assert len(frame) == 34  # 33 mapped + derived NECK
+
+
+def test_frame_is_stamped_with_backend_image_size_and_latency() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image(width=1280, height=720))
+    assert frame is not None
+    assert frame.backend == "mediapipe"
+    assert (frame.image_width, frame.image_height) == (1280, 720)
+    assert frame.inference_ms >= 0.0
+
+
+def test_image_is_converted_from_bgr_to_rgb_before_inference() -> None:
+    """Getting this wrong does not crash — it just quietly degrades detection.
+
+    cv2 decodes to BGR and MediaPipe expects RGB. The stub records the array it received, so the
+    channel order is asserted rather than assumed. Contiguity is checked too: reversing the last
+    axis yields a negative-stride view that the native binding cannot accept.
+    """
+    backend, stub = make_backend(full_detection())
+    bgr = np.zeros((4, 4, 3), dtype=np.uint8)
+    bgr[:, :, 0] = 10  # blue
+    bgr[:, :, 1] = 20  # green
+    bgr[:, :, 2] = 30  # red
+
+    backend.detect(bgr)
+
+    received = stub.calls[0]
+    assert received[0, 0].tolist() == [30, 20, 10]
+    assert received.flags["C_CONTIGUOUS"]
+
+
+# ---------------------------------------------------------------------------------------------
+# Error and degradation paths
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("detection", [None, RawDetection(landmarks=[])])
+def test_no_pose_returns_none_without_raising(detection: RawDetection | None) -> None:
+    """The single most important line of the contract.
+
+    An image with nobody in it is an ordinary outcome of a posture app. The legacy engine returned
+    `None` for this *and* for inference failure, and the caller rendered `None` as "Straight back
+    position" (FINDINGS §2.5) — so an empty desk and a crash both told the user their posture was
+    fine. Here `None` means one thing and breakage raises.
+    """
+    backend, _ = make_backend(detection)
+    assert backend.detect(image()) is None
+
+
+def test_missing_model_file_raises_a_clear_error_not_an_obscure_traceback() -> None:
+    """Names the path and the remedy. Reached before mediapipe is imported, so it works here."""
+    with pytest.raises(ModelNotFoundError, match="make fetch-model"):
+        MediaPipeBackend("/nonexistent/definitely-not-a-model.task")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        np.zeros((480, 640), dtype=np.uint8),  # greyscale
+        np.zeros((480, 640, 4), dtype=np.uint8),  # BGRA
+        np.zeros((0, 640, 3), dtype=np.uint8),  # empty
+    ],
+)
+def test_malformed_arrays_raise_rather_than_returning_none(bad: NDArray[np.uint8]) -> None:
+    """A bad array is a caller bug, not a bad photo, so it must not look like "no person"."""
+    backend, _ = make_backend(full_detection())
+    with pytest.raises(InvalidImageError):
+        backend.detect(bad)
+
+
+# ---------------------------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------------------------
+
+
+def test_model_is_loaded_once_not_per_call() -> None:
+    """The defect that made the legacy engine unusable from a web request.
+
+    Its model was a module global built at import time from a cwd-relative config, so it could
+    neither be loaded once at startup nor be imported at all. Here the factory runs exactly once,
+    in `__init__`.
+    """
+    factory_calls: list[tuple[object, float]] = []
+
+    def factory(path: object, confidence: float) -> StubDetector:
+        factory_calls.append((path, confidence))
+        return StubDetector(full_detection())
+
+    backend = MediaPipeBackend(MODEL, detector_factory=factory)
+    backend.detect(image())
+    backend.detect(image())
+    assert len(factory_calls) == 1
+
+
+def test_warmup_runs_one_inference_and_tolerates_finding_nobody() -> None:
+    """A synthetic frame contains no person, so warmup must survive the `None` path."""
+    backend, stub = make_backend(None)
+    backend.warmup()
+    assert len(stub.calls) == 1
+    assert stub.calls[0].shape == (256, 256, 3)
+
+
+def test_close_releases_the_native_graph_and_is_idempotent() -> None:
+    """Twice from the caller, once to the detector.
+
+    The real detector wraps a vendored C++ object that promises nothing about a second `close()`,
+    and a raise during shutdown turns an orderly stop into a stack trace.
+    """
+    backend, stub = make_backend(full_detection())
+    backend.close()
+    backend.close()
+    assert stub.closed == 1
+
+
+def test_model_path_is_absolute_so_the_backend_does_not_depend_on_cwd() -> None:
+    """The legacy code used relative paths for both weights and config, so it only ran from
+    inside `API/`. Resolving on construction is the fix, and it is worth a test because the
+    failure mode is environment-dependent and would not reproduce for whoever wrote it."""
+    backend, _ = make_backend(full_detection())
+    assert backend.model_path.is_absolute()
+
+
+def test_backend_satisfies_the_protocol() -> None:
+    from pose_backends import PoseBackend
+
+    backend, _ = make_backend(full_detection())
+    assert isinstance(backend, PoseBackend)
+
+
+def test_raw_landmarks_sequence_type_is_not_mutated_by_the_adapter() -> None:
+    """The adapter must not write back into the detector's arrays; a real one reuses them."""
+    landmarks: Sequence[RawLandmark] = [raw(i) for i in range(33)]
+    backend, _ = make_backend(RawDetection(landmarks=landmarks))
+    backend.detect(image())
+    assert landmarks[11] == raw(11)

--- a/packages/pose-backends/tests/test_mediapipe_model.py
+++ b/packages/pose-backends/tests/test_mediapipe_model.py
@@ -1,0 +1,200 @@
+"""Real-model tests: actual weights, actual inference, actual fixture photographs.
+
+**Deselected in required CI** with `-m "not model"`. They need a 9 MB download and the full
+mediapipe extra, and the pull-request workflow deliberately downloads nothing — the stubbed
+adapter tests in `test_mediapipe_backend.py` are what protect every PR. These run on demand in
+`model-validation.yml` (OP-21).
+
+Keeping them in the repository rather than deleting them matters: the stub proves the *mapping*
+is right, and only these prove the mapping is right about a *real model*. A stub agreeing with
+itself is not evidence.
+"""
+
+from __future__ import annotations
+
+import os
+import statistics
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import MediaPipeBackend
+from posture_core import KeypointName, PoseFrame
+
+pytestmark = pytest.mark.model
+
+# Landmarks below this are reported but not trusted. Matches MediaPipe's own default detection
+# confidence; the real per-metric thresholds are Epic C's business (OP-24), not the adapter's.
+VISIBILITY_THRESHOLD = 0.5
+
+FIXTURES = Path(__file__).resolve().parents[3] / "fixtures" / "images"
+DEFAULT_MODEL = Path(__file__).resolve().parents[3] / "models" / "pose_landmarker_full.task"
+
+
+def model_path() -> Path:
+    """Where the weights are. `MODEL_PATH` wins, so a variant can be swapped in (OP-20)."""
+    override = os.environ.get("MODEL_PATH")
+    return Path(override) if override else DEFAULT_MODEL
+
+
+@pytest.fixture(scope="module")
+def backend() -> MediaPipeBackend:
+    path = model_path()
+    if not path.is_file():
+        pytest.skip(f"no model at {path} — run `make fetch-model`")
+    return MediaPipeBackend(path)
+
+
+def load(name: str) -> NDArray[np.uint8]:
+    import cv2
+
+    image = cv2.imread(str(FIXTURES / name))
+    if image is None:
+        pytest.skip(f"fixture {name} could not be decoded")
+    # `asarray` rather than a cast: cv2 ships type stubs, so mypy's view of `imread`'s return
+    # type depends on whether the optional extra happens to be installed. Narrowing it here keeps
+    # the type check identical with and without mediapipe present.
+    return np.asarray(image, dtype=np.uint8)
+
+
+# The side-view fixtures, with the confident-landmark floor each one actually clears. Not all are
+# seated — `kneeling_right` is not — but all are lateral, which is what the floors depend on.
+# Named explicitly rather than globbed so that a fixture disappearing fails the test instead of
+# quietly shrinking it, and floored individually rather than uniformly because the differences are
+# real and worth recording. Measured 2026-07-26 against pose_landmarker_full at 1280x720.
+#
+# `straight_armsfolded` sits lower on purpose: the subject's arms are folded, so both wrists and
+# all six hand points are genuinely occluded. A uniform floor would either fail this fixture for
+# being *correctly* uncertain, or be loosened to the point of proving nothing about the others.
+LATERAL_FIXTURES: list[tuple[str, int]] = [
+    ("hunchback_right.jpg", 25),
+    ("reclined_right.jpg", 25),
+    ("desk_hunch.jpeg", 25),
+    ("kneeling_right.jpg", 25),
+    ("straight_armsfolded.jpg", 20),
+]
+
+PRIMARY_FIXTURE = LATERAL_FIXTURES[0][0]
+
+
+@pytest.mark.parametrize(("fixture", "minimum"), LATERAL_FIXTURES)
+def test_detects_a_confident_skeleton_on_real_photographs(
+    backend: MediaPipeBackend, fixture: str, minimum: int
+) -> None:
+    """Enough landmarks above the visibility threshold to actually assess a seated subject.
+
+    A floor, not a target: a side-on pose legitimately occludes the far arm and part of the far
+    leg. What it rules out is the failure mode where the model returns a full 34-point skeleton of
+    low-confidence guesses — which looks like success to any test that only counts keys, and is
+    precisely how a system starts reporting posture it never measured.
+    """
+    frame = backend.detect(load(fixture))
+    assert frame is not None, f"no pose detected in {fixture}"
+    confident = [lm for lm in frame.landmarks.values() if lm.visibility >= VISIBILITY_THRESHOLD]
+    assert len(confident) >= minimum, f"{fixture}: only {len(confident)} confident landmarks"
+
+
+@pytest.mark.parametrize(("fixture", "_minimum"), LATERAL_FIXTURES)
+def test_presence_and_visibility_carry_different_information(
+    backend: MediaPipeBackend, fixture: str, _minimum: int
+) -> None:
+    """The claim ADR-0002 rests on, checked against the real model rather than assumed.
+
+    On every fixture all 34 points are confidently *present* while only 20-28 are confidently
+    *visible*. The gap is the occluded set — the far arm, the folded wrists — and it exists only
+    because the two signals are independent. Collapse them into one score, as MoveNet does, and
+    "I can see your wrist" becomes indistinguishable from "your wrist is in this photograph".
+    """
+    frame = backend.detect(load(fixture))
+    assert frame is not None
+    # Pin the total as well as the ratio. `present == len(frame)` alone would still pass if the
+    # backend stopped reporting half the skeleton, and the claim being made here is specifically
+    # that *all 34* points are confidently present while only some are confidently visible.
+    assert len(frame) == len(KeypointName)
+    present = sum(1 for lm in frame.landmarks.values() if lm.presence >= VISIBILITY_THRESHOLD)
+    visible = sum(1 for lm in frame.landmarks.values() if lm.visibility >= VISIBILITY_THRESHOLD)
+    assert present == len(frame)
+    assert visible < present
+
+
+def test_real_frames_carry_world_landmarks(backend: MediaPipeBackend) -> None:
+    """The entire reason for choosing this model (ADR-0002, ADR-0005).
+
+    Without metric 3D, every angular metric in Epic C goes back to image space with torso-length
+    normalisation — the problem the model switch was meant to dissolve. Worth asserting against
+    the real runtime, because no stub can tell you the runtime still populates this array.
+    """
+    frame = backend.detect(load(PRIMARY_FIXTURE))
+    assert frame is not None
+    assert frame.has_world_landmarks is True
+
+
+def test_neck_is_derived_on_real_output(backend: MediaPipeBackend) -> None:
+    frame = backend.detect(load(PRIMARY_FIXTURE))
+    assert frame is not None
+    assert KeypointName.NECK in frame
+
+
+def test_returns_none_on_an_image_with_no_person(backend: MediaPipeBackend) -> None:
+    """Flat grey: no person, and no exception either."""
+    blank = np.full((480, 640, 3), 128, dtype=np.uint8)
+    assert backend.detect(blank) is None
+
+
+def test_no_initialisation_cost_is_deferred_past_construction(
+    backend: MediaPipeBackend,
+) -> None:
+    """The property that actually matters, which is not the one warmup was written to provide.
+
+    The plan predicted a lazily-built inference graph, so that a cold backend's first `detect()`
+    would be much slower than its second and `warmup()` would be what closed the gap. Measured on
+    2026-07-26 (Apple M5, `pose_landmarker_full`, 1280x720), that is **not what MediaPipe 0.10.18
+    does** in `RunningMode.IMAGE`: construction costs ~31 ms and every inference thereafter costs
+    ~23 ms, first one included. There is nothing left to warm.
+
+    So this asserts the real guarantee — a cold backend's first inference is already at steady
+    state, meaning no request ever pays an initialisation cost — rather than a speedup that does
+    not exist. `warmup()` stays in the Protocol regardless: it costs one synthetic frame at
+    startup, it is what a lazier backend would need, and a contract that only holds for the
+    current library version is not a contract.
+
+    A fresh backend is constructed rather than reusing the module-scoped one, which other tests
+    have already exercised. Compared as a ratio because absolute latency varies by an order of
+    magnitude between a laptop and a CI runner.
+    """
+    image = load(PRIMARY_FIXTURE)
+    cold = MediaPipeBackend(model_path())
+    first = _timed(cold, image)
+    # Median of several, not the minimum of three. The minimum is the least contended sample a
+    # runner produced, which makes the ratio below stricter than intended when the machine is
+    # busy — and a latency test that fails because CI was loaded teaches nothing.
+    steady = statistics.median(_timed(cold, image) for _ in range(9))
+    assert first < steady * 2.0, f"first inference {first:.1f} ms vs steady {steady:.1f} ms"
+
+
+def test_warmup_does_not_disturb_subsequent_detection(backend: MediaPipeBackend) -> None:
+    """Whatever warmup does or does not save, it must not change results.
+
+    It runs an inference on a synthetic frame of a different size, and a backend that carried
+    state between calls could return something different afterwards. OP-40 calls this at startup
+    on the same instance that then serves every request.
+    """
+    image = load(PRIMARY_FIXTURE)
+    before = backend.detect(image)
+    backend.warmup()
+    after = backend.detect(image)
+    assert before is not None and after is not None
+    assert set(before.landmarks) == set(after.landmarks)
+    # Both axes, at the same tolerance `test_backend_contract.py` uses for repeat stability. A
+    # tighter bound on one axis would fail for reasons unrelated to warmup.
+    for name, landmark in before.landmarks.items():
+        assert landmark.x == pytest.approx(after.landmarks[name].x, abs=1e-6), name
+        assert landmark.y == pytest.approx(after.landmarks[name].y, abs=1e-6), name
+
+
+def _timed(backend: MediaPipeBackend, image: NDArray[np.uint8]) -> float:
+    frame: PoseFrame | None = backend.detect(image)
+    assert frame is not None
+    return frame.inference_ms

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,21 @@ show_error_codes = true
 pretty = true
 exclude = ['^docs/archive/']
 
-# NOTE: `ignore_missing_imports` overrides for untyped third-party packages (cv2, mediapipe)
-# are added by OP-18, when the adapter first imports them. Declaring them now would trip
-# `warn_unused_configs` and train everyone to ignore mypy's output.
+# Untyped third-party packages, added in OP-18 when the adapter first imported them.
+#
+# `mediapipe` ships no type information and, being an optional extra (ADR-0002), is usually not
+# installed at all in the environment mypy runs in — CI installs the base package only. Either way
+# mypy cannot resolve it, and either way the answer is the same: trust the adapter's own
+# annotations and treat the library as Any.
+#
+# The blast radius is deliberately one module. `mediapipe` is imported inside two functions in
+# pose_backends/mediapipe_backend.py and nowhere else, so everything that crosses back into typed
+# code does so through RawDetection and RawLandmark, which are checked normally.
+#
+# `cv2` is here for the same reason and is reached only from the real-model tests and the CLI.
+[[tool.mypy.overrides]]
+module = ["mediapipe.*", "cv2.*"]
+ignore_missing_imports = true
 
 # ---------------------------------------------------------------------------
 # pytest


### PR DESCRIPTION
Closes OP-18. Base: `op-17-keypoint-types`.

Implements the real inference adapter, pinned to `mediapipe==0.10.18` per ADR-0002.

## Changes
- `pose_backends.mediapipe_backend`: `MediaPipeBackend` implementing `PoseBackend` via the Tasks API. Model loaded once in `__init__`; `model_path` resolved to absolute.
- `pose_backends.errors`: `PoseBackendError` and four subclasses — `BackendUnavailableError`, `ModelNotFoundError`, `ModelLoadError`, `InvalidImageError`.
- mypy override for `mediapipe.*` and `cv2.*` (`ignore_missing_imports`).

## Notes
- Inference sits behind a `RawPoseDetector` Protocol, injected via `detector_factory`. This is what lets the index-to-name mapping and `NECK` derivation be tested with no model file and no mediapipe installed, so those tests run in required CI. A transposed landmark index is the class of bug behind FINDINGS §2.1 and is invisible without a test.
- `NECK` confidence is the minimum of the two shoulders, not the mean. A derived point cannot be more trustworthy than its weakest input.
- A world-landmark array whose length differs from the image array causes world coordinates to be dropped rather than paired by index.
- BGR→RGB conversion uses `ascontiguousarray`; the reversed view has a negative stride the native binding rejects.
- Model-load failures catch `(RuntimeError, ValueError, OSError)` specifically. No `except Exception` anywhere in the package.
- The mediapipe import is function-local because the extra is optional; a module-scope import would break `import pose_backends` for fake-backend users.
- `close()` tracks a `_closed` flag rather than forwarding every call. `RawPoseDetector` asks implementors for idempotence, but the real detector wraps a vendored C++ object that promises nothing of the sort, and a raise during shutdown turns an orderly stop into a stack trace.
- `warmup()` saves nothing measurable against this library. Measured 2026-07-27 (Apple M5, `pose_landmarker_full`, 1280x720): the graph is built eagerly in `create_from_options`, so construction costs ~31 ms and every inference ~23 ms including the first. The test asserts the guarantee that is true — no request pays an initialisation cost — rather than a speedup that does not exist. OP-18's acceptance criterion "second inference is materially faster than the first" is therefore not satisfiable.

## Tests
- `test_mediapipe_backend.py` — 30 tests against a stub detector: exhaustive index→name mapping, `NECK` derivation, world/visibility/presence passthrough, no-pose→`None`, malformed arrays, missing model, single model load, channel order.
- `test_mediapipe_model.py` — real-model tests, marked `pytest.mark.model`, deselected in required CI.

## Fixture floors
Confident-landmark floors are per-fixture, not uniform. `straight_armsfolded.jpg` clears 21, not 25: the arms are folded, so both wrists and all six hand points are genuinely occluded. Across all fixtures 34 landmarks are confidently present while 20-28 are confidently visible; the gap is the occluded set, and it exists only because presence and visibility are independent signals.
