### PR TITLE
OP-20: Model acquisition with checksum pin and MODEL_PATH override

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ htmlcov/
 *.egg-info/
 build/
 dist/
+
+# --- Model weights (OP-20) ---
+# Never committed. 9 MB is under GitHub's limit, but weights in git is how the legacy project
+# ended up with a 209 MB blob it could not push and a Dropbox link instead. `make fetch-model`
+# reproduces them from a pinned URL and verifies a pinned SHA256; models/checksums.txt is the
+# thing under version control.
+models/*.task
+models/*.task.download

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,25 @@ Two coverage floors, chosen rather than defaulted:
 Clear a floor by writing a test, not by adding an exclusion. Generated code and type-only modules
 may be excluded; a difficult branch may not.
 
-`-m "not model"` deselects tests needing real model weights. CI never downloads them; they run on
-demand in `model-validation.yml`.
+`-m "not model"` deselects tests needing real model weights. CI never downloads them; they will run
+on demand in `model-validation.yml`, which arrives with the landmark CLI in OP-21.
+
+To run them locally you need the weights and the inference stack:
+
+```bash
+make fetch-model                       # downloads and verifies a pinned SHA256
+uv pip install "mediapipe==0.10.18"    # the optional extra; ~857 MB of site-packages
+uv run pytest -m model
+```
+
+`make fetch-model` writes to `models/`, which is gitignored — the checksum is what is version
+controlled, not the weights. `MODEL_VARIANT=lite|full|heavy` switches variants at fetch time and
+`MODEL_PATH` overrides the location at run time; both are documented in
+[`models/checksums.txt`](models/checksums.txt).
+
+Most of the pose-backend suite deliberately does *not* need any of this. The adapter's landmark
+mapping is tested against a stub, and `POSE_BACKEND=fake` runs the whole application with no model
+at all — which is why the pull-request workflow finishes in minutes without a download.
 
 ## Conventions worth knowing
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,90 @@
+# OpenPosture — developer entry points.
+#
+# Deliberately thin. `uv run <tool>` is already short, discoverable and identical to what CI runs,
+# so wrapping every check in a target would only add a second vocabulary to keep in sync. What
+# belongs here is the work that is genuinely awkward to type correctly by hand — which, so far, is
+# exactly one thing: fetching model weights and refusing to accept the wrong bytes.
+
+MODEL_VARIANT ?= full
+MODEL_DIR     ?= models
+MODEL_FILE    := pose_landmarker_$(MODEL_VARIANT).task
+MODEL_TARGET  := $(MODEL_DIR)/$(MODEL_FILE)
+CHECKSUMS     := $(MODEL_DIR)/checksums.txt
+
+# Pin the versioned path, never `latest`. They are different files — see the note in
+# models/checksums.txt, where the four differing bytes are recorded.
+MODEL_BASE_URL ?= https://storage.googleapis.com/mediapipe-models/pose_landmarker
+MODEL_URL      := $(MODEL_BASE_URL)/pose_landmarker_$(MODEL_VARIANT)/float16/1/$(MODEL_FILE)
+
+# One place that knows how to read the checksum file, so `fetch-model` and `verify-model` cannot
+# drift apart. `$$` escapes for make; this runs in /bin/sh.
+define expected_sha
+$$(grep -E "^[0-9a-f]{64}  $(MODEL_FILE)$$" $(CHECKSUMS) | cut -d' ' -f1)
+endef
+
+.PHONY: help fetch-model verify-model clean-model
+
+help:
+	@echo "fetch-model    download and verify the pose model (MODEL_VARIANT=lite|full|heavy)"
+	@echo "verify-model   re-verify the model already on disk"
+	@echo "clean-model    delete downloaded weights"
+	@echo ""
+	@echo "Everything else runs through uv, the same way CI invokes it:"
+	@echo "  uv run ruff check . && uv run ruff format --check ."
+	@echo "  uv run mypy packages apps"
+	@echo "  uv run pytest -m 'not model'"
+
+## Download the model, verify it, and only then put it where the code looks for it.
+##
+## Downloads to a temporary file first. A checksum failure that has already overwritten the good
+## copy at the target path is a checksum failure that broke your working tree — and the next run
+## would then "succeed" against whatever was left there.
+fetch-model:
+	@expected="$(expected_sha)"; \
+	if [ -z "$$expected" ]; then \
+		echo "ERROR: no pinned SHA256 for $(MODEL_FILE) in $(CHECKSUMS)." >&2; \
+		echo "       Variants available:" >&2; \
+		grep -E "^[0-9a-f]{64}  " $(CHECKSUMS) | sed 's/^.*  /         /' >&2; \
+		exit 1; \
+	fi; \
+	if [ -f "$(MODEL_TARGET)" ] && [ "$$(shasum -a 256 "$(MODEL_TARGET)" | cut -d' ' -f1)" = "$$expected" ]; then \
+		echo "$(MODEL_TARGET) already present and verified."; \
+		exit 0; \
+	fi; \
+	mkdir -p "$(MODEL_DIR)"; \
+	tmp="$(MODEL_TARGET).download"; \
+	echo "Fetching $(MODEL_URL)"; \
+	curl --fail --location --show-error --silent --output "$$tmp" "$(MODEL_URL)" || { \
+		rm -f "$$tmp"; echo "ERROR: download failed." >&2; exit 1; \
+	}; \
+	actual="$$(shasum -a 256 "$$tmp" | cut -d' ' -f1)"; \
+	if [ "$$actual" != "$$expected" ]; then \
+		rm -f "$$tmp"; \
+		echo "ERROR: checksum mismatch for $(MODEL_FILE)." >&2; \
+		echo "       expected $$expected" >&2; \
+		echo "       actual   $$actual" >&2; \
+		echo "       The download was discarded. Do not use an unverified model." >&2; \
+		exit 1; \
+	fi; \
+	mv "$$tmp" "$(MODEL_TARGET)"; \
+	echo "OK  $(MODEL_TARGET)  $$actual"
+
+## Verify whatever is on disk. The model-validation workflow arriving in OP-21 will run this
+## before anything else, so a corrupted or swapped model fails the run instead of quietly
+## changing its results.
+verify-model:
+	@expected="$(expected_sha)"; \
+	if [ ! -f "$(MODEL_TARGET)" ]; then \
+		echo "ERROR: $(MODEL_TARGET) is missing. Run \`make fetch-model\`." >&2; exit 1; \
+	fi; \
+	actual="$$(shasum -a 256 "$(MODEL_TARGET)" | cut -d' ' -f1)"; \
+	if [ "$$actual" != "$$expected" ]; then \
+		echo "ERROR: $(MODEL_TARGET) does not match its pin." >&2; \
+		echo "       expected $$expected" >&2; \
+		echo "       actual   $$actual" >&2; \
+		exit 1; \
+	fi; \
+	echo "OK  $(MODEL_TARGET)  $$actual"
+
+clean-model:
+	rm -f $(MODEL_DIR)/*.task $(MODEL_DIR)/*.task.download

--- a/models/checksums.txt
+++ b/models/checksums.txt
@@ -1,0 +1,56 @@
+# SHA256 checksums for the MediaPipe Pose Landmarker model variants.
+#
+# THIS FILE IS THE SINGLE SOURCE OF TRUTH for model integrity. It is consumed by:
+#
+#   * `make fetch-model`     — verifies a download before moving it into place
+#   * `make verify-model`    — verifies whatever is already on disk
+#   * the API image build    — `ADD --checksum=sha256:<the full hash below>` (planned, OP-43)
+#   * `model-validation.yml` — verifies the hash before running anything (planned, OP-21)
+#
+# The last two do not exist yet; they are named so that when they arrive they reference this file
+# rather than pasting a hash of their own.
+#
+# Format is exactly what `shasum -a 256` emits: `<hash>  <filename>`, one per line, `#` comments
+# ignored. Familiar and trivially greppable.
+#
+# The Makefile deliberately does NOT use `shasum -c` to check it. `shasum -c` treats a line it
+# cannot parse as a warning and still exits 0 — verified on macOS — so a typo'd hash or a file
+# that is simply absent passes the "check" silently. A gate that can pass without verifying
+# anything is worse than no gate, because it is trusted. The Makefile greps the expected hash for
+# one named file and compares it explicitly instead.
+#
+# Replaces the legacy arrangement, where a 209 MB `model.h5` exceeded GitHub's file limit and was
+# distributed by a bare Dropbox link in a readme — no checksum, no licence, no stated origin. A
+# dead link made the entire project unrunnable, and nobody could have told a corrupted copy from
+# a good one. See docs/FINDINGS.md and docs/adr/0002-mediapipe-pose.md.
+#
+# --------------------------------------------------------------------------------------------
+# PIN THE VERSIONED PATH, NOT `latest`
+# --------------------------------------------------------------------------------------------
+# Google publishes each variant under both `/float16/1/` and `/float16/latest/`. These are NOT
+# the same file. Verified 2026-07-26 by downloading both twice: each URL is stable across fetches,
+# but for `pose_landmarker_full` the two differ in exactly four bytes (offsets 12, 2959110,
+# 9398046, 9398112 — container metadata, not weights) and therefore have different hashes:
+#
+#     /float16/1/       5134a3aa...
+#     /float16/latest/  4eaa5eb7...
+#
+# Identical file size, different content. A pin against `latest` would look correct for as long
+# as nobody re-published, then fail a checksum for reasons that would take an afternoon to
+# understand. The Makefile fetches `/1/`.
+#
+# --------------------------------------------------------------------------------------------
+# VARIANTS — set MODEL_VARIANT in the Makefile to switch, or MODEL_PATH at runtime
+# --------------------------------------------------------------------------------------------
+# lite    5.5 MB   fastest, lowest accuracy. Viable for browser-side live mode (Epic G).
+# full    9.0 MB   the default. The accuracy/latency point this project is calibrated against.
+# heavy   29 MB    most accurate, ~3x the latency of full. Worth trying if evaluation (Epic H)
+#                  shows the full model is the limiting factor rather than the rules.
+#
+# Nothing in the code depends on which one is loaded — all three emit the same 33 landmarks with
+# world coordinates, which is exactly what the PoseBackend Protocol is for. Swapping is a
+# MODEL_PATH change, not a rebuild.
+
+59929e1d1ee95287735ddd833b19cf4ac46d29bc7afddbbf6753c459690d574a  pose_landmarker_lite.task
+5134a3aad27a58b93da0088d431f366da362b44e3ccfbe3462b3827a839011b1  pose_landmarker_full.task
+64437af838a65d18e5ba7a0d39b465540069bc8aae8308de3e318aad31fcbc7b  pose_landmarker_heavy.task

--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -23,10 +23,13 @@ from pose_backends.errors import (
     ModelNotFoundError,
     PoseBackendError,
 )
+from pose_backends.fake import FakePoseBackend, PosePreset
 from pose_backends.mediapipe_backend import MediaPipeBackend
+from pose_backends.registry import create_backend, default_model_path
 
 __all__ = [
     "BackendUnavailableError",
+    "FakePoseBackend",
     "ImageBGR",
     "InvalidImageError",
     "MediaPipeBackend",
@@ -34,7 +37,10 @@ __all__ = [
     "ModelNotFoundError",
     "PoseBackend",
     "PoseBackendError",
+    "PosePreset",
     "__version__",
+    "create_backend",
+    "default_model_path",
 ]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/fake.py
+++ b/packages/pose-backends/src/pose_backends/fake.py
@@ -1,0 +1,199 @@
+"""The deterministic backend. Load-bearing infrastructure, not a throwaway test double.
+
+With ``POSE_BACKEND=fake`` the entire application runs with no model weights, no 300 MB inference
+stack and no secrets. That is what lets the container smoke test (OP-43) and the Playwright
+end-to-end suite (OP-47) run on every pull request in seconds. It is the single reason required
+CI stays fast and secret-free, which is why this file gets the same care as the real adapter.
+
+Every preset is built by :mod:`posture_core.synthetic` — the *same* builder the rules-engine tests
+use. That is deliberate and it is the point of the module living in ``posture_core``: if the fake
+had its own private figure construction, it would drift from the one the metrics are tested
+against, and the day it drifted every end-to-end assertion resting on a fake pose would quietly
+stop meaning anything.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from posture_core import PoseFrame
+from posture_core.synthetic import Facing, View, make_pose_frame
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from pose_backends.base import ImageBGR
+
+__all__ = ["FakePoseBackend", "PosePreset"]
+
+BACKEND_NAME: Final = "fake"
+
+
+class PosePreset(StrEnum):
+    """Named situations the rest of the system needs to be able to reproduce on demand."""
+
+    STRAIGHT = "straight"
+    HUNCHBACK = "hunchback"
+    RECLINED = "reclined"
+    KNEELING = "kneeling"
+    PARTIAL_OCCLUSION = "partial_occlusion"
+    FRONTAL_VIEW = "frontal_view"
+    NO_PERSON = "no_person"
+    """``detect()`` returns ``None``. The empty-desk path, exercisable without an empty desk."""
+
+
+# Joint angles per preset, in the convention `posture_core.synthetic` documents: trunk and neck
+# from straight up, limbs from straight down, positive forward.
+#
+# The seated poses share a thigh at 85° (near horizontal) and a shank at 5° (near vertical), which
+# is a chair. What distinguishes them is the trunk and neck.
+_SEATED: Final[Mapping[str, float]] = {"thigh_deg": 85.0, "shank_deg": 5.0}
+
+_PRESETS: Final[Mapping[PosePreset, dict[str, object]]] = {
+    # Upright and neutral: the reference every other preset is a departure from.
+    PosePreset.STRAIGHT: {
+        **_SEATED,
+        "trunk_deg": 3.0,
+        "neck_deg": 5.0,
+        "upper_arm_deg": 10.0,
+        "forearm_deg": 75.0,
+    },
+    # Slumped forward with the head thrust further forward still — the posture the whole
+    # application exists to detect, and the one the legacy engine reported as "Straight back"
+    # whenever its assessment failed (FINDINGS §2.5).
+    PosePreset.HUNCHBACK: {
+        **_SEATED,
+        "trunk_deg": 32.0,
+        "neck_deg": 30.0,
+        "upper_arm_deg": 15.0,
+        "forearm_deg": 80.0,
+    },
+    # Leaning back. Negative trunk angle, which is what makes this a useful test of a *signed*
+    # trunk inclination: an implementation taking an absolute value would report this as identical
+    # to a forward slump of the same magnitude.
+    PosePreset.RECLINED: {
+        **_SEATED,
+        "trunk_deg": -25.0,
+        "neck_deg": 10.0,
+        "upper_arm_deg": -5.0,
+        "forearm_deg": 60.0,
+    },
+    # Kneeling: thigh near vertical, shank folded back underneath. Knee flexion is emergent
+    # (180 - |thigh - shank|), so this figure is physically consistent by construction.
+    PosePreset.KNEELING: {
+        "thigh_deg": 15.0,
+        "shank_deg": 165.0,
+        "trunk_deg": 5.0,
+        "neck_deg": 6.0,
+        "upper_arm_deg": 8.0,
+        "forearm_deg": 20.0,
+    },
+    # Same seating as STRAIGHT, but the lower body is gone and one arm is behind the torso. The
+    # two are different kinds of missing and the frame says so: legs are *omitted* (never
+    # reported), the far arm is present with low visibility and high presence (occluded).
+    #
+    # This preset is how the "couldn't assess your knees, try a wider shot" path gets tested.
+    PosePreset.PARTIAL_OCCLUSION: {
+        **_SEATED,
+        "trunk_deg": 10.0,
+        "neck_deg": 12.0,
+        "upper_arm_deg": 12.0,
+        "forearm_deg": 78.0,
+    },
+    # Facing the camera. The angles are a pronounced slump, but a frontal projection hides it —
+    # which is the point. `view_confidence` (OP-31) must refuse to assess this rather than
+    # reporting the near-zero apparent lean as good posture. The original app asked users for a
+    # side-on photo and never checked that it got one.
+    PosePreset.FRONTAL_VIEW: {
+        **_SEATED,
+        "trunk_deg": 30.0,
+        "neck_deg": 25.0,
+        "upper_arm_deg": 10.0,
+        "forearm_deg": 75.0,
+        "view": View.FRONTAL,
+    },
+}
+
+
+def _build(preset: PosePreset, image_width: int, image_height: int) -> PoseFrame | None:
+    """One preset -> one frame. Pure, so repeated calls are indistinguishable."""
+    if preset is PosePreset.NO_PERSON:
+        return None
+
+    kwargs: dict[str, object] = {
+        "facing": Facing.RIGHT,
+        **_PRESETS[preset],
+        "image_width": image_width,
+        "image_height": image_height,
+        "backend": BACKEND_NAME,
+    }
+
+    if preset is PosePreset.PARTIAL_OCCLUSION:
+        from posture_core import KeypointName
+
+        kwargs["omit"] = (
+            KeypointName.LEFT_KNEE,
+            KeypointName.RIGHT_KNEE,
+            KeypointName.LEFT_ANKLE,
+            KeypointName.RIGHT_ANKLE,
+            KeypointName.LEFT_HEEL,
+            KeypointName.RIGHT_HEEL,
+            KeypointName.LEFT_FOOT_INDEX,
+            KeypointName.RIGHT_FOOT_INDEX,
+        )
+        # Occluded, not out of frame: visibility collapses, presence does not. Expressing the
+        # difference is the whole reason the model was chosen (ADR-0002).
+        kwargs["confidence"] = {
+            KeypointName.LEFT_ELBOW: (0.18, 0.92),
+            KeypointName.LEFT_WRIST: (0.12, 0.90),
+        }
+
+    return make_pose_frame(**kwargs)  # type: ignore[arg-type]
+
+
+class FakePoseBackend:
+    """A ``PoseBackend`` that returns a canned skeleton and never looks at the image.
+
+    Sub-millisecond because there is nothing to decode and nothing to infer. Byte-identical across
+    runs because the figure is analytic and ``inference_ms`` is a constant ``0.0`` rather than a
+    measurement — a real timing would make otherwise-identical frames differ between runs and
+    break every snapshot assertion downstream.
+    """
+
+    name: Final = BACKEND_NAME
+
+    def __init__(
+        self,
+        preset: PosePreset | str = PosePreset.STRAIGHT,
+        *,
+        image_width: int = 640,
+        image_height: int = 480,
+    ) -> None:
+        self._preset = PosePreset(preset)
+        self._image_width = image_width
+        self._image_height = image_height
+        # Built once, then shared. Safe precisely because PoseFrame is genuinely immutable — its
+        # landmark mapping is a MappingProxyType, not a dict a caller could edit and thereby
+        # corrupt every later detection.
+        self._frame = _build(self._preset, image_width, image_height)
+
+    @property
+    def preset(self) -> PosePreset:
+        return self._preset
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        """Return the preset's frame, ignoring the image entirely.
+
+        Ignoring it is the contract, not a shortcut: callers select the *scenario* by constructing
+        the backend, and a fake that inspected pixels would make an end-to-end test's result
+        depend on whatever placeholder JPEG someone happened to upload.
+        """
+        del image_bgr
+        return self._frame
+
+    def warmup(self) -> None:
+        """Nothing to warm. Present because the Protocol requires it and OP-40 calls it blind."""
+
+    def close(self) -> None:
+        """Symmetry with the real backend, so lifespan shutdown needs no special case."""

--- a/packages/pose-backends/src/pose_backends/registry.py
+++ b/packages/pose-backends/src/pose_backends/registry.py
@@ -1,0 +1,71 @@
+"""Choosing a backend at runtime, from configuration rather than from an import.
+
+``POSE_BACKEND=fake`` has to be a *deployment* switch, not a test-only injection point. The
+container smoke test starts the real API image and the Playwright suite drives the real frontend;
+neither can reach into a Python fixture to swap an object. They set an environment variable, and
+this module is what reads it.
+
+The API layer will wrap this in pydantic-settings (OP-39) so the value is validated alongside
+everything else it configures. This function stays the single place that knows how a name maps to
+a class, so adding a backend means adding one entry here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+from pose_backends.base import PoseBackend
+from pose_backends.errors import PoseBackendError
+from pose_backends.fake import BACKEND_NAME as FAKE_NAME
+from pose_backends.fake import FakePoseBackend, PosePreset
+from pose_backends.mediapipe_backend import BACKEND_NAME as MEDIAPIPE_NAME
+from pose_backends.mediapipe_backend import MediaPipeBackend
+
+__all__ = ["DEFAULT_MODEL_PATH", "create_backend", "default_model_path"]
+
+DEFAULT_MODEL_PATH: Final = Path("models/pose_landmarker_full.task")
+"""Where ``make fetch-model`` puts the weights, relative to the repository or image root."""
+
+
+def default_model_path() -> Path:
+    """The model location, with ``MODEL_PATH`` taking precedence.
+
+    The override exists so a heavier or lighter model variant — lite at 5.5 MB, full at 9 MB,
+    heavy at 29 MB — can be swapped in without rebuilding the image (OP-20). It also replaces the
+    legacy arrangement's worst property: weights fetched from a bare Dropbox link recorded in a
+    readme, so a dead link made the whole project unrunnable.
+    """
+    override = os.environ.get("MODEL_PATH")
+    return Path(override) if override else DEFAULT_MODEL_PATH
+
+
+def create_backend(
+    name: str | None = None,
+    *,
+    model_path: Path | str | None = None,
+    preset: PosePreset | str | None = None,
+) -> PoseBackend:
+    """Build the configured backend.
+
+    :param name: ``"mediapipe"`` or ``"fake"``. Defaults to ``POSE_BACKEND``, then ``"mediapipe"``
+        — the real backend is the default so that a missing variable in production yields real
+        inference rather than a fabricated skeleton nobody notices is fabricated.
+    :param preset: fake-backend scenario; defaults to ``POSE_BACKEND_PRESET``, then ``straight``.
+    :raises PoseBackendError: for an unknown name, listing what is available. An unrecognised
+        value must fail loudly at startup: silently falling back to the fake would mean shipping
+        an application that invents its results.
+    """
+    resolved = (name or os.environ.get("POSE_BACKEND") or MEDIAPIPE_NAME).strip().lower()
+
+    if resolved == FAKE_NAME:
+        chosen = preset if preset is not None else os.environ.get("POSE_BACKEND_PRESET")
+        return FakePoseBackend(chosen if chosen is not None else PosePreset.STRAIGHT)
+
+    if resolved == MEDIAPIPE_NAME:
+        return MediaPipeBackend(model_path if model_path is not None else default_model_path())
+
+    raise PoseBackendError(
+        f"unknown POSE_BACKEND {resolved!r}. Available: {MEDIAPIPE_NAME}, {FAKE_NAME}."
+    )

--- a/packages/pose-backends/src/pose_backends/registry.py
+++ b/packages/pose-backends/src/pose_backends/registry.py
@@ -26,16 +26,28 @@ from pose_backends.mediapipe_backend import MediaPipeBackend
 __all__ = ["DEFAULT_MODEL_PATH", "create_backend", "default_model_path"]
 
 DEFAULT_MODEL_PATH: Final = Path("models/pose_landmarker_full.task")
-"""Where ``make fetch-model`` puts the weights, relative to the repository or image root."""
+"""Where ``make fetch-model`` puts the weights.
+
+**Relative, and therefore resolved against the working directory** — which is the repository root
+locally and the image's ``WORKDIR`` in a container. That is a deliberate default rather than a
+repeat of the legacy engine's cwd dependence: there, relative paths to weights and config were
+buried inside the inference code, so the thing only ran from within ``API/`` and there was no way
+to say otherwise. Here it is one documented default with :envvar:`MODEL_PATH` as the override, and
+``MediaPipeBackend`` resolves whatever it is given to an absolute path before loading.
+"""
 
 
 def default_model_path() -> Path:
-    """The model location, with ``MODEL_PATH`` taking precedence.
+    """The model location, with :envvar:`MODEL_PATH` taking precedence.
 
-    The override exists so a heavier or lighter model variant — lite at 5.5 MB, full at 9 MB,
-    heavy at 29 MB — can be swapped in without rebuilding the image (OP-20). It also replaces the
-    legacy arrangement's worst property: weights fetched from a bare Dropbox link recorded in a
-    readme, so a dead link made the whole project unrunnable.
+    The override exists so a variant can be swapped in without rebuilding: lite at 5.5 MB, full at
+    9 MB, heavy at 29 MB. Nothing in the code depends on which one loads — all three emit the same
+    33 landmarks with world coordinates — so this is a configuration change, not a code change.
+    See ``models/checksums.txt`` for the pins and the tradeoffs.
+
+    It also replaces the legacy arrangement's worst property: weights fetched from a bare Dropbox
+    link recorded in a readme, with no checksum and no stated origin, so a dead link made the whole
+    project unrunnable and a corrupted copy was indistinguishable from a good one.
     """
     override = os.environ.get("MODEL_PATH")
     return Path(override) if override else DEFAULT_MODEL_PATH

--- a/packages/pose-backends/tests/test_backend_contract.py
+++ b/packages/pose-backends/tests/test_backend_contract.py
@@ -1,0 +1,204 @@
+"""One suite, run against **every** backend, real and fake.
+
+This is what stops `FakePoseBackend` from drifting into a shape the real adapter never produces.
+Without it the fake is a free variable: it can grow a keypoint MediaPipe does not report, or lose
+world coordinates, or start returning a frame where the real one returns `None` — and every
+downstream test resting on the fake would keep passing while asserting something untrue about the
+production path.
+
+The real backend's parameter is marked `pytest.mark.model`, so required CI runs the fake leg only
+and the on-demand model workflow (OP-21) runs both. That asymmetry is the deliberate trade: cheap
+protection on every pull request, full protection when the weights are available.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import FakePoseBackend, PoseBackend, PosePreset
+from posture_core import KeypointName
+
+WIDTH, HEIGHT = 640, 480
+
+FIXTURES = Path(__file__).resolve().parents[3] / "fixtures" / "images"
+DEFAULT_MODEL = Path(__file__).resolve().parents[3] / "models" / "pose_landmarker_full.task"
+
+# The landmarks every backend must supply for the rules engine to function at all. A backend
+# missing any of these cannot produce a trunk inclination, which is the project's core metric.
+REQUIRED = frozenset(
+    {
+        KeypointName.LEFT_SHOULDER,
+        KeypointName.RIGHT_SHOULDER,
+        KeypointName.LEFT_HIP,
+        KeypointName.RIGHT_HIP,
+        KeypointName.NECK,
+    }
+)
+
+
+@dataclass(frozen=True)
+class Case:
+    """A backend plus the inputs needed to drive it down both paths."""
+
+    with_person: PoseBackend
+    without_person: PoseBackend
+    image_with_person: NDArray[np.uint8]
+    image_without_person: NDArray[np.uint8]
+
+
+def _blank() -> NDArray[np.uint8]:
+    return np.full((HEIGHT, WIDTH, 3), 128, dtype=np.uint8)
+
+
+def _fake_case() -> Case:
+    return Case(
+        with_person=FakePoseBackend(PosePreset.STRAIGHT, image_width=WIDTH, image_height=HEIGHT),
+        # The fake selects its scenario by construction, so "no person" is a second instance
+        # rather than a second input. That difference is confined to this fixture, which is why
+        # the assertions below can be written once for both backends.
+        without_person=FakePoseBackend(PosePreset.NO_PERSON),
+        image_with_person=_blank(),
+        image_without_person=_blank(),
+    )
+
+
+def _mediapipe_case() -> Case:
+    from pose_backends import MediaPipeBackend
+
+    model = Path(os.environ.get("MODEL_PATH", DEFAULT_MODEL))
+    if not model.is_file():
+        pytest.skip(f"no model at {model} — run `make fetch-model`")
+
+    import cv2
+
+    photo = cv2.imread(str(FIXTURES / "straight_armsfolded.jpg"))
+    if photo is None:
+        pytest.skip("fixture image could not be decoded")
+
+    backend = MediaPipeBackend(model)
+    return Case(
+        with_person=backend,
+        without_person=backend,
+        image_with_person=np.asarray(photo, dtype=np.uint8),
+        image_without_person=_blank(),
+    )
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(_fake_case, id="fake"),
+        pytest.param(_mediapipe_case, id="mediapipe", marks=pytest.mark.model),
+    ]
+)
+def case(request: pytest.FixtureRequest) -> Case:
+    factory: object = request.param
+    return factory()  # type: ignore[operator, no-any-return]
+
+
+# ---------------------------------------------------------------------------------------------
+# The contract
+# ---------------------------------------------------------------------------------------------
+
+
+def test_conforms_to_the_protocol(case: Case) -> None:
+    assert isinstance(case.with_person, PoseBackend)
+
+
+def test_name_is_stable_and_stamped_onto_the_frame(case: Case) -> None:
+    """Provenance travels with the data, so a stored report can say which engine produced it."""
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert case.with_person.name
+    assert frame.backend == case.with_person.name
+
+
+def test_reports_only_canonical_keypoints(case: Case) -> None:
+    """A backend must not widen the schema. The canonical set is the project's, not the model's."""
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert set(frame.landmarks) <= set(KeypointName)
+
+
+def test_supplies_the_keypoints_the_rules_engine_cannot_work_without(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert set(frame.landmarks) >= REQUIRED
+
+
+def test_neck_is_the_shoulder_midpoint_on_every_backend(case: Case) -> None:
+    """The one derived keypoint, and both backends must derive it the same way.
+
+    If they disagreed, a threshold tuned against fake frames would be tuned against a skeleton the
+    real backend never produces — the exact silent drift this suite exists to prevent.
+    """
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    left = frame.landmarks[KeypointName.LEFT_SHOULDER]
+    right = frame.landmarks[KeypointName.RIGHT_SHOULDER]
+    neck = frame.landmarks[KeypointName.NECK]
+    assert neck.x == pytest.approx((left.x + right.x) / 2, abs=1e-6)
+    assert neck.y == pytest.approx((left.y + right.y) / 2, abs=1e-6)
+
+
+def test_confidences_are_probabilities(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    for name, landmark in frame.landmarks.items():
+        assert 0.0 <= landmark.visibility <= 1.0, name
+        assert 0.0 <= landmark.presence <= 1.0, name
+
+
+def test_world_coordinates_are_present_for_all_landmarks_or_none(case: Case) -> None:
+    """The optionality rule, stated as a frame-level property.
+
+    A frame where some points carry metres and others do not would let a metric mix coordinate
+    systems in one calculation — wrong answers, no error. `Landmark` enforces all-or-nothing per
+    point; this enforces it across the frame.
+    """
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    with_world = [lm.has_world for lm in frame.landmarks.values()]
+    assert all(with_world) or not any(with_world)
+
+
+def test_frame_metadata_has_the_expected_types(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert isinstance(frame.image_width, int) and frame.image_width > 0
+    assert isinstance(frame.image_height, int) and frame.image_height > 0
+    assert isinstance(frame.inference_ms, float) and frame.inference_ms >= 0.0
+    for landmark in frame.landmarks.values():
+        assert isinstance(landmark.x, float)
+        assert isinstance(landmark.y, float)
+
+
+def test_returns_none_rather_than_raising_when_there_is_no_person(case: Case) -> None:
+    """The behaviour the entire error model rests on, checked identically on both backends."""
+    assert case.without_person.detect(case.image_without_person) is None
+
+
+def test_warmup_is_idempotent_and_never_raises(case: Case) -> None:
+    case.with_person.warmup()
+    case.with_person.warmup()
+
+
+def test_repeated_detection_is_stable(case: Case) -> None:
+    """The same input twice gives the same skeleton.
+
+    Latency will differ, so coordinates are compared rather than whole frames — a real backend
+    that reported different landmarks for an identical image would make every downstream
+    assertion flaky, and the fake would hide it.
+    """
+    first = case.with_person.detect(case.image_with_person)
+    second = case.with_person.detect(case.image_with_person)
+    assert first is not None and second is not None
+    assert set(first.landmarks) == set(second.landmarks)
+    for name, landmark in first.landmarks.items():
+        assert landmark.x == pytest.approx(second.landmarks[name].x, abs=1e-6), name
+        assert landmark.y == pytest.approx(second.landmarks[name].y, abs=1e-6), name

--- a/packages/pose-backends/tests/test_fake.py
+++ b/packages/pose-backends/tests/test_fake.py
@@ -1,0 +1,205 @@
+"""Tests for `FakePoseBackend` and its presets.
+
+Treated as production code, because it is: with `POSE_BACKEND=fake` the whole application runs
+backend-free, so a wrong preset does not fail a test — it silently changes what the container
+smoke test and the Playwright suite are asserting about.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import FakePoseBackend, PoseBackend, PosePreset
+from posture_core import KeypointName, PoseFrame
+
+DETECTABLE = [preset for preset in PosePreset if preset is not PosePreset.NO_PERSON]
+
+
+def image(width: int = 640, height: int = 480) -> NDArray[np.uint8]:
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+def trunk_lean(frame: PoseFrame) -> float:
+    """Signed lean of hip-mid -> shoulder-mid from vertical, positive forward, in world space."""
+    hips = [frame.landmarks[k] for k in (KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)]
+    neck = frame.landmarks[KeypointName.NECK]
+    hip_x = sum(h.x_world or 0.0 for h in hips) / 2
+    hip_y = sum(h.y_world or 0.0 for h in hips) / 2
+    return math.degrees(math.atan2((neck.x_world or 0.0) - hip_x, -((neck.y_world or 0.0) - hip_y)))
+
+
+def knee_flexion(frame: PoseFrame) -> float:
+    hip = frame.landmarks[KeypointName.LEFT_HIP]
+    knee = frame.landmarks[KeypointName.LEFT_KNEE]
+    ankle = frame.landmarks[KeypointName.LEFT_ANKLE]
+    first = [(hip.x_world or 0) - (knee.x_world or 0), (hip.y_world or 0) - (knee.y_world or 0)]
+    second = [
+        (ankle.x_world or 0) - (knee.x_world or 0),
+        (ankle.y_world or 0) - (knee.y_world or 0),
+    ]
+    dot = first[0] * second[0] + first[1] * second[1]
+    norms = math.dist(first, [0, 0]) * math.dist(second, [0, 0])
+    return math.degrees(math.acos(max(-1.0, min(1.0, dot / norms))))
+
+
+# ---------------------------------------------------------------------------------------------
+# Every preset is a usable frame
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("preset", DETECTABLE)
+def test_every_preset_returns_a_complete_frame(preset: PosePreset) -> None:
+    frame = FakePoseBackend(preset).detect(image())
+    assert frame is not None
+    assert frame.backend == "fake"
+    assert KeypointName.NECK in frame
+    assert frame.has_world_landmarks is True
+
+
+def test_no_person_preset_returns_none() -> None:
+    """The empty-desk path, exercisable without an empty desk.
+
+    Every caller downstream has to handle `None`, and this is what makes that branch reachable in
+    a test that runs in milliseconds with no model.
+    """
+    assert FakePoseBackend(PosePreset.NO_PERSON).detect(image()) is None
+
+
+@pytest.mark.parametrize("preset", DETECTABLE)
+def test_preset_output_is_byte_identical_across_runs_and_instances(preset: PosePreset) -> None:
+    """End-to-end snapshot assertions depend on this absolutely.
+
+    Two separately-constructed backends must agree, not just two calls on one — otherwise a
+    process restart between a golden-file capture and its comparison would produce a diff.
+    """
+    first = FakePoseBackend(preset).detect(image())
+    second = FakePoseBackend(preset).detect(image())
+    assert first == second
+    assert first is not None and first.inference_ms == 0.0
+
+
+def test_preset_may_be_named_by_string() -> None:
+    """`POSE_BACKEND_PRESET=hunchback` arrives as a string, not as an enum member."""
+    assert FakePoseBackend("hunchback").preset is PosePreset.HUNCHBACK
+
+
+def test_unknown_preset_name_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="slouchy"):
+        FakePoseBackend("slouchy")
+
+
+# ---------------------------------------------------------------------------------------------
+# The presets describe the postures they are named after
+# ---------------------------------------------------------------------------------------------
+
+
+def test_hunchback_leans_further_forward_than_straight() -> None:
+    """If this ordering were wrong, every rule tuned against these fixtures would be tuned
+    backwards, and nothing else in the suite would notice."""
+    straight = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    hunched = FakePoseBackend(PosePreset.HUNCHBACK).detect(image())
+    assert straight is not None and hunched is not None
+    assert trunk_lean(hunched) > trunk_lean(straight) + 20
+
+
+def test_reclined_leans_backwards_giving_a_negative_trunk_angle() -> None:
+    """The preset that catches an unsigned implementation.
+
+    A metric taking `abs()` of the lean would score reclining identically to slumping. Only a
+    fixture with a genuinely negative angle can fail such an implementation.
+    """
+    reclined = FakePoseBackend(PosePreset.RECLINED).detect(image())
+    assert reclined is not None
+    assert trunk_lean(reclined) < 0
+
+
+def test_kneeling_has_a_sharply_flexed_knee_and_seated_presets_do_not() -> None:
+    kneeling = FakePoseBackend(PosePreset.KNEELING).detect(image())
+    seated = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    assert kneeling is not None and seated is not None
+    assert knee_flexion(kneeling) < 45
+    assert 80 < knee_flexion(seated) < 120
+
+
+def test_frontal_view_shows_broad_shoulders_where_lateral_presets_show_none() -> None:
+    """What `view_confidence` (OP-31) keys off, in image space.
+
+    The original app asked for a side-on photo and assessed whatever it got. This preset is the
+    photo it should refuse.
+    """
+
+    def shoulder_span(frame: PoseFrame) -> float:
+        left = frame.landmarks[KeypointName.LEFT_SHOULDER]
+        right = frame.landmarks[KeypointName.RIGHT_SHOULDER]
+        return abs(left.x - right.x)
+
+    frontal = FakePoseBackend(PosePreset.FRONTAL_VIEW).detect(image())
+    lateral = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    assert frontal is not None and lateral is not None
+    assert shoulder_span(frontal) > 0.1
+    assert shoulder_span(lateral) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_partial_occlusion_distinguishes_missing_from_merely_unseen() -> None:
+    """Two different kinds of "we cannot assess this", and they must not collapse into one.
+
+    The legs are *omitted* — never reported, so the frame does not contain them at all. The far
+    arm is *present* with low visibility and high presence, which is what occluded looks like.
+    Being able to express both is why MediaPipe was chosen over MoveNet (ADR-0002), and this
+    preset is how the "couldn't assess your knees, try a wider shot" path gets tested without
+    finding a photograph of someone whose knees are out of shot.
+    """
+    frame = FakePoseBackend(PosePreset.PARTIAL_OCCLUSION).detect(image())
+    assert frame is not None
+
+    assert KeypointName.LEFT_KNEE not in frame
+    assert KeypointName.RIGHT_ANKLE not in frame
+
+    elbow = frame.landmarks[KeypointName.LEFT_ELBOW]
+    assert elbow.visibility < 0.3
+    assert elbow.presence > 0.8
+
+    # The upper body is still fully assessable, which is the point: partial occlusion must
+    # degrade the report, not void it.
+    assert KeypointName.NECK in frame
+    assert frame.landmarks[KeypointName.RIGHT_SHOULDER].visibility > 0.8
+
+
+# ---------------------------------------------------------------------------------------------
+# Behaviour
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_image_is_ignored_entirely() -> None:
+    """The contract, not a shortcut.
+
+    Callers select the scenario by constructing the backend. A fake that inspected pixels would
+    make an end-to-end test's outcome depend on whichever placeholder JPEG someone uploaded.
+    """
+    backend = FakePoseBackend(PosePreset.STRAIGHT)
+    noise = np.full((480, 640, 3), 255, dtype=np.uint8)
+    assert backend.detect(noise) == backend.detect(image())
+
+
+def test_frame_size_is_configurable() -> None:
+    frame = FakePoseBackend(PosePreset.STRAIGHT, image_width=1920, image_height=1080).detect(
+        image(1920, 1080)
+    )
+    assert frame is not None
+    assert (frame.image_width, frame.image_height) == (1920, 1080)
+
+
+def test_warmup_and_close_are_no_ops_that_do_not_raise() -> None:
+    """OP-40's lifespan hook calls both blind, so neither may need a special case for the fake."""
+    backend = FakePoseBackend()
+    backend.warmup()
+    backend.warmup()
+    backend.close()
+
+
+def test_satisfies_the_protocol() -> None:
+    assert isinstance(FakePoseBackend(), PoseBackend)

--- a/packages/pose-backends/tests/test_model_assets.py
+++ b/packages/pose-backends/tests/test_model_assets.py
@@ -1,0 +1,125 @@
+"""Checks on the model-acquisition contract itself.
+
+Most of these need no model file: they assert that the *pins* are well-formed and that the
+Makefile and the Python default agree about where weights live. Those are cheap and run on every
+pull request, because a checksum file the tooling cannot parse is a checksum file that silently
+verifies nothing — and that failure would only surface the day someone shipped a bad model.
+
+The one test that needs actual weights is marked `pytest.mark.model`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+
+from pose_backends.registry import DEFAULT_MODEL_PATH, default_model_path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKSUMS = REPO_ROOT / "models" / "checksums.txt"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+CHECKSUM_LINE = re.compile(r"^(?P<sha>[0-9a-f]{64})  (?P<name>\S+)$")
+
+
+def pins() -> dict[str, str]:
+    """Parse `checksums.txt` the same way the Makefile's grep does: filename -> sha256."""
+    parsed: dict[str, str] = {}
+    for line in CHECKSUMS.read_text().splitlines():
+        match = CHECKSUM_LINE.match(line)
+        if match:
+            parsed[match["name"]] = match["sha"]
+    return parsed
+
+
+def test_all_three_variants_are_pinned() -> None:
+    """lite, full and heavy. Documented as swappable, so all three must actually be fetchable."""
+    assert set(pins()) == {
+        "pose_landmarker_lite.task",
+        "pose_landmarker_full.task",
+        "pose_landmarker_heavy.task",
+    }
+
+
+def test_every_pin_is_a_full_length_sha256() -> None:
+    """A truncated hash is the failure this file exists to prevent, so it must not be possible
+    to write one here and have the tooling shrug."""
+    for name, sha in pins().items():
+        assert len(sha) == 64, name
+
+
+def test_the_python_default_and_the_makefile_target_are_the_same_file() -> None:
+    """Two places name the model path, and they must not drift.
+
+    `make fetch-model` writes to `models/pose_landmarker_$(MODEL_VARIANT).task`; the API loads
+    `DEFAULT_MODEL_PATH` when `MODEL_PATH` is unset. If those disagreed, fetching the model would
+    appear to work and the backend would still report the file missing.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "MODEL_VARIANT ?= full" in makefile
+    assert "MODEL_DIR     ?= models" in makefile
+    assert Path("models/pose_landmarker_full.task") == DEFAULT_MODEL_PATH
+
+
+def test_the_makefile_fetches_the_versioned_url_not_latest() -> None:
+    """`/1/` and `/latest/` are different files — four bytes apart, different hashes.
+
+    Pinning a checksum against a URL whose contents can be republished is a pin in name only. The
+    discrepancy is recorded in checksums.txt; this keeps the Makefile on the right side of it.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "/float16/1/" in makefile
+    assert "/float16/latest/" not in makefile
+
+
+def test_the_makefile_does_not_trust_shasum_check_mode() -> None:
+    """`shasum -c` exits 0 on a line it could not parse, so a typo'd pin would "pass".
+
+    Asserted rather than merely commented because the obvious "simplification" during a future
+    cleanup is to replace the explicit comparison with `shasum -c`, which would quietly remove
+    the guarantee while looking tidier.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "shasum -a 256 -c" not in makefile
+    assert "-c $(CHECKSUMS)" not in makefile
+
+
+def test_model_path_environment_variable_overrides_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_PATH", "/opt/models/pose_landmarker_lite.task")
+    assert default_model_path() == Path("/opt/models/pose_landmarker_lite.task")
+
+
+def test_weights_are_not_committed() -> None:
+    """The legacy project committed a 209 MB `model.h5`, could not push it, and resorted to a
+    Dropbox link. `make fetch-model` plus a pinned hash is the replacement; a `.task` appearing in
+    the tree means someone bypassed it."""
+    ignored = (REPO_ROOT / ".gitignore").read_text()
+    assert "models/*.task" in ignored
+
+
+@pytest.mark.model
+def test_the_model_on_disk_matches_its_pin() -> None:
+    """The real integrity check, run by model-validation.yml before anything else (OP-21).
+
+    Reads in chunks rather than slurping: `heavy` is 29 MB and there is no reason to hold it all
+    in memory to hash it.
+    """
+    path = default_model_path()
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    if not path.is_file():
+        pytest.skip(f"no model at {path} — run `make fetch-model`")
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    expected = pins().get(path.name)
+    assert expected is not None, f"{path.name} has no pinned checksum in {CHECKSUMS}"
+    assert digest.hexdigest() == expected

--- a/packages/pose-backends/tests/test_registry.py
+++ b/packages/pose-backends/tests/test_registry.py
@@ -1,0 +1,82 @@
+"""Backend selection from configuration.
+
+`POSE_BACKEND=fake` has to work as a deployment switch and not only as a test injection point:
+the container smoke test starts the real image and Playwright drives the real frontend, and
+neither can reach into a Python fixture to swap an object.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pose_backends import (
+    FakePoseBackend,
+    ModelNotFoundError,
+    PoseBackendError,
+    PosePreset,
+    create_backend,
+    default_model_path,
+)
+from pose_backends.registry import DEFAULT_MODEL_PATH
+
+
+def test_explicit_name_selects_the_fake_backend() -> None:
+    backend = create_backend("fake")
+    assert isinstance(backend, FakePoseBackend)
+    assert backend.preset is PosePreset.STRAIGHT
+
+
+def test_environment_selects_the_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSE_BACKEND", "fake")
+    assert isinstance(create_backend(), FakePoseBackend)
+
+
+def test_environment_selects_the_preset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSE_BACKEND", "fake")
+    monkeypatch.setenv("POSE_BACKEND_PRESET", "hunchback")
+    backend = create_backend()
+    assert isinstance(backend, FakePoseBackend)
+    assert backend.preset is PosePreset.HUNCHBACK
+
+
+@pytest.mark.parametrize("value", ["FAKE", " fake ", "Fake"])
+def test_backend_name_is_case_and_whitespace_tolerant(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stray newline in a Compose env file should not silently start real inference."""
+    monkeypatch.setenv("POSE_BACKEND", value)
+    assert isinstance(create_backend(), FakePoseBackend)
+
+
+def test_the_real_backend_is_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing variable must yield real inference, never a fabricated skeleton.
+
+    Defaulting to the fake would mean a deployment that forgot to set the variable would serve
+    invented posture assessments and look perfectly healthy doing it. Asserted here through the
+    model-not-found error, because the real backend is what tries to load weights.
+    """
+    monkeypatch.delenv("POSE_BACKEND", raising=False)
+    with pytest.raises(ModelNotFoundError):
+        create_backend(model_path="/nonexistent/model.task")
+
+
+def test_unknown_backend_fails_loudly_and_lists_the_alternatives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Silently falling back would ship an application that invents its results."""
+    monkeypatch.setenv("POSE_BACKEND", "movenet")
+    with pytest.raises(PoseBackendError, match="mediapipe, fake"):
+        create_backend()
+
+
+def test_model_path_defaults_to_the_fetch_model_location(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODEL_PATH", raising=False)
+    assert default_model_path() == DEFAULT_MODEL_PATH
+
+
+def test_model_path_environment_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """So a lite or heavy model variant can be swapped in without rebuilding the image (OP-20)."""
+    monkeypatch.setenv("MODEL_PATH", "/models/pose_landmarker_heavy.task")
+    assert default_model_path() == Path("/models/pose_landmarker_heavy.task")

--- a/packages/posture-core/src/posture_core/synthetic.py
+++ b/packages/posture-core/src/posture_core/synthetic.py
@@ -1,0 +1,410 @@
+"""Analytic stick-figure construction: skeletons built from angles rather than from photographs.
+
+## Why this is shipped code and not a test helper
+
+Two very different consumers need to build the same synthetic poses:
+
+* ``FakePoseBackend`` (OP-19), which is *production* code — it is what lets the whole application
+  run with ``POSE_BACKEND=fake``, so the container smoke test and the Playwright suite need no
+  model weights and no secrets. That is the single reason CI stays fast.
+* the rules-engine tests in Epic C (OP-33), which assert things like
+  ``metric(make_pose(trunk_deg=35)).value == approx(35, abs=1.0)``.
+
+If those two built their figures separately they would drift, and the day they drifted every
+end-to-end assertion resting on a fake pose would quietly stop meaning anything. One builder, in
+the package both already depend on.
+
+It also inverts the usual test-fixture problem. A metric tested against a photograph can only be
+checked against a human's guess at the true angle; a metric tested against a figure *constructed*
+at 35° has a known-correct answer. The tests become statements about geometry rather than about
+someone's eyeballing of a JPEG.
+
+## The coordinate system
+
+Matches what MediaPipe's world landmarks provide, because that is what the real backend emits:
+metres, **hip midpoint at the origin**, ``x`` to the image right, ``y`` **down**, ``z`` depth.
+Image-space coordinates are an orthographic projection of the same figure — the depth axis is
+simply dropped, which is exactly what a camera does to a subject much further away than they are
+deep.
+
+Everything is pure: no randomness, no clock, no I/O. The same arguments produce byte-identical
+output forever, which is what ``FakePoseBackend``'s stability guarantee rests on.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final, TypeAlias
+
+from posture_core.keypoints import KeypointName, Landmark, PoseFrame
+
+__all__ = [
+    "Anthropometry",
+    "Facing",
+    "View",
+    "make_pose",
+    "make_pose_frame",
+]
+
+Vec3: TypeAlias = tuple[float, float, float]
+
+
+class Facing(StrEnum):
+    """Which way the subject's front points, for a lateral view."""
+
+    RIGHT = "right"
+    LEFT = "left"
+
+
+class View(StrEnum):
+    """Camera position relative to the subject.
+
+    The distinction is not cosmetic. In :attr:`LATERAL` the subject's shoulder separation runs
+    along the depth axis, so the *image* shows almost no shoulder width and a forward lean is
+    plainly visible. In :attr:`FRONTAL` the two swap: shoulders are wide on screen and the lean
+    disappears into depth.
+
+    That ratio — shoulder width against torso length, in image space — is precisely what
+    ``view_confidence`` (OP-31) measures, and this enum is what lets it be tested. The original
+    app *told* users to photograph themselves from the side and then never checked.
+    """
+
+    LATERAL = "lateral"
+    FRONTAL = "frontal"
+
+
+@dataclass(frozen=True, slots=True)
+class Anthropometry:
+    """Segment lengths in metres, roughly a 50th-percentile adult.
+
+    Injected rather than hardcoded so a test can shrink or stretch the figure and assert that an
+    angular metric does not move — the scale-invariance property (OP-34) that the original engine
+    would fail catastrophically, since its thresholds were raw pixel counts.
+    """
+
+    torso: float = 0.50
+    """Hip midpoint to shoulder midpoint."""
+
+    neck: float = 0.24
+    """Shoulder midpoint to the centre of the head."""
+
+    shoulder_width: float = 0.38
+    hip_width: float = 0.30
+    head_width: float = 0.16
+    upper_arm: float = 0.30
+    forearm: float = 0.27
+    hand: float = 0.09
+    thigh: float = 0.42
+    shank: float = 0.42
+    foot: float = 0.16
+    heel_drop: float = 0.05
+    """How far the heel sits below the ankle."""
+
+
+# Where the hip midpoint lands in the frame, and how large the figure is drawn. Chosen so a
+# seated figure fits comfortably at any common aspect ratio; nothing downstream depends on the
+# exact numbers, because every metric is either angular or normalised.
+_HIP_X_FRACTION: Final = 0.4
+_HIP_Y_FRACTION: Final = 0.62
+_FRAME_HEIGHTS_PER_METRE: Final = 0.42
+
+
+def _add(*vectors: Vec3) -> Vec3:
+    return (
+        sum(v[0] for v in vectors),
+        sum(v[1] for v in vectors),
+        sum(v[2] for v in vectors),
+    )
+
+
+def _scale(vector: Vec3, factor: float) -> Vec3:
+    return (vector[0] * factor, vector[1] * factor, vector[2] * factor)
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _Frame:
+    """The subject's own axes, from which every segment direction is built."""
+
+    up: Vec3
+    forward: Vec3
+    left: Vec3
+
+    def from_vertical_down(self, degrees: float) -> Vec3:
+        """Unit direction ``degrees`` from straight down, rotating toward :attr:`forward`.
+
+        The natural way to describe a limb: 0° is a leg hanging straight down, 90° is a thigh
+        held horizontally forward, as in sitting.
+        """
+        radians = math.radians(degrees)
+        return _add(
+            _scale(self.up, -math.cos(radians)),
+            _scale(self.forward, math.sin(radians)),
+        )
+
+    def from_vertical_up(self, degrees: float) -> Vec3:
+        """Unit direction ``degrees`` from straight up, rotating toward :attr:`forward`.
+
+        The natural way to describe the trunk: 0° is upright, positive is leaning forward — which
+        is also the sign convention ``trunk_inclination_deg`` (OP-26) reports.
+        """
+        radians = math.radians(degrees)
+        return _add(
+            _scale(self.up, math.cos(radians)),
+            _scale(self.forward, math.sin(radians)),
+        )
+
+
+def _axes(facing: Facing, view: View) -> _Frame:
+    """Build the subject's axes.
+
+    ``up`` is ``(0, -1, 0)`` because the coordinate system is y-**down**, matching MediaPipe.
+    ``left = cross(up, forward)`` keeps the basis right-handed, which is what makes a single set of
+    segment formulas work for both camera positions: in a lateral view ``left`` comes out along
+    the depth axis, in a frontal view it comes out along the image's horizontal axis. No branching
+    inside the construction itself.
+    """
+    up: Vec3 = (0.0, -1.0, 0.0)
+    if view is View.FRONTAL:
+        # Facing the camera. "Forward" is out of the screen, so a forward lean is a change in
+        # depth and is nearly invisible in the projected image — the whole point of the preset.
+        forward: Vec3 = (0.0, 0.0, -1.0)
+    else:
+        forward = (1.0, 0.0, 0.0) if facing is Facing.RIGHT else (-1.0, 0.0, 0.0)
+    return _Frame(up=up, forward=forward, left=_cross(up, forward))
+
+
+# Keyword-only throughout, and there are a lot of them: a stick figure genuinely has this many
+# joints, and `make_pose(trunk_deg=35)` at a call site is worth more than a config object that
+# would just move the same parameter list somewhere less discoverable.
+def make_pose(
+    *,
+    trunk_deg: float = 0.0,
+    neck_deg: float = 0.0,
+    thigh_deg: float = 0.0,
+    shank_deg: float = 0.0,
+    upper_arm_deg: float = 0.0,
+    forearm_deg: float = 0.0,
+    facing: Facing = Facing.RIGHT,
+    view: View = View.LATERAL,
+    image_width: int = 640,
+    image_height: int = 480,
+    visibility: float = 0.95,
+    presence: float = 0.98,
+    confidence: Mapping[KeypointName, tuple[float, float]] | None = None,
+    omit: Iterable[KeypointName] = (),
+    body: Anthropometry | None = None,
+) -> dict[KeypointName, Landmark]:
+    """Construct a complete canonical skeleton from joint angles.
+
+    All angles are degrees in the sagittal plane. Limb angles (``thigh_deg``, ``shank_deg``,
+    ``upper_arm_deg``, ``forearm_deg``) are measured from **straight down**; ``trunk_deg`` and
+    ``neck_deg`` from **straight up**, positive forward.
+
+    Joint *flexion* is therefore emergent rather than an input — knee flexion is
+    ``180 - |thigh_deg - shank_deg|``. That is deliberate: it means the figure is always
+    physically consistent, whereas taking flexion as an input would let a caller specify a knee
+    angle and a shin direction that contradict each other.
+
+    :param confidence: per-keypoint ``(visibility, presence)`` overrides. The two are independent
+        signals — low visibility with high presence is *occluded*, low presence is *out of frame*
+        — so a preset can express "the far arm is behind the torso" distinctly from "the legs are
+        outside the shot".
+    :param omit: keypoints to leave out entirely, for degradation tests. Absence is not the same
+        as zero confidence and the two must stay distinguishable.
+    """
+    body = body if body is not None else Anthropometry()
+    axes = _axes(facing, view)
+    dropped = frozenset(omit)
+
+    half_shoulder = _scale(axes.left, body.shoulder_width / 2)
+    half_hip = _scale(axes.left, body.hip_width / 2)
+    half_head = _scale(axes.left, body.head_width / 2)
+
+    # The hip midpoint is the origin — the same convention MediaPipe's world landmarks use.
+    hip_mid: Vec3 = (0.0, 0.0, 0.0)
+    shoulder_mid = _scale(axes.from_vertical_up(trunk_deg), body.torso)
+    head_mid = _add(shoulder_mid, _scale(axes.from_vertical_up(trunk_deg + neck_deg), body.neck))
+
+    points: dict[KeypointName, Vec3] = {}
+
+    def place(name: KeypointName, position: Vec3) -> None:
+        if name not in dropped:
+            points[name] = position
+
+    # --- torso ------------------------------------------------------------------------------
+    place(KeypointName.LEFT_HIP, _add(hip_mid, half_hip))
+    place(KeypointName.RIGHT_HIP, _add(hip_mid, _scale(half_hip, -1)))
+    place(KeypointName.LEFT_SHOULDER, _add(shoulder_mid, half_shoulder))
+    place(KeypointName.RIGHT_SHOULDER, _add(shoulder_mid, _scale(half_shoulder, -1)))
+    # NECK is the shoulder midpoint by definition — the same derivation MediaPipeBackend applies,
+    # so a fake frame and a real one describe the neck identically (ADR-0002).
+    place(KeypointName.NECK, shoulder_mid)
+
+    # --- head -------------------------------------------------------------------------------
+    face = axes.forward
+    place(KeypointName.LEFT_EAR, _add(head_mid, half_head))
+    place(KeypointName.RIGHT_EAR, _add(head_mid, _scale(half_head, -1)))
+    nose = _add(head_mid, _scale(face, body.head_width * 0.9))
+    place(KeypointName.NOSE, nose)
+    for name, lateral, forward_frac, rise in (
+        (KeypointName.LEFT_EYE_INNER, 0.15, 0.55, 0.25),
+        (KeypointName.LEFT_EYE, 0.30, 0.55, 0.25),
+        (KeypointName.LEFT_EYE_OUTER, 0.45, 0.50, 0.25),
+        (KeypointName.RIGHT_EYE_INNER, -0.15, 0.55, 0.25),
+        (KeypointName.RIGHT_EYE, -0.30, 0.55, 0.25),
+        (KeypointName.RIGHT_EYE_OUTER, -0.45, 0.50, 0.25),
+        (KeypointName.MOUTH_LEFT, 0.20, 0.80, -0.25),
+        (KeypointName.MOUTH_RIGHT, -0.20, 0.80, -0.25),
+    ):
+        place(
+            name,
+            _add(
+                head_mid,
+                _scale(axes.left, body.head_width * lateral),
+                _scale(face, body.head_width * forward_frac),
+                _scale(axes.up, body.head_width * rise),
+            ),
+        )
+
+    # --- arms -------------------------------------------------------------------------------
+    upper_arm = _scale(axes.from_vertical_down(upper_arm_deg), body.upper_arm)
+    forearm = _scale(axes.from_vertical_down(forearm_deg), body.forearm)
+    for side, elbow_name, wrist_name, hand_names in (
+        (
+            1,
+            KeypointName.LEFT_ELBOW,
+            KeypointName.LEFT_WRIST,
+            (KeypointName.LEFT_PINKY, KeypointName.LEFT_INDEX, KeypointName.LEFT_THUMB),
+        ),
+        (
+            -1,
+            KeypointName.RIGHT_ELBOW,
+            KeypointName.RIGHT_WRIST,
+            (KeypointName.RIGHT_PINKY, KeypointName.RIGHT_INDEX, KeypointName.RIGHT_THUMB),
+        ),
+    ):
+        shoulder = _add(shoulder_mid, _scale(half_shoulder, side))
+        elbow = _add(shoulder, upper_arm)
+        wrist = _add(elbow, forearm)
+        place(elbow_name, elbow)
+        place(wrist_name, wrist)
+        pinky, index, thumb = hand_names
+        hand_direction = _scale(axes.from_vertical_down(forearm_deg), body.hand)
+        place(pinky, _add(wrist, hand_direction, _scale(axes.left, side * 0.02)))
+        place(index, _add(wrist, hand_direction, _scale(axes.left, -side * 0.02)))
+        place(thumb, _add(wrist, _scale(hand_direction, 0.6), _scale(face, 0.03)))
+
+    # --- legs -------------------------------------------------------------------------------
+    thigh = _scale(axes.from_vertical_down(thigh_deg), body.thigh)
+    shank = _scale(axes.from_vertical_down(shank_deg), body.shank)
+    for side, knee_name, ankle_name, heel_name, toe_name in (
+        (
+            1,
+            KeypointName.LEFT_KNEE,
+            KeypointName.LEFT_ANKLE,
+            KeypointName.LEFT_HEEL,
+            KeypointName.LEFT_FOOT_INDEX,
+        ),
+        (
+            -1,
+            KeypointName.RIGHT_KNEE,
+            KeypointName.RIGHT_ANKLE,
+            KeypointName.RIGHT_HEEL,
+            KeypointName.RIGHT_FOOT_INDEX,
+        ),
+    ):
+        hip = _add(hip_mid, _scale(half_hip, side))
+        knee = _add(hip, thigh)
+        ankle = _add(knee, shank)
+        place(knee_name, knee)
+        place(ankle_name, ankle)
+        # The foot is modelled flat: heel behind and below the ankle, toe ahead and below. That is
+        # enough for `heel_contact` (OP-30) to be a real measurement — the capability the original
+        # project listed as a goal and never delivered, because COCO-18 has no foot landmarks.
+        place(
+            heel_name,
+            _add(ankle, _scale(face, -body.foot * 0.25), _scale(axes.up, -body.heel_drop)),
+        )
+        place(
+            toe_name,
+            _add(ankle, _scale(face, body.foot), _scale(axes.up, -body.heel_drop)),
+        )
+
+    return _project(
+        points,
+        image_width=image_width,
+        image_height=image_height,
+        visibility=visibility,
+        presence=presence,
+        confidence=confidence or {},
+    )
+
+
+def _project(
+    points: Mapping[KeypointName, Vec3],
+    *,
+    image_width: int,
+    image_height: int,
+    visibility: float,
+    presence: float,
+    confidence: Mapping[KeypointName, tuple[float, float]],
+) -> dict[KeypointName, Landmark]:
+    """World metres -> canonical landmarks carrying both coordinate systems.
+
+    Orthographic: the depth axis is dropped rather than divided through. A real camera's
+    perspective divide matters when the subject's depth is comparable to their distance from the
+    lens, which is not the case for someone photographed at desk range — and modelling it would
+    make the figure's *known* angles no longer recoverable from the image, defeating the purpose.
+    """
+    scale = image_height * _FRAME_HEIGHTS_PER_METRE
+    origin_x = image_width * _HIP_X_FRACTION
+    origin_y = image_height * _HIP_Y_FRACTION
+
+    landmarks: dict[KeypointName, Landmark] = {}
+    for name, (world_x, world_y, world_z) in points.items():
+        point_visibility, point_presence = confidence.get(name, (visibility, presence))
+        landmarks[name] = Landmark(
+            x=(origin_x + world_x * scale) / image_width,
+            y=(origin_y + world_y * scale) / image_height,
+            visibility=point_visibility,
+            presence=point_presence,
+            x_world=world_x,
+            y_world=world_y,
+            z_world=world_z,
+        )
+    return landmarks
+
+
+def make_pose_frame(
+    *,
+    backend: str = "synthetic",
+    inference_ms: float = 0.0,
+    image_width: int = 640,
+    image_height: int = 480,
+    **pose_kwargs: object,
+) -> PoseFrame:
+    """:func:`make_pose`, wrapped in a :class:`~posture_core.PoseFrame`.
+
+    ``inference_ms`` defaults to exactly ``0.0`` rather than being measured. A synthetic frame has
+    no inference to time, and a real measurement would make otherwise-identical frames differ
+    between runs — which would break the byte-identical guarantee that end-to-end snapshot
+    assertions depend on.
+    """
+    return PoseFrame(
+        landmarks=make_pose(image_width=image_width, image_height=image_height, **pose_kwargs),  # type: ignore[arg-type]
+        image_width=image_width,
+        image_height=image_height,
+        backend=backend,
+        inference_ms=inference_ms,
+    )

--- a/packages/posture-core/tests/test_synthetic.py
+++ b/packages/posture-core/tests/test_synthetic.py
@@ -1,0 +1,254 @@
+"""Tests for the analytic stick-figure builder.
+
+The builder is the thing the *rest* of the test suite will measure against, so it has to be
+correct on its own terms first. A metric asserted to read 35° against a figure that was not
+actually built at 35° proves nothing about the metric.
+
+The recovery helpers below deliberately reimplement the trigonometry from scratch rather than
+importing anything from Epic C. Checking a builder with the code that will be tested using the
+builder is circular; independent arithmetic is the point.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from posture_core import KeypointName, Landmark
+from posture_core.synthetic import Anthropometry, Facing, View, make_pose, make_pose_frame
+
+Pose = dict[KeypointName, Landmark]
+
+
+def world(landmark: Landmark) -> tuple[float, float, float]:
+    assert landmark.x_world is not None
+    assert landmark.y_world is not None
+    assert landmark.z_world is not None
+    return landmark.x_world, landmark.y_world, landmark.z_world
+
+
+def midpoint_world(pose: Pose, a: KeypointName, b: KeypointName) -> tuple[float, float, float]:
+    left, right = world(pose[a]), world(pose[b])
+    return tuple((left[i] + right[i]) / 2 for i in range(3))  # type: ignore[return-value]
+
+
+def trunk_angle(pose: Pose) -> float:
+    """Signed angle of hip-mid -> shoulder-mid away from straight up, **positive toward +x**.
+
+    Not "positive forward". This helper works in raw world coordinates and has no notion of which
+    way the subject faces, so a left-facing figure leaning forward reads *negative* here — which
+    `test_facing_left_mirrors_the_figure` relies on. The metric itself (OP-26) takes facing into
+    account via `resolver.forward_axis()`; this deliberately does not, so that the builder can be
+    checked without depending on the thing being built for.
+    """
+    hip = midpoint_world(pose, KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    shoulder = midpoint_world(pose, KeypointName.LEFT_SHOULDER, KeypointName.RIGHT_SHOULDER)
+    return math.degrees(math.atan2(shoulder[0] - hip[0], -(shoulder[1] - hip[1])))
+
+
+def joint_angle(pose: Pose, a: KeypointName, vertex: KeypointName, c: KeypointName) -> float:
+    origin = world(pose[vertex])
+    first = [world(pose[a])[i] - origin[i] for i in range(3)]
+    second = [world(pose[c])[i] - origin[i] for i in range(3)]
+    dot = sum(p * q for p, q in zip(first, second, strict=True))
+    norms = math.dist(first, [0, 0, 0]) * math.dist(second, [0, 0, 0])
+    return math.degrees(math.acos(max(-1.0, min(1.0, dot / norms))))
+
+
+def image_distance(a: Landmark, b: Landmark, width: int = 640, height: int = 480) -> float:
+    return math.hypot((a.x - b.x) * width, (a.y - b.y) * height)
+
+
+# ---------------------------------------------------------------------------------------------
+# The figure is what it says it is
+# ---------------------------------------------------------------------------------------------
+
+
+def test_produces_the_complete_canonical_skeleton() -> None:
+    assert set(make_pose()) == set(KeypointName)
+
+
+@pytest.mark.parametrize("requested", [-40.0, -25.0, 0.0, 3.0, 32.0, 60.0])
+def test_trunk_angle_is_recoverable_from_the_figure(requested: float) -> None:
+    """The property every Epic C metric test will lean on.
+
+    A figure built at 32° must measure 32°, including when negative — reclining is a different
+    posture from slumping, and a builder that folded the sign would make it impossible to write a
+    test distinguishing them.
+    """
+    assert trunk_angle(make_pose(trunk_deg=requested)) == pytest.approx(requested, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("thigh", "shank"),
+    [(85.0, 5.0), (15.0, 165.0), (0.0, 0.0), (90.0, 90.0)],
+)
+def test_knee_flexion_emerges_from_the_two_segment_angles(thigh: float, shank: float) -> None:
+    """Flexion is derived, not specified — which is what keeps the figure physically consistent.
+
+    Taking flexion as an input would let a caller ask for a 90° knee and a shin pointing in a
+    direction that contradicts it, and the builder would have to silently pick a winner.
+    """
+    pose = make_pose(thigh_deg=thigh, shank_deg=shank)
+    expected = 180.0 - abs(thigh - shank)
+    measured = joint_angle(
+        pose, KeypointName.LEFT_HIP, KeypointName.LEFT_KNEE, KeypointName.LEFT_ANKLE
+    )
+    assert measured == pytest.approx(expected, abs=1e-6)
+
+
+def test_hip_midpoint_is_the_world_origin() -> None:
+    """MediaPipe's world-landmark convention, so fake and real frames are interchangeable."""
+    hip = midpoint_world(make_pose(trunk_deg=20.0), KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    assert hip == pytest.approx((0.0, 0.0, 0.0), abs=1e-12)
+
+
+def test_neck_is_exactly_the_shoulder_midpoint() -> None:
+    """The same derivation `MediaPipeBackend` performs, so the two backends agree on the neck.
+
+    If they disagreed, a rule tuned against fake frames would be tuned against a skeleton the real
+    backend never produces.
+    """
+    pose = make_pose(trunk_deg=18.0)
+    shoulders = midpoint_world(pose, KeypointName.LEFT_SHOULDER, KeypointName.RIGHT_SHOULDER)
+    assert world(pose[KeypointName.NECK]) == pytest.approx(shoulders, abs=1e-12)
+
+
+def test_neck_angle_is_additional_to_the_trunk() -> None:
+    """Forward head posture stacks on top of whatever the trunk is doing.
+
+    Ear ahead of the shoulders is what a craniovertebral angle measures (OP-27), so the builder
+    has to be able to produce it independently of trunk lean.
+    """
+    upright = make_pose(trunk_deg=0.0, neck_deg=0.0)
+    forward_head = make_pose(trunk_deg=0.0, neck_deg=35.0)
+    ear = KeypointName.LEFT_EAR
+    assert world(forward_head[ear])[0] > world(upright[ear])[0]
+
+
+def test_facing_left_mirrors_the_figure() -> None:
+    right = make_pose(trunk_deg=25.0, facing=Facing.RIGHT)
+    left = make_pose(trunk_deg=25.0, facing=Facing.LEFT)
+    assert world(right[KeypointName.NOSE])[0] == pytest.approx(-world(left[KeypointName.NOSE])[0])
+    # The trunk lean itself is unchanged: leaning forward is leaning forward whichever way you
+    # face. An implementation keying lean off raw x would report these as opposite postures —
+    # which is exactly the legacy laterality bug (FINDINGS §2.1), reproduced here as a guard.
+    assert trunk_angle(left) == pytest.approx(-25.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------------------------
+# Camera position
+# ---------------------------------------------------------------------------------------------
+
+
+def test_lateral_view_hides_shoulder_width_and_shows_the_lean() -> None:
+    pose = make_pose(trunk_deg=30.0, view=View.LATERAL)
+    shoulders = image_distance(pose[KeypointName.LEFT_SHOULDER], pose[KeypointName.RIGHT_SHOULDER])
+    assert shoulders == pytest.approx(0.0, abs=1e-9)
+    assert trunk_angle(pose) == pytest.approx(30.0)
+
+
+def test_frontal_view_shows_shoulder_width_and_hides_the_lean() -> None:
+    """The failure the original app invited and never guarded against.
+
+    It told users "this image must be taken from a side angle" and then assessed whatever arrived.
+    A 30° slump photographed head-on projects to almost no apparent lean, so the app would report
+    good posture with complete confidence. `view_confidence` (OP-31) exists to refuse this, and
+    this preset is what it gets tested against.
+    """
+    pose = make_pose(trunk_deg=30.0, view=View.FRONTAL)
+    shoulders = image_distance(pose[KeypointName.LEFT_SHOULDER], pose[KeypointName.RIGHT_SHOULDER])
+    torso = image_distance(pose[KeypointName.NECK], pose[KeypointName.LEFT_HIP])
+    assert shoulders / torso > 0.5
+
+    hip = midpoint_world(pose, KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    neck = world(pose[KeypointName.NECK])
+    apparent_lean = math.degrees(math.atan2(neck[0] - hip[0], -(neck[1] - hip[1])))
+    assert apparent_lean == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------------------------
+# Scale, determinism, degradation
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factor", [0.5, 1.0, 2.5])
+def test_angles_are_invariant_to_body_size(factor: float) -> None:
+    """The proof that the redesign fixed the original defect, in miniature.
+
+    The legacy engine compared raw pixel distances against literal thresholds, so the same posture
+    at a different distance or on a different-sized person got a different verdict. Angles in world
+    space cannot do that. The full Hypothesis version of this property is OP-34; this is the
+    builder's own guarantee that it is a fair test bed for it.
+    """
+    default = Anthropometry()
+    scaled = Anthropometry(
+        torso=default.torso * factor,
+        neck=default.neck * factor,
+        shoulder_width=default.shoulder_width * factor,
+        hip_width=default.hip_width * factor,
+        thigh=default.thigh * factor,
+        shank=default.shank * factor,
+    )
+    pose = make_pose(trunk_deg=27.0, thigh_deg=85.0, shank_deg=5.0, body=scaled)
+    assert trunk_angle(pose) == pytest.approx(27.0, abs=1e-9)
+    assert joint_angle(
+        pose, KeypointName.LEFT_HIP, KeypointName.LEFT_KNEE, KeypointName.LEFT_ANKLE
+    ) == pytest.approx(100.0, abs=1e-6)
+
+
+def test_output_is_byte_identical_across_calls() -> None:
+    """No clock, no randomness. Snapshot assertions downstream depend on this absolutely."""
+    assert make_pose(trunk_deg=12.0) == make_pose(trunk_deg=12.0)
+
+
+def test_omitted_keypoints_are_absent_rather_than_zeroed() -> None:
+    """Degradation tests need "not reported", which is a different fact from "low confidence"."""
+    pose = make_pose(omit=(KeypointName.LEFT_KNEE, KeypointName.RIGHT_KNEE))
+    assert KeypointName.LEFT_KNEE not in pose
+    assert KeypointName.RIGHT_KNEE not in pose
+    assert len(pose) == len(KeypointName) - 2
+
+
+def test_per_keypoint_confidence_can_express_occlusion_separately_from_absence() -> None:
+    """Low visibility with high presence means occluded; low presence means out of frame.
+
+    Two independent signals, and the reason MediaPipe was chosen over MoveNet (ADR-0002). The
+    builder has to be able to produce both or the status model (OP-25) has nothing to test on.
+    """
+    pose = make_pose(confidence={KeypointName.LEFT_WRIST: (0.1, 0.95)})
+    wrist = pose[KeypointName.LEFT_WRIST]
+    assert wrist.visibility == pytest.approx(0.1)
+    assert wrist.presence == pytest.approx(0.95)
+    assert pose[KeypointName.RIGHT_WRIST].visibility == pytest.approx(0.95)
+
+
+def test_image_coordinates_track_the_frame_size() -> None:
+    """Normalised coordinates are resolution-independent: the same figure at 4K reads the same."""
+    small = make_pose(trunk_deg=15.0, image_width=640, image_height=480)
+    large = make_pose(trunk_deg=15.0, image_width=3840, image_height=2880)
+    assert small[KeypointName.NOSE].x == pytest.approx(large[KeypointName.NOSE].x)
+    assert small[KeypointName.NOSE].y == pytest.approx(large[KeypointName.NOSE].y)
+
+
+def test_the_figure_fits_inside_the_frame() -> None:
+    """Not a correctness requirement, but a landmark outside [0, 1] would read as OUT_OF_FRAME to
+    the status model (OP-25) and make every preset look partially clipped."""
+    for landmark in make_pose(trunk_deg=32.0, thigh_deg=85.0, shank_deg=5.0).values():
+        assert 0.0 <= landmark.x <= 1.0
+        assert 0.0 <= landmark.y <= 1.0
+
+
+# ---------------------------------------------------------------------------------------------
+# make_pose_frame
+# ---------------------------------------------------------------------------------------------
+
+
+def test_frame_wraps_the_pose_with_a_constant_zero_latency() -> None:
+    """A synthetic frame has no inference to time, and a measured value would differ between runs
+    — which is precisely what would break the byte-identical guarantee."""
+    frame = make_pose_frame(trunk_deg=10.0)
+    assert frame.inference_ms == 0.0
+    assert frame.has_world_landmarks is True
+    assert make_pose_frame(trunk_deg=10.0) == frame


### PR DESCRIPTION
Closes OP-20. Base: `op-19-fake-backend`.

Makes model weights reproducible and verifiable. Replaces the legacy arrangement, where a 209 MB `model.h5` exceeded GitHub's file limit and was distributed by an unpinned Dropbox link with no checksum.

## Changes
- `Makefile`: `fetch-model`, `verify-model`, `clean-model`, `help`. `MODEL_VARIANT=lite|full|heavy`.
- `models/checksums.txt`: pinned SHA256 for all three variants, with the variant trade-offs documented.
- `pose_backends.registry`: `default_model_path()` and `DEFAULT_MODEL_PATH`, with `MODEL_PATH` taking precedence.
- `.gitignore`: `models/*.task`. `CONTRIBUTING.md`: how to run the model-marked tests locally.

## Notes
- The Makefile fetches `/float16/1/`, not `/float16/latest/`. Verified by downloading each twice: the two are different files, differing in four bytes (offsets 12, 2959110, 9398046, 9398112 — container metadata) with different hashes and identical size. A pin against `latest` would break silently on republish.
- Checksums are compared explicitly rather than with `shasum -c`. Check mode treats an unparseable line as a warning and still exits 0 (verified on macOS), so a typo'd hash or an absent file passes.
- Downloads land in `<target>.download` and move into place only after verification, so a failed checksum cannot leave a bad file where the next run would accept it.
- All three variants emit the same 33 landmarks with world coordinates, so switching is configuration rather than code.

## Deferred
The ticket also asks for a Dockerfile stage using `ADD --checksum=`. No Dockerfile exists yet; the API image is OP-43. `models/checksums.txt` names that consumer, marked `(planned)`, so OP-43 references the same file rather than pasting a hash of its own.

`model-validation.yml` is referenced the same way and arrives in OP-21, whose commit promotes it out of "planned".

## Tests
`test_model_assets.py` — 8 tests, of which 7 need no model: pin format, all three variants present, Makefile target and Python default agreeing on the path, versioned URL, absence of `shasum -c`, `MODEL_PATH` override, weights gitignored. The hash check itself is marked `model`.

Failure paths exercised manually: corrupted file, unknown variant, 404, re-fetch over a corrupted copy.
