### PR TITLE
OP-18 follow-up: correct the real-model tests against measured behaviour

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,11 @@ htmlcov/
 *.egg-info/
 build/
 dist/
+
+# --- Model weights (OP-20) ---
+# Never committed. 9 MB is under GitHub's limit, but weights in git is how the legacy project
+# ended up with a 209 MB blob it could not push and a Dropbox link instead. `make fetch-model`
+# reproduces them from a pinned URL and verifies a pinned SHA256; models/checksums.txt is the
+# thing under version control.
+models/*.task
+models/*.task.download

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,6 +82,23 @@ may be excluded; a difficult branch may not.
 `-m "not model"` deselects tests needing real model weights. CI never downloads them; they run on
 demand in `model-validation.yml`.
 
+To run them locally you need the weights and the inference stack:
+
+```bash
+make fetch-model                       # downloads and verifies a pinned SHA256
+uv pip install "mediapipe==0.10.18"    # the optional extra; ~857 MB of site-packages
+uv run pytest -m model
+```
+
+`make fetch-model` writes to `models/`, which is gitignored — the checksum is what is version
+controlled, not the weights. `MODEL_VARIANT=lite|full|heavy` switches variants at fetch time and
+`MODEL_PATH` overrides the location at run time; both are documented in
+[`models/checksums.txt`](models/checksums.txt).
+
+Most of the pose-backend suite deliberately does *not* need any of this. The adapter's landmark
+mapping is tested against a stub, and `POSE_BACKEND=fake` runs the whole application with no model
+at all — which is why the pull-request workflow finishes in minutes without a download.
+
 ## Conventions worth knowing
 
 **Pinned versions are usually load-bearing.** `mediapipe==0.10.18` is the last release publishing

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,89 @@
+# OpenPosture — developer entry points.
+#
+# Deliberately thin. `uv run <tool>` is already short, discoverable and identical to what CI runs,
+# so wrapping every check in a target would only add a second vocabulary to keep in sync. What
+# belongs here is the work that is genuinely awkward to type correctly by hand — which, so far, is
+# exactly one thing: fetching model weights and refusing to accept the wrong bytes.
+
+MODEL_VARIANT ?= full
+MODEL_DIR     ?= models
+MODEL_FILE    := pose_landmarker_$(MODEL_VARIANT).task
+MODEL_TARGET  := $(MODEL_DIR)/$(MODEL_FILE)
+CHECKSUMS     := $(MODEL_DIR)/checksums.txt
+
+# Pin the versioned path, never `latest`. They are different files — see the note in
+# models/checksums.txt, where the four differing bytes are recorded.
+MODEL_BASE_URL ?= https://storage.googleapis.com/mediapipe-models/pose_landmarker
+MODEL_URL      := $(MODEL_BASE_URL)/pose_landmarker_$(MODEL_VARIANT)/float16/1/$(MODEL_FILE)
+
+# One place that knows how to read the checksum file, so `fetch-model` and `verify-model` cannot
+# drift apart. `$$` escapes for make; this runs in /bin/sh.
+define expected_sha
+$$(grep -E "^[0-9a-f]{64}  $(MODEL_FILE)$$" $(CHECKSUMS) | cut -d' ' -f1)
+endef
+
+.PHONY: help fetch-model verify-model clean-model
+
+help:
+	@echo "fetch-model    download and verify the pose model (MODEL_VARIANT=lite|full|heavy)"
+	@echo "verify-model   re-verify the model already on disk"
+	@echo "clean-model    delete downloaded weights"
+	@echo ""
+	@echo "Everything else runs through uv, the same way CI invokes it:"
+	@echo "  uv run ruff check . && uv run ruff format --check ."
+	@echo "  uv run mypy packages apps"
+	@echo "  uv run pytest -m 'not model'"
+
+## Download the model, verify it, and only then put it where the code looks for it.
+##
+## Downloads to a temporary file first. A checksum failure that has already overwritten the good
+## copy at the target path is a checksum failure that broke your working tree — and the next run
+## would then "succeed" against whatever was left there.
+fetch-model:
+	@expected="$(expected_sha)"; \
+	if [ -z "$$expected" ]; then \
+		echo "ERROR: no pinned SHA256 for $(MODEL_FILE) in $(CHECKSUMS)." >&2; \
+		echo "       Variants available:" >&2; \
+		grep -E "^[0-9a-f]{64}  " $(CHECKSUMS) | sed 's/^.*  /         /' >&2; \
+		exit 1; \
+	fi; \
+	if [ -f "$(MODEL_TARGET)" ] && [ "$$(shasum -a 256 "$(MODEL_TARGET)" | cut -d' ' -f1)" = "$$expected" ]; then \
+		echo "$(MODEL_TARGET) already present and verified."; \
+		exit 0; \
+	fi; \
+	mkdir -p "$(MODEL_DIR)"; \
+	tmp="$(MODEL_TARGET).download"; \
+	echo "Fetching $(MODEL_URL)"; \
+	curl --fail --location --show-error --silent --output "$$tmp" "$(MODEL_URL)" || { \
+		rm -f "$$tmp"; echo "ERROR: download failed." >&2; exit 1; \
+	}; \
+	actual="$$(shasum -a 256 "$$tmp" | cut -d' ' -f1)"; \
+	if [ "$$actual" != "$$expected" ]; then \
+		rm -f "$$tmp"; \
+		echo "ERROR: checksum mismatch for $(MODEL_FILE)." >&2; \
+		echo "       expected $$expected" >&2; \
+		echo "       actual   $$actual" >&2; \
+		echo "       The download was discarded. Do not use an unverified model." >&2; \
+		exit 1; \
+	fi; \
+	mv "$$tmp" "$(MODEL_TARGET)"; \
+	echo "OK  $(MODEL_TARGET)  $$actual"
+
+## Verify whatever is on disk. This is what model-validation.yml runs before anything else, so a
+## corrupted or swapped model fails the workflow instead of quietly changing its results.
+verify-model:
+	@expected="$(expected_sha)"; \
+	if [ ! -f "$(MODEL_TARGET)" ]; then \
+		echo "ERROR: $(MODEL_TARGET) is missing. Run \`make fetch-model\`." >&2; exit 1; \
+	fi; \
+	actual="$$(shasum -a 256 "$(MODEL_TARGET)" | cut -d' ' -f1)"; \
+	if [ "$$actual" != "$$expected" ]; then \
+		echo "ERROR: $(MODEL_TARGET) does not match its pin." >&2; \
+		echo "       expected $$expected" >&2; \
+		echo "       actual   $$actual" >&2; \
+		exit 1; \
+	fi; \
+	echo "OK  $(MODEL_TARGET)  $$actual"
+
+clean-model:
+	rm -f $(MODEL_DIR)/*.task $(MODEL_DIR)/*.task.download

--- a/models/checksums.txt
+++ b/models/checksums.txt
@@ -1,0 +1,53 @@
+# SHA256 checksums for the MediaPipe Pose Landmarker model variants.
+#
+# THIS FILE IS THE SINGLE SOURCE OF TRUTH for model integrity. It is consumed by:
+#
+#   * `make fetch-model`     — verifies a download before moving it into place
+#   * `make verify-model`    — verifies whatever is already on disk
+#   * the API image build    — `ADD --checksum=sha256:<the full hash below>` (Epic D, OP-43)
+#   * `model-validation.yml` — verifies the hash before running anything (OP-21)
+#
+# Format is exactly what `shasum -a 256` emits: `<hash>  <filename>`, one per line, `#` comments
+# ignored. Familiar and trivially greppable.
+#
+# The Makefile deliberately does NOT use `shasum -c` to check it. `shasum -c` treats a line it
+# cannot parse as a warning and still exits 0 — verified on macOS — so a typo'd hash or a file
+# that is simply absent passes the "check" silently. A gate that can pass without verifying
+# anything is worse than no gate, because it is trusted. The Makefile greps the expected hash for
+# one named file and compares it explicitly instead.
+#
+# Replaces the legacy arrangement, where a 209 MB `model.h5` exceeded GitHub's file limit and was
+# distributed by a bare Dropbox link in a readme — no checksum, no licence, no stated origin. A
+# dead link made the entire project unrunnable, and nobody could have told a corrupted copy from
+# a good one. See docs/FINDINGS.md and docs/adr/0002-mediapipe-pose.md.
+#
+# --------------------------------------------------------------------------------------------
+# PIN THE VERSIONED PATH, NOT `latest`
+# --------------------------------------------------------------------------------------------
+# Google publishes each variant under both `/float16/1/` and `/float16/latest/`. These are NOT
+# the same file. Verified 2026-07-26 by downloading both twice: each URL is stable across fetches,
+# but for `pose_landmarker_full` the two differ in exactly four bytes (offsets 12, 2959110,
+# 9398046, 9398112 — container metadata, not weights) and therefore have different hashes:
+#
+#     /float16/1/       5134a3aa...
+#     /float16/latest/  4eaa5eb7...
+#
+# Identical file size, different content. A pin against `latest` would look correct for as long
+# as nobody re-published, then fail a checksum for reasons that would take an afternoon to
+# understand. The Makefile fetches `/1/`.
+#
+# --------------------------------------------------------------------------------------------
+# VARIANTS — set MODEL_VARIANT in the Makefile to switch, or MODEL_PATH at runtime
+# --------------------------------------------------------------------------------------------
+# lite    5.5 MB   fastest, lowest accuracy. Viable for browser-side live mode (Epic G).
+# full    9.0 MB   the default. The accuracy/latency point this project is calibrated against.
+# heavy   29 MB    most accurate, ~3x the latency of full. Worth trying if evaluation (Epic H)
+#                  shows the full model is the limiting factor rather than the rules.
+#
+# Nothing in the code depends on which one is loaded — all three emit the same 33 landmarks with
+# world coordinates, which is exactly what the PoseBackend Protocol is for. Swapping is a
+# MODEL_PATH change, not a rebuild.
+
+59929e1d1ee95287735ddd833b19cf4ac46d29bc7afddbbf6753c459690d574a  pose_landmarker_lite.task
+5134a3aad27a58b93da0088d431f366da362b44e3ccfbe3462b3827a839011b1  pose_landmarker_full.task
+64437af838a65d18e5ba7a0d39b465540069bc8aae8308de3e318aad31fcbc7b  pose_landmarker_heavy.task

--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -23,10 +23,13 @@ from pose_backends.errors import (
     ModelNotFoundError,
     PoseBackendError,
 )
+from pose_backends.fake import FakePoseBackend, PosePreset
 from pose_backends.mediapipe_backend import MediaPipeBackend
+from pose_backends.registry import create_backend, default_model_path
 
 __all__ = [
     "BackendUnavailableError",
+    "FakePoseBackend",
     "ImageBGR",
     "InvalidImageError",
     "MediaPipeBackend",
@@ -34,7 +37,10 @@ __all__ = [
     "ModelNotFoundError",
     "PoseBackend",
     "PoseBackendError",
+    "PosePreset",
     "__version__",
+    "create_backend",
+    "default_model_path",
 ]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -15,6 +15,8 @@ that inversion is what keeps the core installable and testable with no inference
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from pose_backends.base import ImageBGR, PoseBackend
+
+__all__ = ["ImageBGR", "PoseBackend", "__version__"]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/__init__.py
+++ b/packages/pose-backends/src/pose_backends/__init__.py
@@ -16,7 +16,25 @@ that inversion is what keeps the core installable and testable with no inference
 from __future__ import annotations
 
 from pose_backends.base import ImageBGR, PoseBackend
+from pose_backends.errors import (
+    BackendUnavailableError,
+    InvalidImageError,
+    ModelLoadError,
+    ModelNotFoundError,
+    PoseBackendError,
+)
+from pose_backends.mediapipe_backend import MediaPipeBackend
 
-__all__ = ["ImageBGR", "PoseBackend", "__version__"]
+__all__ = [
+    "BackendUnavailableError",
+    "ImageBGR",
+    "InvalidImageError",
+    "MediaPipeBackend",
+    "ModelLoadError",
+    "ModelNotFoundError",
+    "PoseBackend",
+    "PoseBackendError",
+    "__version__",
+]
 
 __version__ = "0.1.0"

--- a/packages/pose-backends/src/pose_backends/base.py
+++ b/packages/pose-backends/src/pose_backends/base.py
@@ -1,0 +1,74 @@
+"""The seam between inference and everything else.
+
+One Protocol, three members. That narrowness is the asset: it is what lets a real model, a
+deterministic fake, and — if the platform bet in ADR-0002 ever goes bad — an entirely different
+inference runtime be swapped for one another without a single line changing in ``posture_core``
+or ``apps/api``.
+
+A ``Protocol`` rather than an ABC because conformance is then structural. Nothing has to import
+this class or inherit from it to satisfy it, so a test double can be a five-line class defined in
+the test that needs it, and mypy still checks it against the real contract. Inheriting from an
+ABC would make the fake depend on the package it exists to avoid.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, TypeAlias, runtime_checkable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from posture_core import PoseFrame
+
+__all__ = ["ImageBGR", "PoseBackend"]
+
+ImageBGR: TypeAlias = NDArray[np.uint8]
+"""An ``(H, W, 3)`` uint8 array in **BGR** channel order.
+
+BGR, not RGB, because that is what ``cv2.imread`` returns and OpenCV is what decodes uploads on
+the API path. Naming the convention in the type is cheap insurance: a silent channel swap does
+not crash, it just quietly degrades detection accuracy in a way no test would obviously catch.
+Adapters that need RGB convert internally — that is adapter business, not the caller's.
+"""
+
+
+@runtime_checkable
+class PoseBackend(Protocol):
+    """What every pose estimator must offer, and nothing more."""
+
+    @property
+    def name(self) -> str:
+        """Short stable identifier, stamped onto every :class:`~posture_core.PoseFrame`.
+
+        Declared as a read-only property rather than a bare ``name: str`` attribute so that both
+        forms conform: an implementation may expose a plain class attribute or a computed
+        property. A mutable attribute in the Protocol would reject the property form.
+        """
+        ...
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        """Find one person and return their skeleton, or ``None`` if there is nobody there.
+
+        **``None`` is the no-pose answer, not an exception.** An image with no person in it is an
+        ordinary outcome of a posture app — the user photographed their desk — and raising for it
+        would push every caller into a ``try/except`` around the happy path. Exceptions are
+        reserved for the backend being *broken*: a missing model file, an unreadable frame.
+
+        That distinction is what stops ``except Exception`` from reappearing. The legacy engine
+        swallowed failures and returned ``None``, and the caller rendered ``None`` as "Straight
+        back position" (FINDINGS §2.5) — so "no person" and "inference exploded" were reported to
+        the user identically, and both were reported as good posture.
+        """
+        ...
+
+    def warmup(self) -> None:
+        """Run one throwaway inference so the first real request does not pay for initialisation.
+
+        Called once at API startup (OP-40), where the cost is invisible. ``RUNDOWN.md``'s open
+        items flagged exactly this on the legacy engine — "a cold load is slow, per-request
+        loading would be unusable" — and never resolved it, because the model lived in a module
+        global built under a ``__main__`` guard and there was no startup hook to move it to.
+
+        Must be idempotent and must never raise on a healthy backend.
+        """
+        ...

--- a/packages/pose-backends/src/pose_backends/errors.py
+++ b/packages/pose-backends/src/pose_backends/errors.py
@@ -1,0 +1,67 @@
+"""What "the backend is broken" looks like, as opposed to "there is nobody in the photo".
+
+That distinction is the whole reason this module exists. ``detect()`` returns ``None`` for the
+ordinary case of an image with no person in it; it raises one of these when the backend itself
+cannot do its job. Collapsing the two is precisely the legacy engine's most damaging behaviour —
+a swallowed exception and an empty desk both became ``None``, and the caller rendered ``None`` as
+"Straight back position" (FINDINGS §2.5).
+
+Every exception here carries a message a human can act on. "Model file not found at
+/app/models/x.task — run `make fetch-model`" is a bug report someone can fix; an
+``AttributeError`` from four frames inside a vendored C++ binding is not.
+"""
+
+from __future__ import annotations
+
+__all__ = [
+    "BackendUnavailableError",
+    "InvalidImageError",
+    "ModelLoadError",
+    "ModelNotFoundError",
+    "PoseBackendError",
+]
+
+
+class PoseBackendError(RuntimeError):
+    """Base for every backend failure.
+
+    One base class so callers that genuinely want to treat all backend breakage alike — the API's
+    problem+json handler (OP-39) — can catch this and nothing else. That is the alternative to
+    ``except Exception``, which the project bans outright: a narrow catch of a type we defined
+    still lets a genuine programming error propagate.
+    """
+
+
+class BackendUnavailableError(PoseBackendError):
+    """The inference library is not installed.
+
+    Its own error rather than letting ``ImportError`` escape, because the fix is specific and
+    non-obvious: ``mediapipe`` is an *optional* extra (ADR-0002), so that ``pose-backends`` can be
+    installed — and ``FakePoseBackend`` used — without a 300 MB inference stack. Someone hitting
+    this has almost certainly installed the base package and expected the real backend.
+    """
+
+
+class ModelNotFoundError(PoseBackendError):
+    """No model file at the configured path.
+
+    Distinct from :class:`ModelLoadError` because the remedies differ: this one means fetch the
+    weights, that one means the weights you fetched are wrong.
+    """
+
+
+class ModelLoadError(PoseBackendError):
+    """A file is there, but the inference runtime would not accept it.
+
+    Truncated download, wrong model variant, corrupted checkout. The checksum pin in OP-20 exists
+    to turn most of these into a loud failure at fetch time instead of a puzzling one at startup.
+    """
+
+
+class InvalidImageError(PoseBackendError):
+    """The array handed to ``detect()`` is not an image this backend can work with.
+
+    A programming error at the call site rather than a bad photo — an empty array, a greyscale
+    frame, a channel count that is not 3. Raising is right here: unlike "no person detected", there
+    is no sensible result to return and no user-facing story to tell.
+    """

--- a/packages/pose-backends/src/pose_backends/fake.py
+++ b/packages/pose-backends/src/pose_backends/fake.py
@@ -1,0 +1,199 @@
+"""The deterministic backend. Load-bearing infrastructure, not a throwaway test double.
+
+With ``POSE_BACKEND=fake`` the entire application runs with no model weights, no 300 MB inference
+stack and no secrets. That is what lets the container smoke test (OP-43) and the Playwright
+end-to-end suite (OP-47) run on every pull request in seconds. It is the single reason required
+CI stays fast and secret-free, which is why this file gets the same care as the real adapter.
+
+Every preset is built by :mod:`posture_core.synthetic` — the *same* builder the rules-engine tests
+use. That is deliberate and it is the point of the module living in ``posture_core``: if the fake
+had its own private figure construction, it would drift from the one the metrics are tested
+against, and the day it drifted every end-to-end assertion resting on a fake pose would quietly
+stop meaning anything.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from posture_core import PoseFrame
+from posture_core.synthetic import Facing, View, make_pose_frame
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from pose_backends.base import ImageBGR
+
+__all__ = ["FakePoseBackend", "PosePreset"]
+
+BACKEND_NAME: Final = "fake"
+
+
+class PosePreset(StrEnum):
+    """Named situations the rest of the system needs to be able to reproduce on demand."""
+
+    STRAIGHT = "straight"
+    HUNCHBACK = "hunchback"
+    RECLINED = "reclined"
+    KNEELING = "kneeling"
+    PARTIAL_OCCLUSION = "partial_occlusion"
+    FRONTAL_VIEW = "frontal_view"
+    NO_PERSON = "no_person"
+    """``detect()`` returns ``None``. The empty-desk path, exercisable without an empty desk."""
+
+
+# Joint angles per preset, in the convention `posture_core.synthetic` documents: trunk and neck
+# from straight up, limbs from straight down, positive forward.
+#
+# The seated poses share a thigh at 85° (near horizontal) and a shank at 5° (near vertical), which
+# is a chair. What distinguishes them is the trunk and neck.
+_SEATED: Final[Mapping[str, float]] = {"thigh_deg": 85.0, "shank_deg": 5.0}
+
+_PRESETS: Final[Mapping[PosePreset, dict[str, object]]] = {
+    # Upright and neutral: the reference every other preset is a departure from.
+    PosePreset.STRAIGHT: {
+        **_SEATED,
+        "trunk_deg": 3.0,
+        "neck_deg": 5.0,
+        "upper_arm_deg": 10.0,
+        "forearm_deg": 75.0,
+    },
+    # Slumped forward with the head thrust further forward still — the posture the whole
+    # application exists to detect, and the one the legacy engine reported as "Straight back"
+    # whenever its assessment failed (FINDINGS §2.5).
+    PosePreset.HUNCHBACK: {
+        **_SEATED,
+        "trunk_deg": 32.0,
+        "neck_deg": 30.0,
+        "upper_arm_deg": 15.0,
+        "forearm_deg": 80.0,
+    },
+    # Leaning back. Negative trunk angle, which is what makes this a useful test of a *signed*
+    # trunk inclination: an implementation taking an absolute value would report this as identical
+    # to a forward slump of the same magnitude.
+    PosePreset.RECLINED: {
+        **_SEATED,
+        "trunk_deg": -25.0,
+        "neck_deg": 10.0,
+        "upper_arm_deg": -5.0,
+        "forearm_deg": 60.0,
+    },
+    # Kneeling: thigh near vertical, shank folded back underneath. Knee flexion is emergent
+    # (180 - |thigh - shank|), so this figure is physically consistent by construction.
+    PosePreset.KNEELING: {
+        "thigh_deg": 15.0,
+        "shank_deg": 165.0,
+        "trunk_deg": 5.0,
+        "neck_deg": 6.0,
+        "upper_arm_deg": 8.0,
+        "forearm_deg": 20.0,
+    },
+    # Same seating as STRAIGHT, but the lower body is gone and one arm is behind the torso. The
+    # two are different kinds of missing and the frame says so: legs are *omitted* (never
+    # reported), the far arm is present with low visibility and high presence (occluded).
+    #
+    # This preset is how the "couldn't assess your knees, try a wider shot" path gets tested.
+    PosePreset.PARTIAL_OCCLUSION: {
+        **_SEATED,
+        "trunk_deg": 10.0,
+        "neck_deg": 12.0,
+        "upper_arm_deg": 12.0,
+        "forearm_deg": 78.0,
+    },
+    # Facing the camera. The angles are a pronounced slump, but a frontal projection hides it —
+    # which is the point. `view_confidence` (OP-31) must refuse to assess this rather than
+    # reporting the near-zero apparent lean as good posture. The original app asked users for a
+    # side-on photo and never checked that it got one.
+    PosePreset.FRONTAL_VIEW: {
+        **_SEATED,
+        "trunk_deg": 30.0,
+        "neck_deg": 25.0,
+        "upper_arm_deg": 10.0,
+        "forearm_deg": 75.0,
+        "view": View.FRONTAL,
+    },
+}
+
+
+def _build(preset: PosePreset, image_width: int, image_height: int) -> PoseFrame | None:
+    """One preset -> one frame. Pure, so repeated calls are indistinguishable."""
+    if preset is PosePreset.NO_PERSON:
+        return None
+
+    kwargs: dict[str, object] = {
+        "facing": Facing.RIGHT,
+        **_PRESETS[preset],
+        "image_width": image_width,
+        "image_height": image_height,
+        "backend": BACKEND_NAME,
+    }
+
+    if preset is PosePreset.PARTIAL_OCCLUSION:
+        from posture_core import KeypointName
+
+        kwargs["omit"] = (
+            KeypointName.LEFT_KNEE,
+            KeypointName.RIGHT_KNEE,
+            KeypointName.LEFT_ANKLE,
+            KeypointName.RIGHT_ANKLE,
+            KeypointName.LEFT_HEEL,
+            KeypointName.RIGHT_HEEL,
+            KeypointName.LEFT_FOOT_INDEX,
+            KeypointName.RIGHT_FOOT_INDEX,
+        )
+        # Occluded, not out of frame: visibility collapses, presence does not. Expressing the
+        # difference is the whole reason the model was chosen (ADR-0002).
+        kwargs["confidence"] = {
+            KeypointName.LEFT_ELBOW: (0.18, 0.92),
+            KeypointName.LEFT_WRIST: (0.12, 0.90),
+        }
+
+    return make_pose_frame(**kwargs)  # type: ignore[arg-type]
+
+
+class FakePoseBackend:
+    """A ``PoseBackend`` that returns a canned skeleton and never looks at the image.
+
+    Sub-millisecond because there is nothing to decode and nothing to infer. Byte-identical across
+    runs because the figure is analytic and ``inference_ms`` is a constant ``0.0`` rather than a
+    measurement — a real timing would make otherwise-identical frames differ between runs and
+    break every snapshot assertion downstream.
+    """
+
+    name: Final = BACKEND_NAME
+
+    def __init__(
+        self,
+        preset: PosePreset | str = PosePreset.STRAIGHT,
+        *,
+        image_width: int = 640,
+        image_height: int = 480,
+    ) -> None:
+        self._preset = PosePreset(preset)
+        self._image_width = image_width
+        self._image_height = image_height
+        # Built once, then shared. Safe precisely because PoseFrame is genuinely immutable — its
+        # landmark mapping is a MappingProxyType, not a dict a caller could edit and thereby
+        # corrupt every later detection.
+        self._frame = _build(self._preset, image_width, image_height)
+
+    @property
+    def preset(self) -> PosePreset:
+        return self._preset
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        """Return the preset's frame, ignoring the image entirely.
+
+        Ignoring it is the contract, not a shortcut: callers select the *scenario* by constructing
+        the backend, and a fake that inspected pixels would make an end-to-end test's result
+        depend on whatever placeholder JPEG someone happened to upload.
+        """
+        del image_bgr
+        return self._frame
+
+    def warmup(self) -> None:
+        """Nothing to warm. Present because the Protocol requires it and OP-40 calls it blind."""
+
+    def close(self) -> None:
+        """Symmetry with the real backend, so lifespan shutdown needs no special case."""

--- a/packages/pose-backends/src/pose_backends/mediapipe_backend.py
+++ b/packages/pose-backends/src/pose_backends/mediapipe_backend.py
@@ -207,10 +207,19 @@ class MediaPipeBackend:
         )
 
     def warmup(self) -> None:
-        """Pay initialisation once, at startup, on a synthetic frame nobody is waiting for.
+        """Run one throwaway inference at startup, on a frame nobody is waiting for.
 
-        MediaPipe builds its inference graph lazily on first use, so without this the first real
-        request absorbs it. Called from the API lifespan hook where the latency is invisible.
+        **Measured caveat, 2026-07-26** (Apple M5, ``pose_landmarker_full``, 1280x720): with
+        ``mediapipe==0.10.18`` in ``RunningMode.IMAGE`` this saves nothing measurable. The graph is
+        built eagerly inside ``create_from_options``, so construction costs ~31 ms and every
+        inference afterwards costs ~23 ms — the first one included. The plan assumed a lazily-built
+        graph. It is not one.
+
+        Kept anyway, and not as dead code. The guarantee the API needs is "no request ever pays an
+        initialisation cost", and that should not silently rest on an implementation detail of one
+        pinned library version. One synthetic frame at startup is a trivial price for a contract
+        that still holds if a future release defers work — and the ONNX escape hatch in ADR-0002
+        would genuinely need it.
         """
         self.detect(np.zeros((256, 256, 3), dtype=np.uint8))
 

--- a/packages/pose-backends/src/pose_backends/mediapipe_backend.py
+++ b/packages/pose-backends/src/pose_backends/mediapipe_backend.py
@@ -1,0 +1,394 @@
+"""The real inference adapter: MediaPipe Pose Landmarker behind the ``PoseBackend`` Protocol.
+
+This module is where the one heavy, platform-fragile dependency in the project is quarantined.
+Everything MediaPipe-specific — the 33 integer landmark indices, the Tasks API, the RGB channel
+order, the vendored C++ binding — stops here. Rules code sees canonical named keypoints.
+
+## The two-layer split, and why it is not over-engineering
+
+``MediaPipeBackend`` does the *translation*: timing, colour conversion, index-to-name mapping,
+``NECK`` derivation, ``PoseFrame`` construction. ``_TasksDetector`` does the *inference*, and is
+the only thing in the file that imports ``mediapipe``.
+
+The seam between them is :class:`RawPoseDetector`. It buys the thing the ticket asks for: the
+mapping tests run against a stub detector, with **no model file and no mediapipe installed**, in
+required CI. A transposed landmark index is exactly the class of bug that made the legacy engine
+wrong (FINDINGS §2.1) and it is invisible without a test — so that test must be cheap enough to
+run on every pull request, which means it cannot need 300 MB of wheels and a model download.
+
+Real-model tests exist too, marked ``pytest.mark.model``, and run on demand (OP-21).
+
+## Legacy defects this design forecloses
+
+* **No module-global model.** The legacy engine built its model at import time from a
+  cwd-relative config, so neither ``process()`` function was importable and the whole thing only
+  ran from inside ``API/``. Here the model is an instance attribute loaded in ``__init__``, and
+  the path is a constructor argument.
+* **No laterality flag.** MediaPipe returns named LEFT and RIGHT landmarks. The hand-rolled ``f``
+  flag that made spine classification backwards for one facing direction has nothing to key off.
+* **No cwd dependency.** ``model_path`` is resolved to an absolute path on construction.
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import TYPE_CHECKING, Final, Protocol, TypeAlias
+
+import numpy as np
+from numpy.typing import NDArray
+
+from pose_backends.errors import (
+    BackendUnavailableError,
+    InvalidImageError,
+    ModelLoadError,
+    ModelNotFoundError,
+)
+from posture_core import KeypointName, Landmark, PoseFrame
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from pose_backends.base import ImageBGR
+
+__all__ = [
+    "MEDIAPIPE_INDEX_TO_KEYPOINT",
+    "MediaPipeBackend",
+    "RawDetection",
+    "RawLandmark",
+    "RawPoseDetector",
+]
+
+ImageRGB: TypeAlias = NDArray[np.uint8]
+
+BACKEND_NAME: Final = "mediapipe"
+
+# The complete MediaPipe Pose Landmarker schema, index -> canonical name. Transcribed from the
+# landmark table in docs/adr/0002-mediapipe-pose.md, which also records the legacy COCO-18
+# correspondence. NECK (index-less, derived below) is deliberately absent: no backend reports it.
+#
+# Written out in full rather than generated from the enum's declaration order. Ordering is not a
+# contract of an enum, and tying a wire format to it would make an innocuous reordering of the
+# members silently remap every landmark.
+MEDIAPIPE_INDEX_TO_KEYPOINT: Final[Mapping[int, KeypointName]] = {
+    0: KeypointName.NOSE,
+    1: KeypointName.LEFT_EYE_INNER,
+    2: KeypointName.LEFT_EYE,
+    3: KeypointName.LEFT_EYE_OUTER,
+    4: KeypointName.RIGHT_EYE_INNER,
+    5: KeypointName.RIGHT_EYE,
+    6: KeypointName.RIGHT_EYE_OUTER,
+    7: KeypointName.LEFT_EAR,
+    8: KeypointName.RIGHT_EAR,
+    9: KeypointName.MOUTH_LEFT,
+    10: KeypointName.MOUTH_RIGHT,
+    11: KeypointName.LEFT_SHOULDER,
+    12: KeypointName.RIGHT_SHOULDER,
+    13: KeypointName.LEFT_ELBOW,
+    14: KeypointName.RIGHT_ELBOW,
+    15: KeypointName.LEFT_WRIST,
+    16: KeypointName.RIGHT_WRIST,
+    17: KeypointName.LEFT_PINKY,
+    18: KeypointName.RIGHT_PINKY,
+    19: KeypointName.LEFT_INDEX,
+    20: KeypointName.RIGHT_INDEX,
+    21: KeypointName.LEFT_THUMB,
+    22: KeypointName.RIGHT_THUMB,
+    23: KeypointName.LEFT_HIP,
+    24: KeypointName.RIGHT_HIP,
+    25: KeypointName.LEFT_KNEE,
+    26: KeypointName.RIGHT_KNEE,
+    27: KeypointName.LEFT_ANKLE,
+    28: KeypointName.RIGHT_ANKLE,
+    29: KeypointName.LEFT_HEEL,
+    30: KeypointName.RIGHT_HEEL,
+    31: KeypointName.LEFT_FOOT_INDEX,
+    32: KeypointName.RIGHT_FOOT_INDEX,
+}
+
+
+@dataclass(frozen=True, slots=True)
+class RawLandmark:
+    """One point as the inference runtime reports it, before any canonical naming.
+
+    Deliberately a plain value object rather than MediaPipe's own type, so that the stub in the
+    tests can produce these without importing mediapipe. ``z`` is normalised depth in the image
+    result and metres in the world result; the adapter only uses the latter.
+    """
+
+    x: float
+    y: float
+    z: float
+    visibility: float
+    presence: float
+
+
+@dataclass(frozen=True, slots=True)
+class RawDetection:
+    """One detected person: the image-space landmarks, and the world-space ones if available."""
+
+    landmarks: Sequence[RawLandmark]
+    world_landmarks: Sequence[RawLandmark] | None = None
+
+
+class RawPoseDetector(Protocol):
+    """The narrow seam that keeps mediapipe out of the mapping tests."""
+
+    def detect(self, image_rgb: ImageRGB) -> RawDetection | None:
+        """Landmarks for the most prominent person, or ``None`` if there is nobody."""
+        ...
+
+    def close(self) -> None:
+        """Release the native inference graph. Must be idempotent."""
+        ...
+
+
+class MediaPipeBackend:
+    """Pose estimation via MediaPipe Pose Landmarker, pinned to ``mediapipe==0.10.18``.
+
+    The pin is load-bearing, not incidental: 0.10.18 is the last release publishing a PyPI
+    ``linux aarch64`` wheel, and bumping it kills the local Docker demo on Apple Silicon. See
+    ADR-0002 for the spike that established this.
+    """
+
+    name: Final = BACKEND_NAME
+
+    def __init__(
+        self,
+        model_path: Path | str,
+        *,
+        min_pose_detection_confidence: float = 0.5,
+        detector_factory: Callable[[Path, float], RawPoseDetector] | None = None,
+    ) -> None:
+        """Load the model **once**, here, and keep it for the life of the instance.
+
+        The API constructs exactly one of these in its ``lifespan`` hook (OP-40) and reuses it for
+        every request. Loading per request would be unusable — which is what ``RUNDOWN.md``'s open
+        items flagged about the legacy engine and never resolved.
+
+        ``detector_factory`` is the test seam. Left at ``None`` it builds the real MediaPipe Tasks
+        detector; the mapping tests pass a stub and never touch a model file.
+        """
+        self._model_path = Path(model_path).expanduser().resolve()
+        factory = detector_factory if detector_factory is not None else _create_tasks_detector
+        self._detector = factory(self._model_path, min_pose_detection_confidence)
+
+    @property
+    def model_path(self) -> Path:
+        """Absolute path to the loaded weights — reported by the CLI and the health endpoint."""
+        return self._model_path
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        _validate_image(image_bgr)
+        height, width = image_bgr.shape[:2]
+
+        # BGR -> RGB. cv2 decodes to BGR, MediaPipe expects RGB, and getting this wrong does not
+        # crash — it silently degrades detection in a way no assertion would obviously catch.
+        # `ascontiguousarray` because the reversed view has a negative stride and the native
+        # binding needs a contiguous buffer.
+        image_rgb: ImageRGB = np.ascontiguousarray(image_bgr[:, :, ::-1])
+
+        started = time.perf_counter()
+        raw = self._detector.detect(image_rgb)
+        inference_ms = (time.perf_counter() - started) * 1000.0
+
+        if raw is None or not raw.landmarks:
+            # An ordinary outcome — the user photographed their desk. Not an error.
+            return None
+
+        return PoseFrame(
+            landmarks=self._to_canonical(raw),
+            image_width=width,
+            image_height=height,
+            backend=self.name,
+            inference_ms=inference_ms,
+        )
+
+    def warmup(self) -> None:
+        """Pay initialisation once, at startup, on a synthetic frame nobody is waiting for.
+
+        MediaPipe builds its inference graph lazily on first use, so without this the first real
+        request absorbs it. Called from the API lifespan hook where the latency is invisible.
+        """
+        self.detect(np.zeros((256, 256, 3), dtype=np.uint8))
+
+    def close(self) -> None:
+        """Release the native graph. Idempotent; safe to call from a lifespan shutdown."""
+        self._detector.close()
+
+    # -- translation ---------------------------------------------------------------------------
+
+    def _to_canonical(self, raw: RawDetection) -> dict[KeypointName, Landmark]:
+        """MediaPipe's indexed arrays -> the canonical named skeleton."""
+        world = raw.world_landmarks
+        # A world array of a different length than the image array can only be a runtime change we
+        # have not accounted for. Pairing them by index anyway would attach one landmark's metres
+        # to another landmark's pixels — wrong answers, no error. Drop world instead.
+        if world is not None and len(world) != len(raw.landmarks):
+            world = None
+
+        landmarks: dict[KeypointName, Landmark] = {}
+        for index, raw_landmark in enumerate(raw.landmarks):
+            name = MEDIAPIPE_INDEX_TO_KEYPOINT.get(index)
+            if name is None:
+                # A future model variant reporting extra points. Ignoring them is correct: the
+                # canonical schema is the project's, not MediaPipe's.
+                continue
+            world_landmark = world[index] if world is not None else None
+            landmarks[name] = Landmark(
+                x=raw_landmark.x,
+                y=raw_landmark.y,
+                visibility=raw_landmark.visibility,
+                presence=raw_landmark.presence,
+                x_world=None if world_landmark is None else world_landmark.x,
+                y_world=None if world_landmark is None else world_landmark.y,
+                z_world=None if world_landmark is None else world_landmark.z,
+            )
+
+        neck = _derive_neck(landmarks)
+        if neck is not None:
+            landmarks[KeypointName.NECK] = neck
+        return landmarks
+
+
+def _derive_neck(landmarks: Mapping[KeypointName, Landmark]) -> Landmark | None:
+    """``NECK`` as the midpoint of the two shoulders — the one real schema change (ADR-0002).
+
+    Derived **here, in the adapter**, so every backend presents the same skeleton and no rule ever
+    has to know that MediaPipe lacks a neck landmark. Note this is not an innovation: legacy COCO
+    keypoint 1 was itself synthesised from the two shoulders. Making the derivation explicit is
+    what exposed FINDINGS §2.2, where ``evaluate_neck_posture`` compared the shoulder midpoint's
+    *y* against the shoulder midpoint's *y* — a point against itself, one possible answer.
+
+    Confidence is the **minimum** of the two shoulders, not the mean. A derived point cannot be
+    more trustworthy than the least trustworthy thing it was derived from, and averaging would let
+    one confidently-seen shoulder launder an unseen one into a plausible-looking neck.
+    """
+    left = landmarks.get(KeypointName.LEFT_SHOULDER)
+    right = landmarks.get(KeypointName.RIGHT_SHOULDER)
+    if left is None or right is None:
+        return None
+
+    has_world = left.has_world and right.has_world
+
+    def midpoint(a: float | None, b: float | None) -> float | None:
+        return None if a is None or b is None else (a + b) / 2.0
+
+    return Landmark(
+        x=(left.x + right.x) / 2.0,
+        y=(left.y + right.y) / 2.0,
+        visibility=min(left.visibility, right.visibility),
+        presence=min(left.presence, right.presence),
+        x_world=midpoint(left.x_world, right.x_world) if has_world else None,
+        y_world=midpoint(left.y_world, right.y_world) if has_world else None,
+        z_world=midpoint(left.z_world, right.z_world) if has_world else None,
+    )
+
+
+def _validate_image(image: ImageBGR) -> None:
+    """Reject arrays that are not images, loudly, at the call site that produced them."""
+    if image.ndim != 3 or image.shape[2] != 3:
+        raise InvalidImageError(
+            f"expected an (H, W, 3) BGR image, got an array of shape {image.shape}"
+        )
+    if image.shape[0] == 0 or image.shape[1] == 0:
+        raise InvalidImageError(f"image has a zero dimension: {image.shape}")
+
+
+# ---------------------------------------------------------------------------------------------
+# The only part of the file that knows MediaPipe exists.
+# ---------------------------------------------------------------------------------------------
+
+
+def _create_tasks_detector(
+    model_path: Path, min_pose_detection_confidence: float
+) -> RawPoseDetector:
+    """Build the real detector, turning each failure mode into an actionable error.
+
+    The import is function-local by necessity, not by style: ``mediapipe`` is an optional extra
+    (ADR-0002), and a module-scope import would make ``import pose_backends`` fail for everyone
+    running the fake backend — which is most of CI.
+    """
+    if not model_path.is_file():
+        raise ModelNotFoundError(
+            f"pose model not found at {model_path}. Run `make fetch-model`, or set MODEL_PATH "
+            "to an existing pose_landmarker .task file."
+        )
+
+    try:
+        from mediapipe.tasks import python as mp_python
+        from mediapipe.tasks.python import vision
+    except ImportError as exc:  # pragma: no cover - exercised only without the extra installed
+        raise BackendUnavailableError(
+            "mediapipe is not installed. It is an optional extra so that the fake backend can "
+            "run without a 300 MB inference stack: install `pose-backends[mediapipe]`, or set "
+            "POSE_BACKEND=fake."
+        ) from exc
+
+    try:
+        options = vision.PoseLandmarkerOptions(
+            base_options=mp_python.BaseOptions(model_asset_path=str(model_path)),
+            running_mode=vision.RunningMode.IMAGE,
+            num_poses=1,
+            min_pose_detection_confidence=min_pose_detection_confidence,
+            # Segmentation masks cost time and memory and nothing in this project draws one.
+            output_segmentation_masks=False,
+        )
+        landmarker = vision.PoseLandmarker.create_from_options(options)
+    except (RuntimeError, ValueError, OSError) as exc:
+        # The file exists but the runtime rejected it: truncated download, wrong variant, or a
+        # corrupted checkout. The checksum pin in OP-20 is what turns most of these into a loud
+        # failure at fetch time rather than a puzzling one at startup.
+        raise ModelLoadError(
+            f"mediapipe could not load the model at {model_path}: {exc}. Verify its SHA256 with "
+            "`make fetch-model`."
+        ) from exc
+
+    return _TasksDetector(landmarker)
+
+
+class _TasksDetector:
+    """Thin wrapper over a MediaPipe ``PoseLandmarker``, normalising its result shape."""
+
+    def __init__(self, landmarker: object) -> None:
+        self._landmarker = landmarker
+
+    def detect(self, image_rgb: ImageRGB) -> RawDetection | None:
+        import mediapipe as mp
+
+        mp_image = mp.Image(image_format=mp.ImageFormat.SRGB, data=image_rgb)
+        result = self._landmarker.detect(mp_image)  # type: ignore[attr-defined]
+
+        # MediaPipe returns lists-of-lists, one inner list per detected person. `num_poses=1`
+        # means at most one, and an empty outer list means nobody was found.
+        if not result.pose_landmarks:
+            return None
+
+        world = result.pose_world_landmarks[0] if result.pose_world_landmarks else None
+        return RawDetection(
+            landmarks=[_to_raw(lm) for lm in result.pose_landmarks[0]],
+            world_landmarks=None if world is None else [_to_raw(lm) for lm in world],
+        )
+
+    def close(self) -> None:
+        close = getattr(self._landmarker, "close", None)
+        if callable(close):
+            close()
+
+
+def _to_raw(landmark: object) -> RawLandmark:
+    """MediaPipe landmark -> :class:`RawLandmark`.
+
+    ``visibility`` and ``presence`` are read defensively because MediaPipe leaves them unset on
+    *world* landmarks. Defaulting to 0.0 there is right: the canonical landmark takes its
+    confidence from the image-space point, which does carry both.
+    """
+    return RawLandmark(
+        x=float(landmark.x),  # type: ignore[attr-defined]
+        y=float(landmark.y),  # type: ignore[attr-defined]
+        z=float(landmark.z),  # type: ignore[attr-defined]
+        visibility=float(getattr(landmark, "visibility", 0.0) or 0.0),
+        presence=float(getattr(landmark, "presence", 0.0) or 0.0),
+    )

--- a/packages/pose-backends/src/pose_backends/registry.py
+++ b/packages/pose-backends/src/pose_backends/registry.py
@@ -1,0 +1,71 @@
+"""Choosing a backend at runtime, from configuration rather than from an import.
+
+``POSE_BACKEND=fake`` has to be a *deployment* switch, not a test-only injection point. The
+container smoke test starts the real API image and the Playwright suite drives the real frontend;
+neither can reach into a Python fixture to swap an object. They set an environment variable, and
+this module is what reads it.
+
+The API layer will wrap this in pydantic-settings (OP-39) so the value is validated alongside
+everything else it configures. This function stays the single place that knows how a name maps to
+a class, so adding a backend means adding one entry here.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Final
+
+from pose_backends.base import PoseBackend
+from pose_backends.errors import PoseBackendError
+from pose_backends.fake import BACKEND_NAME as FAKE_NAME
+from pose_backends.fake import FakePoseBackend, PosePreset
+from pose_backends.mediapipe_backend import BACKEND_NAME as MEDIAPIPE_NAME
+from pose_backends.mediapipe_backend import MediaPipeBackend
+
+__all__ = ["DEFAULT_MODEL_PATH", "create_backend", "default_model_path"]
+
+DEFAULT_MODEL_PATH: Final = Path("models/pose_landmarker_full.task")
+"""Where ``make fetch-model`` puts the weights, relative to the repository or image root."""
+
+
+def default_model_path() -> Path:
+    """The model location, with ``MODEL_PATH`` taking precedence.
+
+    The override exists so a heavier or lighter model variant — lite at 5.5 MB, full at 9 MB,
+    heavy at 29 MB — can be swapped in without rebuilding the image (OP-20). It also replaces the
+    legacy arrangement's worst property: weights fetched from a bare Dropbox link recorded in a
+    readme, so a dead link made the whole project unrunnable.
+    """
+    override = os.environ.get("MODEL_PATH")
+    return Path(override) if override else DEFAULT_MODEL_PATH
+
+
+def create_backend(
+    name: str | None = None,
+    *,
+    model_path: Path | str | None = None,
+    preset: PosePreset | str | None = None,
+) -> PoseBackend:
+    """Build the configured backend.
+
+    :param name: ``"mediapipe"`` or ``"fake"``. Defaults to ``POSE_BACKEND``, then ``"mediapipe"``
+        — the real backend is the default so that a missing variable in production yields real
+        inference rather than a fabricated skeleton nobody notices is fabricated.
+    :param preset: fake-backend scenario; defaults to ``POSE_BACKEND_PRESET``, then ``straight``.
+    :raises PoseBackendError: for an unknown name, listing what is available. An unrecognised
+        value must fail loudly at startup: silently falling back to the fake would mean shipping
+        an application that invents its results.
+    """
+    resolved = (name or os.environ.get("POSE_BACKEND") or MEDIAPIPE_NAME).strip().lower()
+
+    if resolved == FAKE_NAME:
+        chosen = preset if preset is not None else os.environ.get("POSE_BACKEND_PRESET")
+        return FakePoseBackend(chosen if chosen is not None else PosePreset.STRAIGHT)
+
+    if resolved == MEDIAPIPE_NAME:
+        return MediaPipeBackend(model_path if model_path is not None else default_model_path())
+
+    raise PoseBackendError(
+        f"unknown POSE_BACKEND {resolved!r}. Available: {MEDIAPIPE_NAME}, {FAKE_NAME}."
+    )

--- a/packages/pose-backends/src/pose_backends/registry.py
+++ b/packages/pose-backends/src/pose_backends/registry.py
@@ -26,16 +26,28 @@ from pose_backends.mediapipe_backend import MediaPipeBackend
 __all__ = ["DEFAULT_MODEL_PATH", "create_backend", "default_model_path"]
 
 DEFAULT_MODEL_PATH: Final = Path("models/pose_landmarker_full.task")
-"""Where ``make fetch-model`` puts the weights, relative to the repository or image root."""
+"""Where ``make fetch-model`` puts the weights.
+
+**Relative, and therefore resolved against the working directory** — which is the repository root
+locally and the image's ``WORKDIR`` in a container. That is a deliberate default rather than a
+repeat of the legacy engine's cwd dependence: there, relative paths to weights and config were
+buried inside the inference code, so the thing only ran from within ``API/`` and there was no way
+to say otherwise. Here it is one documented default with :envvar:`MODEL_PATH` as the override, and
+``MediaPipeBackend`` resolves whatever it is given to an absolute path before loading.
+"""
 
 
 def default_model_path() -> Path:
-    """The model location, with ``MODEL_PATH`` taking precedence.
+    """The model location, with :envvar:`MODEL_PATH` taking precedence.
 
-    The override exists so a heavier or lighter model variant — lite at 5.5 MB, full at 9 MB,
-    heavy at 29 MB — can be swapped in without rebuilding the image (OP-20). It also replaces the
-    legacy arrangement's worst property: weights fetched from a bare Dropbox link recorded in a
-    readme, so a dead link made the whole project unrunnable.
+    The override exists so a variant can be swapped in without rebuilding: lite at 5.5 MB, full at
+    9 MB, heavy at 29 MB. Nothing in the code depends on which one loads — all three emit the same
+    33 landmarks with world coordinates — so this is a configuration change, not a code change.
+    See ``models/checksums.txt`` for the pins and the tradeoffs.
+
+    It also replaces the legacy arrangement's worst property: weights fetched from a bare Dropbox
+    link recorded in a readme, with no checksum and no stated origin, so a dead link made the whole
+    project unrunnable and a corrupted copy was indistinguishable from a good one.
     """
     override = os.environ.get("MODEL_PATH")
     return Path(override) if override else DEFAULT_MODEL_PATH

--- a/packages/pose-backends/tests/test_backend_contract.py
+++ b/packages/pose-backends/tests/test_backend_contract.py
@@ -1,0 +1,204 @@
+"""One suite, run against **every** backend, real and fake.
+
+This is what stops `FakePoseBackend` from drifting into a shape the real adapter never produces.
+Without it the fake is a free variable: it can grow a keypoint MediaPipe does not report, or lose
+world coordinates, or start returning a frame where the real one returns `None` — and every
+downstream test resting on the fake would keep passing while asserting something untrue about the
+production path.
+
+The real backend's parameter is marked `pytest.mark.model`, so required CI runs the fake leg only
+and the on-demand model workflow (OP-21) runs both. That asymmetry is the deliberate trade: cheap
+protection on every pull request, full protection when the weights are available.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import FakePoseBackend, PoseBackend, PosePreset
+from posture_core import KeypointName
+
+WIDTH, HEIGHT = 640, 480
+
+FIXTURES = Path(__file__).resolve().parents[3] / "fixtures" / "images"
+DEFAULT_MODEL = Path(__file__).resolve().parents[3] / "models" / "pose_landmarker_full.task"
+
+# The landmarks every backend must supply for the rules engine to function at all. A backend
+# missing any of these cannot produce a trunk inclination, which is the project's core metric.
+REQUIRED = frozenset(
+    {
+        KeypointName.LEFT_SHOULDER,
+        KeypointName.RIGHT_SHOULDER,
+        KeypointName.LEFT_HIP,
+        KeypointName.RIGHT_HIP,
+        KeypointName.NECK,
+    }
+)
+
+
+@dataclass(frozen=True)
+class Case:
+    """A backend plus the inputs needed to drive it down both paths."""
+
+    with_person: PoseBackend
+    without_person: PoseBackend
+    image_with_person: NDArray[np.uint8]
+    image_without_person: NDArray[np.uint8]
+
+
+def _blank() -> NDArray[np.uint8]:
+    return np.full((HEIGHT, WIDTH, 3), 128, dtype=np.uint8)
+
+
+def _fake_case() -> Case:
+    return Case(
+        with_person=FakePoseBackend(PosePreset.STRAIGHT, image_width=WIDTH, image_height=HEIGHT),
+        # The fake selects its scenario by construction, so "no person" is a second instance
+        # rather than a second input. That difference is confined to this fixture, which is why
+        # the assertions below can be written once for both backends.
+        without_person=FakePoseBackend(PosePreset.NO_PERSON),
+        image_with_person=_blank(),
+        image_without_person=_blank(),
+    )
+
+
+def _mediapipe_case() -> Case:
+    from pose_backends import MediaPipeBackend
+
+    model = Path(os.environ.get("MODEL_PATH", DEFAULT_MODEL))
+    if not model.is_file():
+        pytest.skip(f"no model at {model} — run `make fetch-model`")
+
+    import cv2
+
+    photo = cv2.imread(str(FIXTURES / "straight_armsfolded.jpg"))
+    if photo is None:
+        pytest.skip("fixture image could not be decoded")
+
+    backend = MediaPipeBackend(model)
+    return Case(
+        with_person=backend,
+        without_person=backend,
+        image_with_person=photo,
+        image_without_person=_blank(),
+    )
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(_fake_case, id="fake"),
+        pytest.param(_mediapipe_case, id="mediapipe", marks=pytest.mark.model),
+    ]
+)
+def case(request: pytest.FixtureRequest) -> Case:
+    factory: object = request.param
+    return factory()  # type: ignore[operator, no-any-return]
+
+
+# ---------------------------------------------------------------------------------------------
+# The contract
+# ---------------------------------------------------------------------------------------------
+
+
+def test_conforms_to_the_protocol(case: Case) -> None:
+    assert isinstance(case.with_person, PoseBackend)
+
+
+def test_name_is_stable_and_stamped_onto_the_frame(case: Case) -> None:
+    """Provenance travels with the data, so a stored report can say which engine produced it."""
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert case.with_person.name
+    assert frame.backend == case.with_person.name
+
+
+def test_reports_only_canonical_keypoints(case: Case) -> None:
+    """A backend must not widen the schema. The canonical set is the project's, not the model's."""
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert set(frame.landmarks) <= set(KeypointName)
+
+
+def test_supplies_the_keypoints_the_rules_engine_cannot_work_without(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert set(frame.landmarks) >= REQUIRED
+
+
+def test_neck_is_the_shoulder_midpoint_on_every_backend(case: Case) -> None:
+    """The one derived keypoint, and both backends must derive it the same way.
+
+    If they disagreed, a threshold tuned against fake frames would be tuned against a skeleton the
+    real backend never produces — the exact silent drift this suite exists to prevent.
+    """
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    left = frame.landmarks[KeypointName.LEFT_SHOULDER]
+    right = frame.landmarks[KeypointName.RIGHT_SHOULDER]
+    neck = frame.landmarks[KeypointName.NECK]
+    assert neck.x == pytest.approx((left.x + right.x) / 2, abs=1e-6)
+    assert neck.y == pytest.approx((left.y + right.y) / 2, abs=1e-6)
+
+
+def test_confidences_are_probabilities(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    for name, landmark in frame.landmarks.items():
+        assert 0.0 <= landmark.visibility <= 1.0, name
+        assert 0.0 <= landmark.presence <= 1.0, name
+
+
+def test_world_coordinates_are_present_for_all_landmarks_or_none(case: Case) -> None:
+    """The optionality rule, stated as a frame-level property.
+
+    A frame where some points carry metres and others do not would let a metric mix coordinate
+    systems in one calculation — wrong answers, no error. `Landmark` enforces all-or-nothing per
+    point; this enforces it across the frame.
+    """
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    with_world = [lm.has_world for lm in frame.landmarks.values()]
+    assert all(with_world) or not any(with_world)
+
+
+def test_frame_metadata_has_the_expected_types(case: Case) -> None:
+    frame = case.with_person.detect(case.image_with_person)
+    assert frame is not None
+    assert isinstance(frame.image_width, int) and frame.image_width > 0
+    assert isinstance(frame.image_height, int) and frame.image_height > 0
+    assert isinstance(frame.inference_ms, float) and frame.inference_ms >= 0.0
+    for landmark in frame.landmarks.values():
+        assert isinstance(landmark.x, float)
+        assert isinstance(landmark.y, float)
+
+
+def test_returns_none_rather_than_raising_when_there_is_no_person(case: Case) -> None:
+    """The behaviour the entire error model rests on, checked identically on both backends."""
+    assert case.without_person.detect(case.image_without_person) is None
+
+
+def test_warmup_is_idempotent_and_never_raises(case: Case) -> None:
+    case.with_person.warmup()
+    case.with_person.warmup()
+
+
+def test_repeated_detection_is_stable(case: Case) -> None:
+    """The same input twice gives the same skeleton.
+
+    Latency will differ, so coordinates are compared rather than whole frames — a real backend
+    that reported different landmarks for an identical image would make every downstream
+    assertion flaky, and the fake would hide it.
+    """
+    first = case.with_person.detect(case.image_with_person)
+    second = case.with_person.detect(case.image_with_person)
+    assert first is not None and second is not None
+    assert set(first.landmarks) == set(second.landmarks)
+    for name, landmark in first.landmarks.items():
+        assert landmark.x == pytest.approx(second.landmarks[name].x, abs=1e-6), name
+        assert landmark.y == pytest.approx(second.landmarks[name].y, abs=1e-6), name

--- a/packages/pose-backends/tests/test_backend_contract.py
+++ b/packages/pose-backends/tests/test_backend_contract.py
@@ -85,7 +85,7 @@ def _mediapipe_case() -> Case:
     return Case(
         with_person=backend,
         without_person=backend,
-        image_with_person=photo,
+        image_with_person=np.asarray(photo, dtype=np.uint8),
         image_without_person=_blank(),
     )
 

--- a/packages/pose-backends/tests/test_base.py
+++ b/packages/pose-backends/tests/test_base.py
@@ -1,0 +1,114 @@
+"""Conformance tests for the `PoseBackend` Protocol.
+
+The Protocol is checked two ways, and both are needed because they catch different things:
+
+* **statically** — the `_assert_conforms` helper below assigns an implementation to a
+  `PoseBackend`-typed variable, so mypy --strict verifies signatures, argument types and return
+  types. This is the check that catches a `detect` returning `PoseFrame` instead of
+  `PoseFrame | None`.
+* **at runtime** — `isinstance`, which only sees whether the members exist. Weak on its own, but
+  it is what proves `@runtime_checkable` is actually usable for the config-driven backend
+  selection in OP-19.
+
+A missing method is caught by both. A wrong *signature* is caught only by mypy, which is why the
+static half is not redundant.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from pose_backends import ImageBGR, PoseBackend
+from posture_core import KeypointName, Landmark, PoseFrame
+
+
+class MinimalBackend:
+    """The smallest thing that satisfies the Protocol.
+
+    Note what it does *not* do: import `PoseBackend`, inherit from it, or register with it. That
+    is the whole argument for a Protocol over an ABC — a test double is a local class, and mypy
+    still checks it against the real contract.
+    """
+
+    name = "minimal"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        height, width = image_bgr.shape[:2]
+        return PoseFrame(
+            landmarks={KeypointName.NOSE: Landmark(x=0.5, y=0.5, visibility=1.0, presence=1.0)},
+            image_width=width,
+            image_height=height,
+            backend=self.name,
+            inference_ms=0.0,
+        )
+
+    def warmup(self) -> None:
+        return None
+
+
+class ComputedNameBackend:
+    """`name` as a property, not an attribute — the reason the Protocol declares it as one.
+
+    Had the Protocol said `name: str`, mypy would reject this class: a read-only property does not
+    satisfy a mutable attribute. Both forms are legitimate, so the Protocol accommodates both.
+    """
+
+    @property
+    def name(self) -> str:
+        return "computed"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        return None
+
+    def warmup(self) -> None:
+        return None
+
+
+class MissingWarmup:
+    name = "incomplete"
+
+    def detect(self, image_bgr: ImageBGR) -> PoseFrame | None:
+        return None
+
+
+def _assert_conforms(backend: PoseBackend) -> str:
+    """Static conformance: mypy --strict checks the argument at every call site below."""
+    return backend.name
+
+
+def test_minimal_implementation_conforms_statically_and_at_runtime() -> None:
+    backend = MinimalBackend()
+    assert _assert_conforms(backend) == "minimal"
+    assert isinstance(backend, PoseBackend)
+
+
+def test_name_may_be_a_property() -> None:
+    backend = ComputedNameBackend()
+    assert _assert_conforms(backend) == "computed"
+    assert isinstance(backend, PoseBackend)
+
+
+def test_incomplete_implementation_is_rejected_at_runtime() -> None:
+    """A backend missing `warmup` must not pass as one — OP-40 calls it unconditionally."""
+    assert not isinstance(MissingWarmup(), PoseBackend)
+
+
+def test_detect_returns_a_frame_stamped_with_the_backend_and_image_size() -> None:
+    """Provenance travels with the data rather than being logged beside it."""
+    image: ImageBGR = np.zeros((480, 640, 3), dtype=np.uint8)
+    frame = MinimalBackend().detect(image)
+    assert frame is not None
+    assert frame.backend == "minimal"
+    assert (frame.image_width, frame.image_height) == (640, 480)
+
+
+def test_none_is_a_legitimate_detect_result() -> None:
+    """No person in the photo is an ordinary outcome, not an error.
+
+    This is the single most important line of the contract. The legacy engine returned `None` for
+    *both* "nobody there" and "inference failed", and the caller rendered `None` as "Straight back
+    position" (FINDINGS §2.5) — so a crash and a photo of an empty desk both told the user their
+    posture was fine. Here `None` means exactly one thing, and breakage raises.
+    """
+    image: ImageBGR = np.zeros((16, 16, 3), dtype=np.uint8)
+    assert ComputedNameBackend().detect(image) is None

--- a/packages/pose-backends/tests/test_fake.py
+++ b/packages/pose-backends/tests/test_fake.py
@@ -1,0 +1,205 @@
+"""Tests for `FakePoseBackend` and its presets.
+
+Treated as production code, because it is: with `POSE_BACKEND=fake` the whole application runs
+backend-free, so a wrong preset does not fail a test — it silently changes what the container
+smoke test and the Playwright suite are asserting about.
+"""
+
+from __future__ import annotations
+
+import math
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import FakePoseBackend, PoseBackend, PosePreset
+from posture_core import KeypointName, PoseFrame
+
+DETECTABLE = [preset for preset in PosePreset if preset is not PosePreset.NO_PERSON]
+
+
+def image(width: int = 640, height: int = 480) -> NDArray[np.uint8]:
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+def trunk_lean(frame: PoseFrame) -> float:
+    """Signed lean of hip-mid -> shoulder-mid from vertical, positive forward, in world space."""
+    hips = [frame.landmarks[k] for k in (KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)]
+    neck = frame.landmarks[KeypointName.NECK]
+    hip_x = sum(h.x_world or 0.0 for h in hips) / 2
+    hip_y = sum(h.y_world or 0.0 for h in hips) / 2
+    return math.degrees(math.atan2((neck.x_world or 0.0) - hip_x, -((neck.y_world or 0.0) - hip_y)))
+
+
+def knee_flexion(frame: PoseFrame) -> float:
+    hip = frame.landmarks[KeypointName.LEFT_HIP]
+    knee = frame.landmarks[KeypointName.LEFT_KNEE]
+    ankle = frame.landmarks[KeypointName.LEFT_ANKLE]
+    first = [(hip.x_world or 0) - (knee.x_world or 0), (hip.y_world or 0) - (knee.y_world or 0)]
+    second = [
+        (ankle.x_world or 0) - (knee.x_world or 0),
+        (ankle.y_world or 0) - (knee.y_world or 0),
+    ]
+    dot = first[0] * second[0] + first[1] * second[1]
+    norms = math.dist(first, [0, 0]) * math.dist(second, [0, 0])
+    return math.degrees(math.acos(max(-1.0, min(1.0, dot / norms))))
+
+
+# ---------------------------------------------------------------------------------------------
+# Every preset is a usable frame
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("preset", DETECTABLE)
+def test_every_preset_returns_a_complete_frame(preset: PosePreset) -> None:
+    frame = FakePoseBackend(preset).detect(image())
+    assert frame is not None
+    assert frame.backend == "fake"
+    assert KeypointName.NECK in frame
+    assert frame.has_world_landmarks is True
+
+
+def test_no_person_preset_returns_none() -> None:
+    """The empty-desk path, exercisable without an empty desk.
+
+    Every caller downstream has to handle `None`, and this is what makes that branch reachable in
+    a test that runs in milliseconds with no model.
+    """
+    assert FakePoseBackend(PosePreset.NO_PERSON).detect(image()) is None
+
+
+@pytest.mark.parametrize("preset", DETECTABLE)
+def test_preset_output_is_byte_identical_across_runs_and_instances(preset: PosePreset) -> None:
+    """End-to-end snapshot assertions depend on this absolutely.
+
+    Two separately-constructed backends must agree, not just two calls on one — otherwise a
+    process restart between a golden-file capture and its comparison would produce a diff.
+    """
+    first = FakePoseBackend(preset).detect(image())
+    second = FakePoseBackend(preset).detect(image())
+    assert first == second
+    assert first is not None and first.inference_ms == 0.0
+
+
+def test_preset_may_be_named_by_string() -> None:
+    """`POSE_BACKEND_PRESET=hunchback` arrives as a string, not as an enum member."""
+    assert FakePoseBackend("hunchback").preset is PosePreset.HUNCHBACK
+
+
+def test_unknown_preset_name_fails_loudly() -> None:
+    with pytest.raises(ValueError, match="slouchy"):
+        FakePoseBackend("slouchy")
+
+
+# ---------------------------------------------------------------------------------------------
+# The presets describe the postures they are named after
+# ---------------------------------------------------------------------------------------------
+
+
+def test_hunchback_leans_further_forward_than_straight() -> None:
+    """If this ordering were wrong, every rule tuned against these fixtures would be tuned
+    backwards, and nothing else in the suite would notice."""
+    straight = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    hunched = FakePoseBackend(PosePreset.HUNCHBACK).detect(image())
+    assert straight is not None and hunched is not None
+    assert trunk_lean(hunched) > trunk_lean(straight) + 20
+
+
+def test_reclined_leans_backwards_giving_a_negative_trunk_angle() -> None:
+    """The preset that catches an unsigned implementation.
+
+    A metric taking `abs()` of the lean would score reclining identically to slumping. Only a
+    fixture with a genuinely negative angle can fail such an implementation.
+    """
+    reclined = FakePoseBackend(PosePreset.RECLINED).detect(image())
+    assert reclined is not None
+    assert trunk_lean(reclined) < 0
+
+
+def test_kneeling_has_a_sharply_flexed_knee_and_seated_presets_do_not() -> None:
+    kneeling = FakePoseBackend(PosePreset.KNEELING).detect(image())
+    seated = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    assert kneeling is not None and seated is not None
+    assert knee_flexion(kneeling) < 45
+    assert 80 < knee_flexion(seated) < 120
+
+
+def test_frontal_view_shows_broad_shoulders_where_lateral_presets_show_none() -> None:
+    """What `view_confidence` (OP-31) keys off, in image space.
+
+    The original app asked for a side-on photo and assessed whatever it got. This preset is the
+    photo it should refuse.
+    """
+
+    def shoulder_span(frame: PoseFrame) -> float:
+        left = frame.landmarks[KeypointName.LEFT_SHOULDER]
+        right = frame.landmarks[KeypointName.RIGHT_SHOULDER]
+        return abs(left.x - right.x)
+
+    frontal = FakePoseBackend(PosePreset.FRONTAL_VIEW).detect(image())
+    lateral = FakePoseBackend(PosePreset.STRAIGHT).detect(image())
+    assert frontal is not None and lateral is not None
+    assert shoulder_span(frontal) > 0.1
+    assert shoulder_span(lateral) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_partial_occlusion_distinguishes_missing_from_merely_unseen() -> None:
+    """Two different kinds of "we cannot assess this", and they must not collapse into one.
+
+    The legs are *omitted* — never reported, so the frame does not contain them at all. The far
+    arm is *present* with low visibility and high presence, which is what occluded looks like.
+    Being able to express both is why MediaPipe was chosen over MoveNet (ADR-0002), and this
+    preset is how the "couldn't assess your knees, try a wider shot" path gets tested without
+    finding a photograph of someone whose knees are out of shot.
+    """
+    frame = FakePoseBackend(PosePreset.PARTIAL_OCCLUSION).detect(image())
+    assert frame is not None
+
+    assert KeypointName.LEFT_KNEE not in frame
+    assert KeypointName.RIGHT_ANKLE not in frame
+
+    elbow = frame.landmarks[KeypointName.LEFT_ELBOW]
+    assert elbow.visibility < 0.3
+    assert elbow.presence > 0.8
+
+    # The upper body is still fully assessable, which is the point: partial occlusion must
+    # degrade the report, not void it.
+    assert KeypointName.NECK in frame
+    assert frame.landmarks[KeypointName.RIGHT_SHOULDER].visibility > 0.8
+
+
+# ---------------------------------------------------------------------------------------------
+# Behaviour
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_image_is_ignored_entirely() -> None:
+    """The contract, not a shortcut.
+
+    Callers select the scenario by constructing the backend. A fake that inspected pixels would
+    make an end-to-end test's outcome depend on whichever placeholder JPEG someone uploaded.
+    """
+    backend = FakePoseBackend(PosePreset.STRAIGHT)
+    noise = np.full((480, 640, 3), 255, dtype=np.uint8)
+    assert backend.detect(noise) == backend.detect(image())
+
+
+def test_frame_size_is_configurable() -> None:
+    frame = FakePoseBackend(PosePreset.STRAIGHT, image_width=1920, image_height=1080).detect(
+        image(1920, 1080)
+    )
+    assert frame is not None
+    assert (frame.image_width, frame.image_height) == (1920, 1080)
+
+
+def test_warmup_and_close_are_no_ops_that_do_not_raise() -> None:
+    """OP-40's lifespan hook calls both blind, so neither may need a special case for the fake."""
+    backend = FakePoseBackend()
+    backend.warmup()
+    backend.warmup()
+    backend.close()
+
+
+def test_satisfies_the_protocol() -> None:
+    assert isinstance(FakePoseBackend(), PoseBackend)

--- a/packages/pose-backends/tests/test_mediapipe_backend.py
+++ b/packages/pose-backends/tests/test_mediapipe_backend.py
@@ -1,0 +1,374 @@
+"""Adapter tests for `MediaPipeBackend`, run against a stub detector.
+
+**No model file, no mediapipe installed, no download.** That is the point: a transposed landmark
+index is exactly the class of bug that made the legacy engine wrong (FINDINGS §2.1) and it is
+invisible without a test, so the test has to be cheap enough to run on every pull request. The
+`detector_factory` seam is what makes that possible.
+
+Real-model tests live in `test_mediapipe_model.py`, marked `pytest.mark.model`, and are
+deselected in required CI.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import InvalidImageError, MediaPipeBackend, ModelNotFoundError
+from pose_backends.mediapipe_backend import (
+    MEDIAPIPE_INDEX_TO_KEYPOINT,
+    RawDetection,
+    RawLandmark,
+)
+from posture_core import KeypointName
+
+MODEL = "/nonexistent/pose_landmarker_full.task"
+
+
+class StubDetector:
+    """Stands in for the MediaPipe Tasks graph, and records what it was handed."""
+
+    def __init__(self, detection: RawDetection | None) -> None:
+        self.detection = detection
+        self.calls: list[NDArray[np.uint8]] = []
+        self.closed = 0
+
+    def detect(self, image_rgb: NDArray[np.uint8]) -> RawDetection | None:
+        self.calls.append(image_rgb)
+        return self.detection
+
+    def close(self) -> None:
+        self.closed += 1
+
+
+def raw(index: int, *, visibility: float = 0.9, presence: float = 0.95) -> RawLandmark:
+    """A landmark whose coordinates encode its index, so a mis-mapping is legible in a failure."""
+    return RawLandmark(
+        x=index / 100.0,
+        y=index / 200.0,
+        z=index / 400.0,
+        visibility=visibility,
+        presence=presence,
+    )
+
+
+def full_detection(*, world: bool = True) -> RawDetection:
+    landmarks = [raw(i) for i in range(33)]
+    world_landmarks = (
+        [RawLandmark(x=i, y=-i, z=i / 2, visibility=0.0, presence=0.0) for i in range(33)]
+        if world
+        else None
+    )
+    return RawDetection(landmarks=landmarks, world_landmarks=world_landmarks)
+
+
+def make_backend(detection: RawDetection | None) -> tuple[MediaPipeBackend, StubDetector]:
+    stub = StubDetector(detection)
+    backend = MediaPipeBackend(MODEL, detector_factory=lambda _path, _conf: stub)
+    return backend, stub
+
+
+def image(width: int = 640, height: int = 480) -> NDArray[np.uint8]:
+    return np.zeros((height, width, 3), dtype=np.uint8)
+
+
+# ---------------------------------------------------------------------------------------------
+# The mapping table itself
+# ---------------------------------------------------------------------------------------------
+
+
+def test_mapping_covers_every_mediapipe_index_exactly_once() -> None:
+    assert sorted(MEDIAPIPE_INDEX_TO_KEYPOINT) == list(range(33))
+    assert len(set(MEDIAPIPE_INDEX_TO_KEYPOINT.values())) == 33
+
+
+def test_mapping_covers_every_canonical_keypoint_except_the_derived_neck() -> None:
+    """NECK is the only canonical name no backend reports; everything else must be reachable.
+
+    An unreachable name would be a keypoint the rules engine can ask for and never receive — a
+    metric that silently abstains forever, for a reason nobody would think to look for here.
+    """
+    mapped = set(MEDIAPIPE_INDEX_TO_KEYPOINT.values())
+    assert set(KeypointName) - mapped == {KeypointName.NECK}
+
+
+@pytest.mark.parametrize(
+    ("index", "expected"),
+    [
+        # The landmarks the rules engine actually uses, pinned individually against ADR-0002's
+        # table. Spot-checking a handful is not enough here: the legacy bug was one inverted pair.
+        (0, KeypointName.NOSE),
+        (7, KeypointName.LEFT_EAR),
+        (8, KeypointName.RIGHT_EAR),
+        (11, KeypointName.LEFT_SHOULDER),
+        (12, KeypointName.RIGHT_SHOULDER),
+        (13, KeypointName.LEFT_ELBOW),
+        (14, KeypointName.RIGHT_ELBOW),
+        (15, KeypointName.LEFT_WRIST),
+        (16, KeypointName.RIGHT_WRIST),
+        (23, KeypointName.LEFT_HIP),
+        (24, KeypointName.RIGHT_HIP),
+        (25, KeypointName.LEFT_KNEE),
+        (26, KeypointName.RIGHT_KNEE),
+        (27, KeypointName.LEFT_ANKLE),
+        (28, KeypointName.RIGHT_ANKLE),
+        (29, KeypointName.LEFT_HEEL),
+        (30, KeypointName.RIGHT_HEEL),
+        (31, KeypointName.LEFT_FOOT_INDEX),
+        (32, KeypointName.RIGHT_FOOT_INDEX),
+    ],
+)
+def test_index_maps_to_the_keypoint_adr_0002_says_it_does(
+    index: int, expected: KeypointName
+) -> None:
+    assert MEDIAPIPE_INDEX_TO_KEYPOINT[index] is expected
+
+
+def test_landmarks_are_placed_under_the_name_matching_their_index() -> None:
+    """End-to-end version of the table test: a transposition inside `_to_canonical` fails here.
+
+    `raw()` encodes the index into the coordinates, so the assertion checks placement rather than
+    merely presence.
+    """
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    for index, name in MEDIAPIPE_INDEX_TO_KEYPOINT.items():
+        landmark = frame.get(name)
+        assert landmark is not None
+        assert landmark.x == pytest.approx(index / 100.0)
+        assert landmark.y == pytest.approx(index / 200.0)
+
+
+# ---------------------------------------------------------------------------------------------
+# NECK derivation
+# ---------------------------------------------------------------------------------------------
+
+
+def test_neck_is_the_midpoint_of_the_two_shoulders() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    left = frame.get(KeypointName.LEFT_SHOULDER)
+    right = frame.get(KeypointName.RIGHT_SHOULDER)
+    neck = frame.get(KeypointName.NECK)
+    assert left is not None and right is not None and neck is not None
+    assert neck.x == pytest.approx((left.x + right.x) / 2)
+    assert neck.y == pytest.approx((left.y + right.y) / 2)
+    assert left.x_world is not None and right.x_world is not None
+    assert neck.x_world == pytest.approx((left.x_world + right.x_world) / 2)
+
+
+def test_neck_takes_the_minimum_confidence_of_its_two_shoulders() -> None:
+    """Not the mean.
+
+    A derived point cannot be more trustworthy than the least trustworthy thing it came from.
+    Averaging would let one confidently-seen shoulder launder an unseen one into a plausible neck
+    — which is how a metric ends up reported with confidence it has not earned.
+    """
+    landmarks = [raw(i) for i in range(33)]
+    landmarks[11] = raw(11, visibility=0.2, presence=0.3)
+    landmarks[12] = raw(12, visibility=0.95, presence=0.99)
+    backend, _ = make_backend(RawDetection(landmarks=landmarks))
+
+    frame = backend.detect(image())
+    assert frame is not None
+    neck = frame.get(KeypointName.NECK)
+    assert neck is not None
+    assert neck.visibility == pytest.approx(0.2)
+    assert neck.presence == pytest.approx(0.3)
+
+
+def test_neck_is_absent_when_a_shoulder_is_missing() -> None:
+    """Absent, not guessed. A one-shoulder neck would be an invented measurement."""
+    backend, _ = make_backend(RawDetection(landmarks=[raw(i) for i in range(12)]))  # 0..11 only
+    frame = backend.detect(image())
+    assert frame is not None
+    assert KeypointName.LEFT_SHOULDER in frame
+    assert KeypointName.RIGHT_SHOULDER not in frame
+    assert KeypointName.NECK not in frame
+
+
+# ---------------------------------------------------------------------------------------------
+# Passthrough
+# ---------------------------------------------------------------------------------------------
+
+
+def test_world_landmarks_visibility_and_presence_pass_through() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image())
+    assert frame is not None
+    hip = frame.get(KeypointName.LEFT_HIP)
+    assert hip is not None
+    assert (hip.x_world, hip.y_world, hip.z_world) == (23.0, -23.0, 11.5)
+    assert hip.visibility == pytest.approx(0.9)
+    assert hip.presence == pytest.approx(0.95)
+    assert frame.has_world_landmarks is True
+
+
+def test_absent_world_landmarks_leave_the_frame_in_image_space() -> None:
+    """The ADR-0005 fallback path, and it must be detectable rather than silently zero-filled."""
+    backend, _ = make_backend(full_detection(world=False))
+    frame = backend.detect(image())
+    assert frame is not None
+    assert frame.has_world_landmarks is False
+    nose = frame.get(KeypointName.NOSE)
+    assert nose is not None and nose.x_world is None
+
+
+def test_mismatched_world_array_length_drops_world_rather_than_pairing_by_index() -> None:
+    """Silently wrong beats loudly wrong is never the trade here.
+
+    Pairing arrays of different lengths by index attaches one landmark's metres to another's
+    pixels: no exception, no warning, just angles that are quietly incorrect.
+    """
+    detection = RawDetection(
+        landmarks=[raw(i) for i in range(33)],
+        world_landmarks=[raw(i) for i in range(20)],
+    )
+    backend, _ = make_backend(detection)
+    frame = backend.detect(image())
+    assert frame is not None
+    assert frame.has_world_landmarks is False
+
+
+def test_unknown_landmark_indices_are_ignored() -> None:
+    """A future variant reporting extra points must not widen the canonical schema."""
+    detection = RawDetection(landmarks=[raw(i) for i in range(40)])
+    backend, _ = make_backend(detection)
+    frame = backend.detect(image())
+    assert frame is not None
+    assert len(frame) == 34  # 33 mapped + derived NECK
+
+
+def test_frame_is_stamped_with_backend_image_size_and_latency() -> None:
+    backend, _ = make_backend(full_detection())
+    frame = backend.detect(image(width=1280, height=720))
+    assert frame is not None
+    assert frame.backend == "mediapipe"
+    assert (frame.image_width, frame.image_height) == (1280, 720)
+    assert frame.inference_ms >= 0.0
+
+
+def test_image_is_converted_from_bgr_to_rgb_before_inference() -> None:
+    """Getting this wrong does not crash — it just quietly degrades detection.
+
+    cv2 decodes to BGR and MediaPipe expects RGB. The stub records the array it received, so the
+    channel order is asserted rather than assumed. Contiguity is checked too: reversing the last
+    axis yields a negative-stride view that the native binding cannot accept.
+    """
+    backend, stub = make_backend(full_detection())
+    bgr = np.zeros((4, 4, 3), dtype=np.uint8)
+    bgr[:, :, 0] = 10  # blue
+    bgr[:, :, 1] = 20  # green
+    bgr[:, :, 2] = 30  # red
+
+    backend.detect(bgr)
+
+    received = stub.calls[0]
+    assert received[0, 0].tolist() == [30, 20, 10]
+    assert received.flags["C_CONTIGUOUS"]
+
+
+# ---------------------------------------------------------------------------------------------
+# Error and degradation paths
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("detection", [None, RawDetection(landmarks=[])])
+def test_no_pose_returns_none_without_raising(detection: RawDetection | None) -> None:
+    """The single most important line of the contract.
+
+    An image with nobody in it is an ordinary outcome of a posture app. The legacy engine returned
+    `None` for this *and* for inference failure, and the caller rendered `None` as "Straight back
+    position" (FINDINGS §2.5) — so an empty desk and a crash both told the user their posture was
+    fine. Here `None` means one thing and breakage raises.
+    """
+    backend, _ = make_backend(detection)
+    assert backend.detect(image()) is None
+
+
+def test_missing_model_file_raises_a_clear_error_not_an_obscure_traceback() -> None:
+    """Names the path and the remedy. Reached before mediapipe is imported, so it works here."""
+    with pytest.raises(ModelNotFoundError, match="make fetch-model"):
+        MediaPipeBackend("/nonexistent/definitely-not-a-model.task")
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        np.zeros((480, 640), dtype=np.uint8),  # greyscale
+        np.zeros((480, 640, 4), dtype=np.uint8),  # BGRA
+        np.zeros((0, 640, 3), dtype=np.uint8),  # empty
+    ],
+)
+def test_malformed_arrays_raise_rather_than_returning_none(bad: NDArray[np.uint8]) -> None:
+    """A bad array is a caller bug, not a bad photo, so it must not look like "no person"."""
+    backend, _ = make_backend(full_detection())
+    with pytest.raises(InvalidImageError):
+        backend.detect(bad)
+
+
+# ---------------------------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------------------------
+
+
+def test_model_is_loaded_once_not_per_call() -> None:
+    """The defect that made the legacy engine unusable from a web request.
+
+    Its model was a module global built at import time from a cwd-relative config, so it could
+    neither be loaded once at startup nor be imported at all. Here the factory runs exactly once,
+    in `__init__`.
+    """
+    factory_calls: list[tuple[object, float]] = []
+
+    def factory(path: object, confidence: float) -> StubDetector:
+        factory_calls.append((path, confidence))
+        return StubDetector(full_detection())
+
+    backend = MediaPipeBackend(MODEL, detector_factory=factory)
+    backend.detect(image())
+    backend.detect(image())
+    assert len(factory_calls) == 1
+
+
+def test_warmup_runs_one_inference_and_tolerates_finding_nobody() -> None:
+    """A synthetic frame contains no person, so warmup must survive the `None` path."""
+    backend, stub = make_backend(None)
+    backend.warmup()
+    assert len(stub.calls) == 1
+    assert stub.calls[0].shape == (256, 256, 3)
+
+
+def test_close_releases_the_native_graph_and_is_idempotent() -> None:
+    backend, stub = make_backend(full_detection())
+    backend.close()
+    backend.close()
+    assert stub.closed == 2
+
+
+def test_model_path_is_absolute_so_the_backend_does_not_depend_on_cwd() -> None:
+    """The legacy code used relative paths for both weights and config, so it only ran from
+    inside `API/`. Resolving on construction is the fix, and it is worth a test because the
+    failure mode is environment-dependent and would not reproduce for whoever wrote it."""
+    backend, _ = make_backend(full_detection())
+    assert backend.model_path.is_absolute()
+
+
+def test_backend_satisfies_the_protocol() -> None:
+    from pose_backends import PoseBackend
+
+    backend, _ = make_backend(full_detection())
+    assert isinstance(backend, PoseBackend)
+
+
+def test_raw_landmarks_sequence_type_is_not_mutated_by_the_adapter() -> None:
+    """The adapter must not write back into the detector's arrays; a real one reuses them."""
+    landmarks: Sequence[RawLandmark] = [raw(i) for i in range(33)]
+    backend, _ = make_backend(RawDetection(landmarks=landmarks))
+    backend.detect(image())
+    assert landmarks[11] == raw(11)

--- a/packages/pose-backends/tests/test_mediapipe_model.py
+++ b/packages/pose-backends/tests/test_mediapipe_model.py
@@ -52,28 +52,65 @@ def load(name: str) -> NDArray[np.uint8]:
     image = cv2.imread(str(FIXTURES / name))
     if image is None:
         pytest.skip(f"fixture {name} could not be decoded")
-    return image  # type: ignore[no-any-return]
+    # `asarray` rather than a cast: cv2 ships type stubs, so mypy's view of `imread`'s return
+    # type depends on whether the optional extra happens to be installed. Narrowing it here keeps
+    # the type check identical with and without mediapipe present.
+    return np.asarray(image, dtype=np.uint8)
 
 
-# The three seated side-view fixtures the whole project is calibrated against. Named explicitly
-# rather than globbed so that a fixture disappearing fails the test instead of shrinking it.
-SEATED_FIXTURES = ["hunchback_right.jpg", "reclined_right.jpg", "straight_armsfolded.jpg"]
+# The seated side-view fixtures, with the confident-landmark floor each one actually clears.
+# Named explicitly rather than globbed so that a fixture disappearing fails the test instead of
+# quietly shrinking it, and floored individually rather than uniformly because the differences are
+# real and worth recording. Measured 2026-07-26 against pose_landmarker_full at 1280x720.
+#
+# `straight_armsfolded` sits lower on purpose: the subject's arms are folded, so both wrists and
+# all six hand points are genuinely occluded. A uniform floor would either fail this fixture for
+# being *correctly* uncertain, or be loosened to the point of proving nothing about the others.
+SEATED_FIXTURES: list[tuple[str, int]] = [
+    ("hunchback_right.jpg", 25),
+    ("reclined_right.jpg", 25),
+    ("desk_hunch.jpeg", 25),
+    ("kneeling_right.jpg", 25),
+    ("straight_armsfolded.jpg", 20),
+]
+
+PRIMARY_FIXTURE = SEATED_FIXTURES[0][0]
 
 
-@pytest.mark.parametrize("fixture", SEATED_FIXTURES)
+@pytest.mark.parametrize(("fixture", "minimum"), SEATED_FIXTURES)
 def test_detects_a_confident_skeleton_on_real_photographs(
-    backend: MediaPipeBackend, fixture: str
+    backend: MediaPipeBackend, fixture: str, minimum: int
 ) -> None:
-    """25 of 34 landmarks above the visibility threshold, on a real seated subject.
+    """Enough landmarks above the visibility threshold to actually assess a seated subject.
 
-    The number is a floor, not a target: a side-on seated pose legitimately occludes one arm and
-    part of one leg. What it rules out is the failure mode where the model returns a full skeleton
-    of low-confidence guesses, which would look like success to any test that only counted keys.
+    A floor, not a target: a side-on pose legitimately occludes the far arm and part of the far
+    leg. What it rules out is the failure mode where the model returns a full 34-point skeleton of
+    low-confidence guesses — which looks like success to any test that only counts keys, and is
+    precisely how a system starts reporting posture it never measured.
     """
     frame = backend.detect(load(fixture))
     assert frame is not None, f"no pose detected in {fixture}"
     confident = [lm for lm in frame.landmarks.values() if lm.visibility >= VISIBILITY_THRESHOLD]
-    assert len(confident) >= 25, f"{fixture}: only {len(confident)} confident landmarks"
+    assert len(confident) >= minimum, f"{fixture}: only {len(confident)} confident landmarks"
+
+
+@pytest.mark.parametrize(("fixture", "_minimum"), SEATED_FIXTURES)
+def test_presence_and_visibility_carry_different_information(
+    backend: MediaPipeBackend, fixture: str, _minimum: int
+) -> None:
+    """The claim ADR-0002 rests on, checked against the real model rather than assumed.
+
+    On every fixture all 34 points are confidently *present* while only 20-28 are confidently
+    *visible*. The gap is the occluded set — the far arm, the folded wrists — and it exists only
+    because the two signals are independent. Collapse them into one score, as MoveNet does, and
+    "I can see your wrist" becomes indistinguishable from "your wrist is in this photograph".
+    """
+    frame = backend.detect(load(fixture))
+    assert frame is not None
+    present = sum(1 for lm in frame.landmarks.values() if lm.presence >= VISIBILITY_THRESHOLD)
+    visible = sum(1 for lm in frame.landmarks.values() if lm.visibility >= VISIBILITY_THRESHOLD)
+    assert present == len(frame)
+    assert visible < present
 
 
 def test_real_frames_carry_world_landmarks(backend: MediaPipeBackend) -> None:
@@ -83,13 +120,13 @@ def test_real_frames_carry_world_landmarks(backend: MediaPipeBackend) -> None:
     normalisation — the problem the model switch was meant to dissolve. Worth asserting against
     the real runtime, because no stub can tell you the runtime still populates this array.
     """
-    frame = backend.detect(load(SEATED_FIXTURES[0]))
+    frame = backend.detect(load(PRIMARY_FIXTURE))
     assert frame is not None
     assert frame.has_world_landmarks is True
 
 
 def test_neck_is_derived_on_real_output(backend: MediaPipeBackend) -> None:
-    frame = backend.detect(load(SEATED_FIXTURES[0]))
+    frame = backend.detect(load(PRIMARY_FIXTURE))
     assert frame is not None
     assert KeypointName.NECK in frame
 
@@ -100,24 +137,49 @@ def test_returns_none_on_an_image_with_no_person(backend: MediaPipeBackend) -> N
     assert backend.detect(blank) is None
 
 
-def test_warmup_makes_the_first_real_inference_materially_faster(
+def test_no_initialisation_cost_is_deferred_past_construction(
     backend: MediaPipeBackend,
 ) -> None:
-    """Proves `warmup()` does what it claims, which is the only way to know it is worth calling.
+    """The property that actually matters, which is not the one warmup was written to provide.
 
-    MediaPipe builds its inference graph lazily, so the first `detect()` on a cold backend pays
-    for it. A fresh backend is constructed here rather than reusing the module-scoped one, which
-    other tests have already warmed.
+    The plan predicted a lazily-built inference graph, so that a cold backend's first `detect()`
+    would be much slower than its second and `warmup()` would be what closed the gap. Measured on
+    2026-07-26 (Apple M5, `pose_landmarker_full`, 1280x720), that is **not what MediaPipe 0.10.18
+    does** in `RunningMode.IMAGE`: construction costs ~31 ms and every inference thereafter costs
+    ~23 ms, first one included. There is nothing left to warm.
 
-    Asserted as a ratio against the *cold* call rather than an absolute millisecond budget:
-    absolute latency varies by an order of magnitude between a laptop and a CI runner, and a
-    threshold that survives both would be too loose to mean anything.
+    So this asserts the real guarantee — a cold backend's first inference is already at steady
+    state, meaning no request ever pays an initialisation cost — rather than a speedup that does
+    not exist. `warmup()` stays in the Protocol regardless: it costs one synthetic frame at
+    startup, it is what a lazier backend would need, and a contract that only holds for the
+    current library version is not a contract.
+
+    A fresh backend is constructed rather than reusing the module-scoped one, which other tests
+    have already exercised. Compared as a ratio because absolute latency varies by an order of
+    magnitude between a laptop and a CI runner.
     """
+    image = load(PRIMARY_FIXTURE)
     cold = MediaPipeBackend(model_path())
-    first = _timed(cold, load(SEATED_FIXTURES[0]))
-    cold.warmup()
-    warmed = min(_timed(cold, load(SEATED_FIXTURES[0])) for _ in range(3))
-    assert warmed < first * 0.8, f"cold {first:.1f} ms vs warmed {warmed:.1f} ms"
+    first = _timed(cold, image)
+    steady = min(_timed(cold, image) for _ in range(3))
+    assert first < steady * 2.0, f"first inference {first:.1f} ms vs steady {steady:.1f} ms"
+
+
+def test_warmup_does_not_disturb_subsequent_detection(backend: MediaPipeBackend) -> None:
+    """Whatever warmup does or does not save, it must not change results.
+
+    It runs an inference on a synthetic frame of a different size, and a backend that carried
+    state between calls could return something different afterwards. OP-40 calls this at startup
+    on the same instance that then serves every request.
+    """
+    image = load(PRIMARY_FIXTURE)
+    before = backend.detect(image)
+    backend.warmup()
+    after = backend.detect(image)
+    assert before is not None and after is not None
+    assert set(before.landmarks) == set(after.landmarks)
+    for name, landmark in before.landmarks.items():
+        assert landmark.x == pytest.approx(after.landmarks[name].x, abs=1e-9), name
 
 
 def _timed(backend: MediaPipeBackend, image: NDArray[np.uint8]) -> float:

--- a/packages/pose-backends/tests/test_mediapipe_model.py
+++ b/packages/pose-backends/tests/test_mediapipe_model.py
@@ -1,0 +1,126 @@
+"""Real-model tests: actual weights, actual inference, actual fixture photographs.
+
+**Deselected in required CI** with `-m "not model"`. They need a 9 MB download and the full
+mediapipe extra, and the pull-request workflow deliberately downloads nothing — the stubbed
+adapter tests in `test_mediapipe_backend.py` are what protect every PR. These run on demand in
+`model-validation.yml` (OP-21).
+
+Keeping them in the repository rather than deleting them matters: the stub proves the *mapping*
+is right, and only these prove the mapping is right about a *real model*. A stub agreeing with
+itself is not evidence.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from pose_backends import MediaPipeBackend
+from posture_core import KeypointName, PoseFrame
+
+pytestmark = pytest.mark.model
+
+# Landmarks below this are reported but not trusted. Matches MediaPipe's own default detection
+# confidence; the real per-metric thresholds are Epic C's business (OP-24), not the adapter's.
+VISIBILITY_THRESHOLD = 0.5
+
+FIXTURES = Path(__file__).resolve().parents[3] / "fixtures" / "images"
+DEFAULT_MODEL = Path(__file__).resolve().parents[3] / "models" / "pose_landmarker_full.task"
+
+
+def model_path() -> Path:
+    """Where the weights are. `MODEL_PATH` wins, so a variant can be swapped in (OP-20)."""
+    override = os.environ.get("MODEL_PATH")
+    return Path(override) if override else DEFAULT_MODEL
+
+
+@pytest.fixture(scope="module")
+def backend() -> MediaPipeBackend:
+    path = model_path()
+    if not path.is_file():
+        pytest.skip(f"no model at {path} — run `make fetch-model`")
+    return MediaPipeBackend(path)
+
+
+def load(name: str) -> NDArray[np.uint8]:
+    import cv2
+
+    image = cv2.imread(str(FIXTURES / name))
+    if image is None:
+        pytest.skip(f"fixture {name} could not be decoded")
+    return image  # type: ignore[no-any-return]
+
+
+# The three seated side-view fixtures the whole project is calibrated against. Named explicitly
+# rather than globbed so that a fixture disappearing fails the test instead of shrinking it.
+SEATED_FIXTURES = ["hunchback_right.jpg", "reclined_right.jpg", "straight_armsfolded.jpg"]
+
+
+@pytest.mark.parametrize("fixture", SEATED_FIXTURES)
+def test_detects_a_confident_skeleton_on_real_photographs(
+    backend: MediaPipeBackend, fixture: str
+) -> None:
+    """25 of 34 landmarks above the visibility threshold, on a real seated subject.
+
+    The number is a floor, not a target: a side-on seated pose legitimately occludes one arm and
+    part of one leg. What it rules out is the failure mode where the model returns a full skeleton
+    of low-confidence guesses, which would look like success to any test that only counted keys.
+    """
+    frame = backend.detect(load(fixture))
+    assert frame is not None, f"no pose detected in {fixture}"
+    confident = [lm for lm in frame.landmarks.values() if lm.visibility >= VISIBILITY_THRESHOLD]
+    assert len(confident) >= 25, f"{fixture}: only {len(confident)} confident landmarks"
+
+
+def test_real_frames_carry_world_landmarks(backend: MediaPipeBackend) -> None:
+    """The entire reason for choosing this model (ADR-0002, ADR-0005).
+
+    Without metric 3D, every angular metric in Epic C goes back to image space with torso-length
+    normalisation — the problem the model switch was meant to dissolve. Worth asserting against
+    the real runtime, because no stub can tell you the runtime still populates this array.
+    """
+    frame = backend.detect(load(SEATED_FIXTURES[0]))
+    assert frame is not None
+    assert frame.has_world_landmarks is True
+
+
+def test_neck_is_derived_on_real_output(backend: MediaPipeBackend) -> None:
+    frame = backend.detect(load(SEATED_FIXTURES[0]))
+    assert frame is not None
+    assert KeypointName.NECK in frame
+
+
+def test_returns_none_on_an_image_with_no_person(backend: MediaPipeBackend) -> None:
+    """Flat grey: no person, and no exception either."""
+    blank = np.full((480, 640, 3), 128, dtype=np.uint8)
+    assert backend.detect(blank) is None
+
+
+def test_warmup_makes_the_first_real_inference_materially_faster(
+    backend: MediaPipeBackend,
+) -> None:
+    """Proves `warmup()` does what it claims, which is the only way to know it is worth calling.
+
+    MediaPipe builds its inference graph lazily, so the first `detect()` on a cold backend pays
+    for it. A fresh backend is constructed here rather than reusing the module-scoped one, which
+    other tests have already warmed.
+
+    Asserted as a ratio against the *cold* call rather than an absolute millisecond budget:
+    absolute latency varies by an order of magnitude between a laptop and a CI runner, and a
+    threshold that survives both would be too loose to mean anything.
+    """
+    cold = MediaPipeBackend(model_path())
+    first = _timed(cold, load(SEATED_FIXTURES[0]))
+    cold.warmup()
+    warmed = min(_timed(cold, load(SEATED_FIXTURES[0])) for _ in range(3))
+    assert warmed < first * 0.8, f"cold {first:.1f} ms vs warmed {warmed:.1f} ms"
+
+
+def _timed(backend: MediaPipeBackend, image: NDArray[np.uint8]) -> float:
+    frame: PoseFrame | None = backend.detect(image)
+    assert frame is not None
+    return frame.inference_ms

--- a/packages/pose-backends/tests/test_model_assets.py
+++ b/packages/pose-backends/tests/test_model_assets.py
@@ -1,0 +1,125 @@
+"""Checks on the model-acquisition contract itself.
+
+Most of these need no model file: they assert that the *pins* are well-formed and that the
+Makefile and the Python default agree about where weights live. Those are cheap and run on every
+pull request, because a checksum file the tooling cannot parse is a checksum file that silently
+verifies nothing — and that failure would only surface the day someone shipped a bad model.
+
+The one test that needs actual weights is marked `pytest.mark.model`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from pathlib import Path
+
+import pytest
+
+from pose_backends.registry import DEFAULT_MODEL_PATH, default_model_path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+CHECKSUMS = REPO_ROOT / "models" / "checksums.txt"
+MAKEFILE = REPO_ROOT / "Makefile"
+
+CHECKSUM_LINE = re.compile(r"^(?P<sha>[0-9a-f]{64})  (?P<name>\S+)$")
+
+
+def pins() -> dict[str, str]:
+    """Parse `checksums.txt` the same way the Makefile's grep does: filename -> sha256."""
+    parsed: dict[str, str] = {}
+    for line in CHECKSUMS.read_text().splitlines():
+        match = CHECKSUM_LINE.match(line)
+        if match:
+            parsed[match["name"]] = match["sha"]
+    return parsed
+
+
+def test_all_three_variants_are_pinned() -> None:
+    """lite, full and heavy. Documented as swappable, so all three must actually be fetchable."""
+    assert set(pins()) == {
+        "pose_landmarker_lite.task",
+        "pose_landmarker_full.task",
+        "pose_landmarker_heavy.task",
+    }
+
+
+def test_every_pin_is_a_full_length_sha256() -> None:
+    """A truncated hash is the failure this file exists to prevent, so it must not be possible
+    to write one here and have the tooling shrug."""
+    for name, sha in pins().items():
+        assert len(sha) == 64, name
+
+
+def test_the_python_default_and_the_makefile_target_are_the_same_file() -> None:
+    """Two places name the model path, and they must not drift.
+
+    `make fetch-model` writes to `models/pose_landmarker_$(MODEL_VARIANT).task`; the API loads
+    `DEFAULT_MODEL_PATH` when `MODEL_PATH` is unset. If those disagreed, fetching the model would
+    appear to work and the backend would still report the file missing.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "MODEL_VARIANT ?= full" in makefile
+    assert "MODEL_DIR     ?= models" in makefile
+    assert Path("models/pose_landmarker_full.task") == DEFAULT_MODEL_PATH
+
+
+def test_the_makefile_fetches_the_versioned_url_not_latest() -> None:
+    """`/1/` and `/latest/` are different files — four bytes apart, different hashes.
+
+    Pinning a checksum against a URL whose contents can be republished is a pin in name only. The
+    discrepancy is recorded in checksums.txt; this keeps the Makefile on the right side of it.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "/float16/1/" in makefile
+    assert "/float16/latest/" not in makefile
+
+
+def test_the_makefile_does_not_trust_shasum_check_mode() -> None:
+    """`shasum -c` exits 0 on a line it could not parse, so a typo'd pin would "pass".
+
+    Asserted rather than merely commented because the obvious "simplification" during a future
+    cleanup is to replace the explicit comparison with `shasum -c`, which would quietly remove
+    the guarantee while looking tidier.
+    """
+    makefile = MAKEFILE.read_text()
+    assert "shasum -a 256 -c" not in makefile
+    assert "-c $(CHECKSUMS)" not in makefile
+
+
+def test_model_path_environment_variable_overrides_the_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_PATH", "/opt/models/pose_landmarker_lite.task")
+    assert default_model_path() == Path("/opt/models/pose_landmarker_lite.task")
+
+
+def test_weights_are_not_committed() -> None:
+    """The legacy project committed a 209 MB `model.h5`, could not push it, and resorted to a
+    Dropbox link. `make fetch-model` plus a pinned hash is the replacement; a `.task` appearing in
+    the tree means someone bypassed it."""
+    ignored = (REPO_ROOT / ".gitignore").read_text()
+    assert "models/*.task" in ignored
+
+
+@pytest.mark.model
+def test_the_model_on_disk_matches_its_pin() -> None:
+    """The real integrity check, run by model-validation.yml before anything else (OP-21).
+
+    Reads in chunks rather than slurping: `heavy` is 29 MB and there is no reason to hold it all
+    in memory to hash it.
+    """
+    path = default_model_path()
+    if not path.is_absolute():
+        path = REPO_ROOT / path
+    if not path.is_file():
+        pytest.skip(f"no model at {path} — run `make fetch-model`")
+
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+
+    expected = pins().get(path.name)
+    assert expected is not None, f"{path.name} has no pinned checksum in {CHECKSUMS}"
+    assert digest.hexdigest() == expected

--- a/packages/pose-backends/tests/test_registry.py
+++ b/packages/pose-backends/tests/test_registry.py
@@ -1,0 +1,82 @@
+"""Backend selection from configuration.
+
+`POSE_BACKEND=fake` has to work as a deployment switch and not only as a test injection point:
+the container smoke test starts the real image and Playwright drives the real frontend, and
+neither can reach into a Python fixture to swap an object.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from pose_backends import (
+    FakePoseBackend,
+    ModelNotFoundError,
+    PoseBackendError,
+    PosePreset,
+    create_backend,
+    default_model_path,
+)
+from pose_backends.registry import DEFAULT_MODEL_PATH
+
+
+def test_explicit_name_selects_the_fake_backend() -> None:
+    backend = create_backend("fake")
+    assert isinstance(backend, FakePoseBackend)
+    assert backend.preset is PosePreset.STRAIGHT
+
+
+def test_environment_selects_the_backend(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSE_BACKEND", "fake")
+    assert isinstance(create_backend(), FakePoseBackend)
+
+
+def test_environment_selects_the_preset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("POSE_BACKEND", "fake")
+    monkeypatch.setenv("POSE_BACKEND_PRESET", "hunchback")
+    backend = create_backend()
+    assert isinstance(backend, FakePoseBackend)
+    assert backend.preset is PosePreset.HUNCHBACK
+
+
+@pytest.mark.parametrize("value", ["FAKE", " fake ", "Fake"])
+def test_backend_name_is_case_and_whitespace_tolerant(
+    value: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stray newline in a Compose env file should not silently start real inference."""
+    monkeypatch.setenv("POSE_BACKEND", value)
+    assert isinstance(create_backend(), FakePoseBackend)
+
+
+def test_the_real_backend_is_the_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A missing variable must yield real inference, never a fabricated skeleton.
+
+    Defaulting to the fake would mean a deployment that forgot to set the variable would serve
+    invented posture assessments and look perfectly healthy doing it. Asserted here through the
+    model-not-found error, because the real backend is what tries to load weights.
+    """
+    monkeypatch.delenv("POSE_BACKEND", raising=False)
+    with pytest.raises(ModelNotFoundError):
+        create_backend(model_path="/nonexistent/model.task")
+
+
+def test_unknown_backend_fails_loudly_and_lists_the_alternatives(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Silently falling back would ship an application that invents its results."""
+    monkeypatch.setenv("POSE_BACKEND", "movenet")
+    with pytest.raises(PoseBackendError, match="mediapipe, fake"):
+        create_backend()
+
+
+def test_model_path_defaults_to_the_fetch_model_location(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MODEL_PATH", raising=False)
+    assert default_model_path() == DEFAULT_MODEL_PATH
+
+
+def test_model_path_environment_override_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    """So a lite or heavy model variant can be swapped in without rebuilding the image (OP-20)."""
+    monkeypatch.setenv("MODEL_PATH", "/models/pose_landmarker_heavy.task")
+    assert default_model_path() == Path("/models/pose_landmarker_heavy.task")

--- a/packages/posture-core/src/posture_core/__init__.py
+++ b/packages/posture-core/src/posture_core/__init__.py
@@ -19,6 +19,8 @@ posture was fine whenever the system had failed to assess them at all.
 
 from __future__ import annotations
 
-__all__ = ["__version__"]
+from posture_core.keypoints import KeypointName, Landmark, PoseFrame
+
+__all__ = ["KeypointName", "Landmark", "PoseFrame", "__version__"]
 
 __version__ = "0.1.0"

--- a/packages/posture-core/src/posture_core/keypoints.py
+++ b/packages/posture-core/src/posture_core/keypoints.py
@@ -1,0 +1,222 @@
+"""The canonical skeleton: the vocabulary every other module in the project speaks.
+
+These types live in ``posture_core`` — the package that depends on nothing heavier than numpy —
+and *not* in ``pose_backends``, which is where the inference libraries live. That inversion is
+deliberate and it is the load-bearing idea of the whole architecture:
+
+    the rules engine defines the contract, and inference adapters conform to it
+
+Put the types next to MediaPipe instead and the dependency arrow flips. ``posture_core`` would
+then need an inference stack installed just to describe a shoulder, its test suite would need a
+model, and swapping backends would mean editing rules. Defining them here means a backend is a
+file you add and a file you delete.
+
+Nothing in this module knows that MediaPipe exists. ``KeypointName`` members are project-owned
+names, not MediaPipe indices and not COCO indices; the integer mapping is private to each adapter
+(see ``pose_backends/mediapipe_backend.py``). Rules code never sees a magic number — which is
+precisely how the legacy engine's ear-index inversion (FINDINGS §2.1) became possible.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import Iterator, Mapping
+from enum import StrEnum
+from types import MappingProxyType
+
+__all__ = ["KeypointName", "Landmark", "PoseFrame"]
+
+
+class KeypointName(StrEnum):
+    """Every point the canonical skeleton can carry.
+
+    A ``StrEnum`` rather than a plain ``Enum`` so members serialise to readable JSON without a
+    custom encoder — ``"left_shoulder"``, not ``"KeypointName.LEFT_SHOULDER"``. The CLI (OP-21),
+    the golden fixtures (OP-43) and the API response all get that for free.
+
+    The set is the 33 landmarks MediaPipe produces, plus :attr:`NECK`, which no backend provides
+    directly. Members a given backend cannot supply are simply *absent* from a
+    :class:`PoseFrame`'s mapping — absence is the honest representation, and it is what lets a
+    17-point backend (the ONNX MoveNet escape hatch in ADR-0002) conform to the same schema
+    without inventing coordinates it never measured.
+    """
+
+    # --- head -------------------------------------------------------------------------------
+    NOSE = "nose"
+    LEFT_EYE_INNER = "left_eye_inner"
+    LEFT_EYE = "left_eye"
+    LEFT_EYE_OUTER = "left_eye_outer"
+    RIGHT_EYE_INNER = "right_eye_inner"
+    RIGHT_EYE = "right_eye"
+    RIGHT_EYE_OUTER = "right_eye_outer"
+    LEFT_EAR = "left_ear"
+    RIGHT_EAR = "right_ear"
+    MOUTH_LEFT = "mouth_left"
+    MOUTH_RIGHT = "mouth_right"
+
+    # --- upper body -------------------------------------------------------------------------
+    LEFT_SHOULDER = "left_shoulder"
+    RIGHT_SHOULDER = "right_shoulder"
+    LEFT_ELBOW = "left_elbow"
+    RIGHT_ELBOW = "right_elbow"
+    LEFT_WRIST = "left_wrist"
+    RIGHT_WRIST = "right_wrist"
+    LEFT_PINKY = "left_pinky"
+    RIGHT_PINKY = "right_pinky"
+    LEFT_INDEX = "left_index"
+    RIGHT_INDEX = "right_index"
+    LEFT_THUMB = "left_thumb"
+    RIGHT_THUMB = "right_thumb"
+
+    # --- lower body -------------------------------------------------------------------------
+    LEFT_HIP = "left_hip"
+    RIGHT_HIP = "right_hip"
+    LEFT_KNEE = "left_knee"
+    RIGHT_KNEE = "right_knee"
+    LEFT_ANKLE = "left_ankle"
+    RIGHT_ANKLE = "right_ankle"
+    LEFT_HEEL = "left_heel"
+    RIGHT_HEEL = "right_heel"
+    LEFT_FOOT_INDEX = "left_foot_index"
+    RIGHT_FOOT_INDEX = "right_foot_index"
+
+    # --- derived ----------------------------------------------------------------------------
+    NECK = "neck"
+    """Midpoint of the two shoulders. **Derived in the adapter, never in a rule.**
+
+    MediaPipe has no neck landmark, and neither did the legacy engine really: COCO keypoint 1 was
+    itself synthesised from the two shoulders. Deriving it once, in the adapter, is what makes
+    every backend present the same skeleton — and making the derivation explicit is what exposed
+    FINDINGS §2.2, where ``evaluate_neck_posture`` compared the shoulder midpoint's *y* against
+    the shoulder midpoint's *y* and could therefore only ever return one answer.
+    """
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Landmark:
+    """One measured point on the body.
+
+    Two coordinate systems, and the difference between them is the reason this project changed
+    models at all (ADR-0002, ADR-0005):
+
+    * :attr:`x` / :attr:`y` are **image space**, normalised to the frame's width and height. Good
+      for drawing an overlay; useless for a threshold, because the same posture photographed from
+      twice the distance produces half the pixel distances. That is FINDINGS §2.6 — the legacy
+      engine's central defect.
+    * :attr:`x_world` / :attr:`y_world` / :attr:`z_world` are **metres**, origin at the hip
+      midpoint. An angle computed from these is invariant to resolution and subject distance by
+      construction, so scale invariance stops being a normalisation problem and becomes a choice
+      of coordinate system.
+
+    Normalised coordinates are deliberately **not** range-validated. MediaPipe emits values
+    outside ``[0, 1]`` for joints it has extrapolated past the frame edge, and that is real
+    information — clamping or rejecting it here would destroy the signal the ``OUT_OF_FRAME``
+    keypoint status (OP-25) is built on.
+    """
+
+    x: float
+    """Horizontal position in image space, normalised by frame width. May fall outside [0, 1]."""
+
+    y: float
+    """Vertical position in image space, normalised by frame height, origin top-left."""
+
+    visibility: float
+    """[0, 1] — confidence the point is *visible*, i.e. not occluded by the body or an object."""
+
+    presence: float
+    """[0, 1] — confidence the point is *in frame at all*.
+
+    Independent of :attr:`visibility`, and the pairing is the point: low visibility with high
+    presence means occluded, low presence means out of frame. The legacy engine had no confidence
+    signal whatsoever, which is why a failed assessment surfaced as "Straight back position"
+    (FINDINGS §2.5) rather than as an honest "I could not see your knees".
+    """
+
+    x_world: float | None = None
+    """Metres, hip-midpoint origin. ``None`` on backends that produce no metric 3D."""
+
+    y_world: float | None = None
+    z_world: float | None = None
+
+    def __post_init__(self) -> None:
+        # World coordinates are all-or-nothing. A backend either reconstructs metric 3D or it does
+        # not; a half-populated triple could only come from an adapter bug, and letting it through
+        # would surface much later as a nonsensical angle rather than as an obviously bad frame.
+        world = (self.x_world, self.y_world, self.z_world)
+        if any(c is None for c in world) and any(c is not None for c in world):
+            raise ValueError(
+                "world coordinates must be all present or all absent, "
+                f"got x_world={self.x_world!r}, y_world={self.y_world!r}, "
+                f"z_world={self.z_world!r}"
+            )
+
+    @property
+    def has_world(self) -> bool:
+        """Whether this landmark carries metric 3D, and so whether world-space rules may use it."""
+        return self.x_world is not None
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PoseFrame:
+    """One person's skeleton, detected in one image, by one backend.
+
+    This is the entire surface between inference and rules. Everything downstream — metrics,
+    findings, the report, the API response, the canvas overlay — is a pure function of a
+    ``PoseFrame``, which is what lets the rules engine be tested with hand-built skeletons and no
+    model installed (OP-33, OP-40).
+
+    :attr:`backend` and :attr:`inference_ms` travel *with* the data rather than being logged
+    beside it, so a stored report can always answer "which engine produced this, and how long did
+    it take" — the raw material for the legacy-vs-new comparison in ``docs/evaluation.md``.
+    """
+
+    landmarks: Mapping[KeypointName, Landmark]
+    """Detected points only.
+
+    A missing key means "this backend did not report this point", never "confidence zero". Callers
+    must handle absence; :meth:`get` and ``in`` are the intended way to do it.
+    """
+
+    image_width: int
+    image_height: int
+    backend: str
+    """Identifier of the adapter that produced this frame, e.g. ``"mediapipe"`` or ``"fake"``."""
+
+    inference_ms: float
+    """Wall-clock time spent inside ``detect()``, for the CLI table and latency diagnostics."""
+
+    def __post_init__(self) -> None:
+        # A frozen dataclass freezes the *attribute binding*, not the object bound to it — without
+        # this, `frame.landmarks[NECK] = ...` would mutate a "frozen" frame quite happily. Copying
+        # into a MappingProxyType makes the mapping genuinely read-only and detaches it from the
+        # dict the adapter built, which the adapter is otherwise free to keep mutating.
+        object.__setattr__(self, "landmarks", MappingProxyType(dict(self.landmarks)))
+
+        if self.image_width <= 0 or self.image_height <= 0:
+            raise ValueError(
+                f"image dimensions must be positive, got {self.image_width}x{self.image_height}"
+            )
+
+    def get(self, name: KeypointName) -> Landmark | None:
+        """The landmark for ``name``, or ``None`` if this backend did not report it."""
+        return self.landmarks.get(name)
+
+    def __contains__(self, name: KeypointName) -> bool:
+        return name in self.landmarks
+
+    def __iter__(self) -> Iterator[KeypointName]:
+        return iter(self.landmarks)
+
+    def __len__(self) -> int:
+        return len(self.landmarks)
+
+    @property
+    def has_world_landmarks(self) -> bool:
+        """Whether every reported landmark carries metric 3D.
+
+        The switch ADR-0005 turns on: ``True`` means angular metrics may be computed in world
+        space and are scale-invariant for free; ``False`` means falling back to image space with
+        torso-length normalisation, with the accuracy loss that implies. An empty frame is
+        ``False`` — no evidence is not evidence of world coordinates.
+        """
+        return bool(self.landmarks) and all(lm.has_world for lm in self.landmarks.values())

--- a/packages/posture-core/src/posture_core/synthetic.py
+++ b/packages/posture-core/src/posture_core/synthetic.py
@@ -1,0 +1,410 @@
+"""Analytic stick-figure construction: skeletons built from angles rather than from photographs.
+
+## Why this is shipped code and not a test helper
+
+Two very different consumers need to build the same synthetic poses:
+
+* ``FakePoseBackend`` (OP-19), which is *production* code — it is what lets the whole application
+  run with ``POSE_BACKEND=fake``, so the container smoke test and the Playwright suite need no
+  model weights and no secrets. That is the single reason CI stays fast.
+* the rules-engine tests in Epic C (OP-33), which assert things like
+  ``metric(make_pose(trunk_deg=35)).value == approx(35, abs=1.0)``.
+
+If those two built their figures separately they would drift, and the day they drifted every
+end-to-end assertion resting on a fake pose would quietly stop meaning anything. One builder, in
+the package both already depend on.
+
+It also inverts the usual test-fixture problem. A metric tested against a photograph can only be
+checked against a human's guess at the true angle; a metric tested against a figure *constructed*
+at 35° has a known-correct answer. The tests become statements about geometry rather than about
+someone's eyeballing of a JPEG.
+
+## The coordinate system
+
+Matches what MediaPipe's world landmarks provide, because that is what the real backend emits:
+metres, **hip midpoint at the origin**, ``x`` to the image right, ``y`` **down**, ``z`` depth.
+Image-space coordinates are an orthographic projection of the same figure — the depth axis is
+simply dropped, which is exactly what a camera does to a subject much further away than they are
+deep.
+
+Everything is pure: no randomness, no clock, no I/O. The same arguments produce byte-identical
+output forever, which is what ``FakePoseBackend``'s stability guarantee rests on.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final, TypeAlias
+
+from posture_core.keypoints import KeypointName, Landmark, PoseFrame
+
+__all__ = [
+    "Anthropometry",
+    "Facing",
+    "View",
+    "make_pose",
+    "make_pose_frame",
+]
+
+Vec3: TypeAlias = tuple[float, float, float]
+
+
+class Facing(StrEnum):
+    """Which way the subject's front points, for a lateral view."""
+
+    RIGHT = "right"
+    LEFT = "left"
+
+
+class View(StrEnum):
+    """Camera position relative to the subject.
+
+    The distinction is not cosmetic. In :attr:`LATERAL` the subject's shoulder separation runs
+    along the depth axis, so the *image* shows almost no shoulder width and a forward lean is
+    plainly visible. In :attr:`FRONTAL` the two swap: shoulders are wide on screen and the lean
+    disappears into depth.
+
+    That ratio — shoulder width against torso length, in image space — is precisely what
+    ``view_confidence`` (OP-31) measures, and this enum is what lets it be tested. The original
+    app *told* users to photograph themselves from the side and then never checked.
+    """
+
+    LATERAL = "lateral"
+    FRONTAL = "frontal"
+
+
+@dataclass(frozen=True, slots=True)
+class Anthropometry:
+    """Segment lengths in metres, roughly a 50th-percentile adult.
+
+    Injected rather than hardcoded so a test can shrink or stretch the figure and assert that an
+    angular metric does not move — the scale-invariance property (OP-34) that the original engine
+    would fail catastrophically, since its thresholds were raw pixel counts.
+    """
+
+    torso: float = 0.50
+    """Hip midpoint to shoulder midpoint."""
+
+    neck: float = 0.24
+    """Shoulder midpoint to the centre of the head."""
+
+    shoulder_width: float = 0.38
+    hip_width: float = 0.30
+    head_width: float = 0.16
+    upper_arm: float = 0.30
+    forearm: float = 0.27
+    hand: float = 0.09
+    thigh: float = 0.42
+    shank: float = 0.42
+    foot: float = 0.16
+    heel_drop: float = 0.05
+    """How far the heel sits below the ankle."""
+
+
+# Where the hip midpoint lands in the frame, and how large the figure is drawn. Chosen so a
+# seated figure fits comfortably at any common aspect ratio; nothing downstream depends on the
+# exact numbers, because every metric is either angular or normalised.
+_HIP_X_FRACTION: Final = 0.4
+_HIP_Y_FRACTION: Final = 0.62
+_FRAME_HEIGHTS_PER_METRE: Final = 0.42
+
+
+def _add(*vectors: Vec3) -> Vec3:
+    return (
+        sum(v[0] for v in vectors),
+        sum(v[1] for v in vectors),
+        sum(v[2] for v in vectors),
+    )
+
+
+def _scale(vector: Vec3, factor: float) -> Vec3:
+    return (vector[0] * factor, vector[1] * factor, vector[2] * factor)
+
+
+def _cross(a: Vec3, b: Vec3) -> Vec3:
+    return (
+        a[1] * b[2] - a[2] * b[1],
+        a[2] * b[0] - a[0] * b[2],
+        a[0] * b[1] - a[1] * b[0],
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class _Frame:
+    """The subject's own axes, from which every segment direction is built."""
+
+    up: Vec3
+    forward: Vec3
+    left: Vec3
+
+    def from_vertical_down(self, degrees: float) -> Vec3:
+        """Unit direction ``degrees`` from straight down, rotating toward :attr:`forward`.
+
+        The natural way to describe a limb: 0° is a leg hanging straight down, 90° is a thigh
+        held horizontally forward, as in sitting.
+        """
+        radians = math.radians(degrees)
+        return _add(
+            _scale(self.up, -math.cos(radians)),
+            _scale(self.forward, math.sin(radians)),
+        )
+
+    def from_vertical_up(self, degrees: float) -> Vec3:
+        """Unit direction ``degrees`` from straight up, rotating toward :attr:`forward`.
+
+        The natural way to describe the trunk: 0° is upright, positive is leaning forward — which
+        is also the sign convention ``trunk_inclination_deg`` (OP-26) reports.
+        """
+        radians = math.radians(degrees)
+        return _add(
+            _scale(self.up, math.cos(radians)),
+            _scale(self.forward, math.sin(radians)),
+        )
+
+
+def _axes(facing: Facing, view: View) -> _Frame:
+    """Build the subject's axes.
+
+    ``up`` is ``(0, -1, 0)`` because the coordinate system is y-**down**, matching MediaPipe.
+    ``left = cross(up, forward)`` keeps the basis right-handed, which is what makes a single set of
+    segment formulas work for both camera positions: in a lateral view ``left`` comes out along
+    the depth axis, in a frontal view it comes out along the image's horizontal axis. No branching
+    inside the construction itself.
+    """
+    up: Vec3 = (0.0, -1.0, 0.0)
+    if view is View.FRONTAL:
+        # Facing the camera. "Forward" is out of the screen, so a forward lean is a change in
+        # depth and is nearly invisible in the projected image — the whole point of the preset.
+        forward: Vec3 = (0.0, 0.0, -1.0)
+    else:
+        forward = (1.0, 0.0, 0.0) if facing is Facing.RIGHT else (-1.0, 0.0, 0.0)
+    return _Frame(up=up, forward=forward, left=_cross(up, forward))
+
+
+# Keyword-only throughout, and there are a lot of them: a stick figure genuinely has this many
+# joints, and `make_pose(trunk_deg=35)` at a call site is worth more than a config object that
+# would just move the same parameter list somewhere less discoverable.
+def make_pose(
+    *,
+    trunk_deg: float = 0.0,
+    neck_deg: float = 0.0,
+    thigh_deg: float = 0.0,
+    shank_deg: float = 0.0,
+    upper_arm_deg: float = 0.0,
+    forearm_deg: float = 0.0,
+    facing: Facing = Facing.RIGHT,
+    view: View = View.LATERAL,
+    image_width: int = 640,
+    image_height: int = 480,
+    visibility: float = 0.95,
+    presence: float = 0.98,
+    confidence: Mapping[KeypointName, tuple[float, float]] | None = None,
+    omit: Iterable[KeypointName] = (),
+    body: Anthropometry | None = None,
+) -> dict[KeypointName, Landmark]:
+    """Construct a complete canonical skeleton from joint angles.
+
+    All angles are degrees in the sagittal plane. Limb angles (``thigh_deg``, ``shank_deg``,
+    ``upper_arm_deg``, ``forearm_deg``) are measured from **straight down**; ``trunk_deg`` and
+    ``neck_deg`` from **straight up**, positive forward.
+
+    Joint *flexion* is therefore emergent rather than an input — knee flexion is
+    ``180 - |thigh_deg - shank_deg|``. That is deliberate: it means the figure is always
+    physically consistent, whereas taking flexion as an input would let a caller specify a knee
+    angle and a shin direction that contradict each other.
+
+    :param confidence: per-keypoint ``(visibility, presence)`` overrides. The two are independent
+        signals — low visibility with high presence is *occluded*, low presence is *out of frame*
+        — so a preset can express "the far arm is behind the torso" distinctly from "the legs are
+        outside the shot".
+    :param omit: keypoints to leave out entirely, for degradation tests. Absence is not the same
+        as zero confidence and the two must stay distinguishable.
+    """
+    body = body if body is not None else Anthropometry()
+    axes = _axes(facing, view)
+    dropped = frozenset(omit)
+
+    half_shoulder = _scale(axes.left, body.shoulder_width / 2)
+    half_hip = _scale(axes.left, body.hip_width / 2)
+    half_head = _scale(axes.left, body.head_width / 2)
+
+    # The hip midpoint is the origin — the same convention MediaPipe's world landmarks use.
+    hip_mid: Vec3 = (0.0, 0.0, 0.0)
+    shoulder_mid = _scale(axes.from_vertical_up(trunk_deg), body.torso)
+    head_mid = _add(shoulder_mid, _scale(axes.from_vertical_up(trunk_deg + neck_deg), body.neck))
+
+    points: dict[KeypointName, Vec3] = {}
+
+    def place(name: KeypointName, position: Vec3) -> None:
+        if name not in dropped:
+            points[name] = position
+
+    # --- torso ------------------------------------------------------------------------------
+    place(KeypointName.LEFT_HIP, _add(hip_mid, half_hip))
+    place(KeypointName.RIGHT_HIP, _add(hip_mid, _scale(half_hip, -1)))
+    place(KeypointName.LEFT_SHOULDER, _add(shoulder_mid, half_shoulder))
+    place(KeypointName.RIGHT_SHOULDER, _add(shoulder_mid, _scale(half_shoulder, -1)))
+    # NECK is the shoulder midpoint by definition — the same derivation MediaPipeBackend applies,
+    # so a fake frame and a real one describe the neck identically (ADR-0002).
+    place(KeypointName.NECK, shoulder_mid)
+
+    # --- head -------------------------------------------------------------------------------
+    face = axes.forward
+    place(KeypointName.LEFT_EAR, _add(head_mid, half_head))
+    place(KeypointName.RIGHT_EAR, _add(head_mid, _scale(half_head, -1)))
+    nose = _add(head_mid, _scale(face, body.head_width * 0.9))
+    place(KeypointName.NOSE, nose)
+    for name, lateral, forward_frac, rise in (
+        (KeypointName.LEFT_EYE_INNER, 0.15, 0.55, 0.25),
+        (KeypointName.LEFT_EYE, 0.30, 0.55, 0.25),
+        (KeypointName.LEFT_EYE_OUTER, 0.45, 0.50, 0.25),
+        (KeypointName.RIGHT_EYE_INNER, -0.15, 0.55, 0.25),
+        (KeypointName.RIGHT_EYE, -0.30, 0.55, 0.25),
+        (KeypointName.RIGHT_EYE_OUTER, -0.45, 0.50, 0.25),
+        (KeypointName.MOUTH_LEFT, 0.20, 0.80, -0.25),
+        (KeypointName.MOUTH_RIGHT, -0.20, 0.80, -0.25),
+    ):
+        place(
+            name,
+            _add(
+                head_mid,
+                _scale(axes.left, body.head_width * lateral),
+                _scale(face, body.head_width * forward_frac),
+                _scale(axes.up, body.head_width * rise),
+            ),
+        )
+
+    # --- arms -------------------------------------------------------------------------------
+    upper_arm = _scale(axes.from_vertical_down(upper_arm_deg), body.upper_arm)
+    forearm = _scale(axes.from_vertical_down(forearm_deg), body.forearm)
+    for side, elbow_name, wrist_name, hand_names in (
+        (
+            1,
+            KeypointName.LEFT_ELBOW,
+            KeypointName.LEFT_WRIST,
+            (KeypointName.LEFT_PINKY, KeypointName.LEFT_INDEX, KeypointName.LEFT_THUMB),
+        ),
+        (
+            -1,
+            KeypointName.RIGHT_ELBOW,
+            KeypointName.RIGHT_WRIST,
+            (KeypointName.RIGHT_PINKY, KeypointName.RIGHT_INDEX, KeypointName.RIGHT_THUMB),
+        ),
+    ):
+        shoulder = _add(shoulder_mid, _scale(half_shoulder, side))
+        elbow = _add(shoulder, upper_arm)
+        wrist = _add(elbow, forearm)
+        place(elbow_name, elbow)
+        place(wrist_name, wrist)
+        pinky, index, thumb = hand_names
+        hand_direction = _scale(axes.from_vertical_down(forearm_deg), body.hand)
+        place(pinky, _add(wrist, hand_direction, _scale(axes.left, side * 0.02)))
+        place(index, _add(wrist, hand_direction, _scale(axes.left, -side * 0.02)))
+        place(thumb, _add(wrist, _scale(hand_direction, 0.6), _scale(face, 0.03)))
+
+    # --- legs -------------------------------------------------------------------------------
+    thigh = _scale(axes.from_vertical_down(thigh_deg), body.thigh)
+    shank = _scale(axes.from_vertical_down(shank_deg), body.shank)
+    for side, knee_name, ankle_name, heel_name, toe_name in (
+        (
+            1,
+            KeypointName.LEFT_KNEE,
+            KeypointName.LEFT_ANKLE,
+            KeypointName.LEFT_HEEL,
+            KeypointName.LEFT_FOOT_INDEX,
+        ),
+        (
+            -1,
+            KeypointName.RIGHT_KNEE,
+            KeypointName.RIGHT_ANKLE,
+            KeypointName.RIGHT_HEEL,
+            KeypointName.RIGHT_FOOT_INDEX,
+        ),
+    ):
+        hip = _add(hip_mid, _scale(half_hip, side))
+        knee = _add(hip, thigh)
+        ankle = _add(knee, shank)
+        place(knee_name, knee)
+        place(ankle_name, ankle)
+        # The foot is modelled flat: heel behind and below the ankle, toe ahead and below. That is
+        # enough for `heel_contact` (OP-30) to be a real measurement — the capability the original
+        # project listed as a goal and never delivered, because COCO-18 has no foot landmarks.
+        place(
+            heel_name,
+            _add(ankle, _scale(face, -body.foot * 0.25), _scale(axes.up, -body.heel_drop)),
+        )
+        place(
+            toe_name,
+            _add(ankle, _scale(face, body.foot), _scale(axes.up, -body.heel_drop)),
+        )
+
+    return _project(
+        points,
+        image_width=image_width,
+        image_height=image_height,
+        visibility=visibility,
+        presence=presence,
+        confidence=confidence or {},
+    )
+
+
+def _project(
+    points: Mapping[KeypointName, Vec3],
+    *,
+    image_width: int,
+    image_height: int,
+    visibility: float,
+    presence: float,
+    confidence: Mapping[KeypointName, tuple[float, float]],
+) -> dict[KeypointName, Landmark]:
+    """World metres -> canonical landmarks carrying both coordinate systems.
+
+    Orthographic: the depth axis is dropped rather than divided through. A real camera's
+    perspective divide matters when the subject's depth is comparable to their distance from the
+    lens, which is not the case for someone photographed at desk range — and modelling it would
+    make the figure's *known* angles no longer recoverable from the image, defeating the purpose.
+    """
+    scale = image_height * _FRAME_HEIGHTS_PER_METRE
+    origin_x = image_width * _HIP_X_FRACTION
+    origin_y = image_height * _HIP_Y_FRACTION
+
+    landmarks: dict[KeypointName, Landmark] = {}
+    for name, (world_x, world_y, world_z) in points.items():
+        point_visibility, point_presence = confidence.get(name, (visibility, presence))
+        landmarks[name] = Landmark(
+            x=(origin_x + world_x * scale) / image_width,
+            y=(origin_y + world_y * scale) / image_height,
+            visibility=point_visibility,
+            presence=point_presence,
+            x_world=world_x,
+            y_world=world_y,
+            z_world=world_z,
+        )
+    return landmarks
+
+
+def make_pose_frame(
+    *,
+    backend: str = "synthetic",
+    inference_ms: float = 0.0,
+    image_width: int = 640,
+    image_height: int = 480,
+    **pose_kwargs: object,
+) -> PoseFrame:
+    """:func:`make_pose`, wrapped in a :class:`~posture_core.PoseFrame`.
+
+    ``inference_ms`` defaults to exactly ``0.0`` rather than being measured. A synthetic frame has
+    no inference to time, and a real measurement would make otherwise-identical frames differ
+    between runs — which would break the byte-identical guarantee that end-to-end snapshot
+    assertions depend on.
+    """
+    return PoseFrame(
+        landmarks=make_pose(image_width=image_width, image_height=image_height, **pose_kwargs),  # type: ignore[arg-type]
+        image_width=image_width,
+        image_height=image_height,
+        backend=backend,
+        inference_ms=inference_ms,
+    )

--- a/packages/posture-core/tests/test_keypoints.py
+++ b/packages/posture-core/tests/test_keypoints.py
@@ -1,0 +1,237 @@
+"""Tests for the canonical skeleton types.
+
+These are cheap tests of a cheap module, and worth writing anyway: every metric, every rule and
+every API response is built on these three types, so an invariant that leaks here is one that
+leaks everywhere. In particular the immutability tests below guard something a reader would
+reasonably assume `frozen=True` already gave them, and which it does not.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+from posture_core import KeypointName, Landmark, PoseFrame
+
+
+def make_landmark(**overrides: float | None) -> Landmark:
+    defaults: dict[str, float | None] = {"x": 0.5, "y": 0.5, "visibility": 0.9, "presence": 0.9}
+    defaults.update(overrides)
+    return Landmark(**defaults)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------------------------
+# KeypointName
+# ---------------------------------------------------------------------------------------------
+
+
+def test_covers_all_33_mediapipe_landmarks_plus_derived_neck() -> None:
+    """The count is the contract OP-18 and OP-21 are written against.
+
+    MediaPipe reports 33 points; NECK is derived by the adapter and brings the canonical skeleton
+    to 34. The CLI's landmark table and the adapter's "25 or more landmarks detected" acceptance
+    criterion both assume this, so pinning the number here makes an accidental addition or
+    deletion a test failure rather than a puzzling off-by-one in a downstream assertion.
+    """
+    assert len(KeypointName) == 34
+
+
+def test_members_serialise_as_readable_strings() -> None:
+    """StrEnum, so JSON needs no custom encoder. The CLI and golden fixtures depend on this.
+
+    `str(member)` rather than `member == "..."`: mypy --strict rejects the direct comparison as
+    non-overlapping even though StrEnum makes it true at runtime. Asserting on the rendered string
+    is the property that actually matters anyway — it is what lands in JSON.
+    """
+    assert str(KeypointName.LEFT_SHOULDER) == "left_shoulder"
+    assert f"{KeypointName.NECK}" == "neck"
+    assert json.dumps([KeypointName.NECK]) == '["neck"]'
+
+
+def test_values_are_unique() -> None:
+    """Two names sharing a value would silently alias — StrEnum resolves the second to the first.
+
+    That is not hypothetical here: the members are hand-written and several differ by one word.
+    A duplicated value would make one keypoint permanently unreachable with no error anywhere.
+    """
+    assert len({member.value for member in KeypointName}) == len(KeypointName)
+
+
+def test_laterality_is_symmetric() -> None:
+    """Every LEFT_* has a RIGHT_* twin and vice versa.
+
+    Worth asserting because the legacy engine's defining bug was a laterality mix-up: `API/config`
+    declared 16=left ear, the code commented it the other way round, and the resulting flag made
+    spine classification backwards for one facing direction (FINDINGS §2.1). Named landmarks make
+    that class of bug impossible — provided the names themselves are complete.
+    """
+    left = {name.value.removeprefix("left_") for name in KeypointName if name.startswith("left_")}
+    right = {
+        name.value.removeprefix("right_") for name in KeypointName if name.startswith("right_")
+    }
+    assert left == right
+
+
+# ---------------------------------------------------------------------------------------------
+# Landmark
+# ---------------------------------------------------------------------------------------------
+
+
+def test_landmark_is_immutable() -> None:
+    landmark = make_landmark()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        landmark.x = 0.1  # type: ignore[misc]
+
+
+def test_landmark_uses_slots() -> None:
+    """No `__dict__`: a typo'd attribute cannot be silently attached to an instance.
+
+    There is one Landmark per keypoint per frame — 34 per detection — so the memory saving is
+    real, but the typo-catching is the reason. Asserting on `__dict__`'s absence rather than
+    trying an assignment because on a `frozen=True, slots=True` dataclass an unknown attribute
+    raises from the frozen `__setattr__` first, which would make this test pass for the wrong
+    reason on a class that had slots removed.
+    """
+    assert not hasattr(make_landmark(), "__dict__")
+    assert Landmark.__slots__ == (
+        "x",
+        "y",
+        "visibility",
+        "presence",
+        "x_world",
+        "y_world",
+        "z_world",
+    )
+
+
+def test_world_coordinates_default_to_absent() -> None:
+    landmark = make_landmark()
+    assert landmark.has_world is False
+    assert (landmark.x_world, landmark.y_world, landmark.z_world) == (None, None, None)
+
+
+def test_world_coordinates_are_recognised_when_present() -> None:
+    landmark = make_landmark(x_world=0.1, y_world=-0.4, z_world=0.02)
+    assert landmark.has_world is True
+
+
+@pytest.mark.parametrize(
+    "partial",
+    [
+        {"x_world": 0.1},
+        {"x_world": 0.1, "y_world": 0.2},
+        {"z_world": 0.3},
+        {"y_world": 0.2, "z_world": 0.3},
+    ],
+)
+def test_partial_world_coordinates_are_rejected(partial: dict[str, float]) -> None:
+    """All-or-nothing: a backend either reconstructs metric 3D or it does not.
+
+    A half-populated triple can only be an adapter bug, and if it were allowed through it would
+    surface much later as a nonsensical angle rather than as an obviously malformed frame.
+    """
+    with pytest.raises(ValueError, match="all present or all absent"):
+        make_landmark(**partial)
+
+
+@pytest.mark.parametrize("coordinate", [-0.2, 1.4])
+def test_out_of_frame_coordinates_are_allowed(coordinate: float) -> None:
+    """Deliberately not range-validated.
+
+    MediaPipe extrapolates joints past the frame edge and reports normalised values outside
+    [0, 1]. That is real information — it is the evidence the OUT_OF_FRAME keypoint status (OP-25)
+    is built on — so clamping or rejecting it here would destroy the signal.
+    """
+    assert make_landmark(x=coordinate).x == coordinate
+
+
+# ---------------------------------------------------------------------------------------------
+# PoseFrame
+# ---------------------------------------------------------------------------------------------
+
+
+def make_frame(
+    landmarks: dict[KeypointName, Landmark] | None = None, **overrides: object
+) -> PoseFrame:
+    kwargs: dict[str, object] = {
+        "landmarks": landmarks if landmarks is not None else {KeypointName.NOSE: make_landmark()},
+        "image_width": 640,
+        "image_height": 480,
+        "backend": "test",
+        "inference_ms": 1.5,
+    }
+    kwargs.update(overrides)
+    return PoseFrame(**kwargs)  # type: ignore[arg-type]
+
+
+def test_frame_is_immutable() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        make_frame().backend = "other"  # type: ignore[misc]
+
+
+def test_landmark_mapping_cannot_be_mutated_through_the_frame() -> None:
+    """The one that `frozen=True` does *not* give you.
+
+    Freezing a dataclass freezes the attribute *binding*, not the object bound to it — so without
+    the MappingProxyType wrapper in `__post_init__`, `frame.landmarks[NECK] = ...` would mutate a
+    supposedly frozen frame without complaint.
+    """
+    frame = make_frame()
+    with pytest.raises(TypeError):
+        frame.landmarks[KeypointName.NECK] = make_landmark()  # type: ignore[index]
+
+
+def test_frame_is_detached_from_the_dict_it_was_built_from() -> None:
+    """An adapter reusing its scratch dict between calls must not retroactively edit past frames."""
+    scratch = {KeypointName.NOSE: make_landmark()}
+    frame = make_frame(scratch)
+    scratch[KeypointName.LEFT_EAR] = make_landmark()
+    assert KeypointName.LEFT_EAR not in frame
+    assert len(frame) == 1
+
+
+@pytest.mark.parametrize(("width", "height"), [(0, 480), (640, 0), (-1, 480), (640, -1)])
+def test_non_positive_image_dimensions_are_rejected(width: int, height: int) -> None:
+    """Guards a divide-by-zero in every image-space normalisation downstream."""
+    with pytest.raises(ValueError, match="dimensions must be positive"):
+        make_frame(image_width=width, image_height=height)
+
+
+def test_missing_landmark_reads_as_absent_not_as_zero_confidence() -> None:
+    """Absence and low confidence are different facts and must stay distinguishable.
+
+    Collapsing them is how you end up asserting on a keypoint the backend never reported.
+    """
+    frame = make_frame({KeypointName.NOSE: make_landmark()})
+    assert frame.get(KeypointName.LEFT_KNEE) is None
+    assert KeypointName.LEFT_KNEE not in frame
+    assert frame.get(KeypointName.NOSE) is not None
+
+
+def test_frame_is_iterable_over_reported_keypoints() -> None:
+    frame = make_frame({KeypointName.NOSE: make_landmark(), KeypointName.NECK: make_landmark()})
+    assert set(frame) == {KeypointName.NOSE, KeypointName.NECK}
+    assert len(frame) == 2
+
+
+def test_has_world_landmarks_requires_every_reported_point_to_carry_metric_3d() -> None:
+    """The ADR-0005 switch: world-space geometry, or image space with torso normalisation.
+
+    A partially-world frame must read as False. Answering True would let a metric silently mix
+    metres and normalised pixels in one calculation.
+    """
+    world = make_landmark(x_world=0.0, y_world=0.0, z_world=0.0)
+    assert make_frame({KeypointName.NOSE: world}).has_world_landmarks is True
+    assert (
+        make_frame(
+            {KeypointName.NOSE: world, KeypointName.NECK: make_landmark()}
+        ).has_world_landmarks
+        is False
+    )
+
+
+def test_empty_frame_has_no_world_landmarks() -> None:
+    """`all()` over nothing is True, which would be exactly the wrong answer here."""
+    assert make_frame({}).has_world_landmarks is False

--- a/packages/posture-core/tests/test_synthetic.py
+++ b/packages/posture-core/tests/test_synthetic.py
@@ -1,0 +1,247 @@
+"""Tests for the analytic stick-figure builder.
+
+The builder is the thing the *rest* of the test suite will measure against, so it has to be
+correct on its own terms first. A metric asserted to read 35° against a figure that was not
+actually built at 35° proves nothing about the metric.
+
+The recovery helpers below deliberately reimplement the trigonometry from scratch rather than
+importing anything from Epic C. Checking a builder with the code that will be tested using the
+builder is circular; independent arithmetic is the point.
+"""
+
+from __future__ import annotations
+
+import math
+
+import pytest
+
+from posture_core import KeypointName, Landmark
+from posture_core.synthetic import Anthropometry, Facing, View, make_pose, make_pose_frame
+
+Pose = dict[KeypointName, Landmark]
+
+
+def world(landmark: Landmark) -> tuple[float, float, float]:
+    assert landmark.x_world is not None
+    assert landmark.y_world is not None
+    assert landmark.z_world is not None
+    return landmark.x_world, landmark.y_world, landmark.z_world
+
+
+def midpoint_world(pose: Pose, a: KeypointName, b: KeypointName) -> tuple[float, float, float]:
+    left, right = world(pose[a]), world(pose[b])
+    return tuple((left[i] + right[i]) / 2 for i in range(3))  # type: ignore[return-value]
+
+
+def trunk_angle(pose: Pose) -> float:
+    """Signed angle of hip-mid -> shoulder-mid away from straight up, positive forward."""
+    hip = midpoint_world(pose, KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    shoulder = midpoint_world(pose, KeypointName.LEFT_SHOULDER, KeypointName.RIGHT_SHOULDER)
+    return math.degrees(math.atan2(shoulder[0] - hip[0], -(shoulder[1] - hip[1])))
+
+
+def joint_angle(pose: Pose, a: KeypointName, vertex: KeypointName, c: KeypointName) -> float:
+    origin = world(pose[vertex])
+    first = [world(pose[a])[i] - origin[i] for i in range(3)]
+    second = [world(pose[c])[i] - origin[i] for i in range(3)]
+    dot = sum(p * q for p, q in zip(first, second, strict=True))
+    norms = math.dist(first, [0, 0, 0]) * math.dist(second, [0, 0, 0])
+    return math.degrees(math.acos(max(-1.0, min(1.0, dot / norms))))
+
+
+def image_distance(a: Landmark, b: Landmark, width: int = 640, height: int = 480) -> float:
+    return math.hypot((a.x - b.x) * width, (a.y - b.y) * height)
+
+
+# ---------------------------------------------------------------------------------------------
+# The figure is what it says it is
+# ---------------------------------------------------------------------------------------------
+
+
+def test_produces_the_complete_canonical_skeleton() -> None:
+    assert set(make_pose()) == set(KeypointName)
+
+
+@pytest.mark.parametrize("requested", [-40.0, -25.0, 0.0, 3.0, 32.0, 60.0])
+def test_trunk_angle_is_recoverable_from_the_figure(requested: float) -> None:
+    """The property every Epic C metric test will lean on.
+
+    A figure built at 32° must measure 32°, including when negative — reclining is a different
+    posture from slumping, and a builder that folded the sign would make it impossible to write a
+    test distinguishing them.
+    """
+    assert trunk_angle(make_pose(trunk_deg=requested)) == pytest.approx(requested, abs=1e-9)
+
+
+@pytest.mark.parametrize(
+    ("thigh", "shank"),
+    [(85.0, 5.0), (15.0, 165.0), (0.0, 0.0), (90.0, 90.0)],
+)
+def test_knee_flexion_emerges_from_the_two_segment_angles(thigh: float, shank: float) -> None:
+    """Flexion is derived, not specified — which is what keeps the figure physically consistent.
+
+    Taking flexion as an input would let a caller ask for a 90° knee and a shin pointing in a
+    direction that contradicts it, and the builder would have to silently pick a winner.
+    """
+    pose = make_pose(thigh_deg=thigh, shank_deg=shank)
+    expected = 180.0 - abs(thigh - shank)
+    measured = joint_angle(
+        pose, KeypointName.LEFT_HIP, KeypointName.LEFT_KNEE, KeypointName.LEFT_ANKLE
+    )
+    assert measured == pytest.approx(expected, abs=1e-6)
+
+
+def test_hip_midpoint_is_the_world_origin() -> None:
+    """MediaPipe's world-landmark convention, so fake and real frames are interchangeable."""
+    hip = midpoint_world(make_pose(trunk_deg=20.0), KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    assert hip == pytest.approx((0.0, 0.0, 0.0), abs=1e-12)
+
+
+def test_neck_is_exactly_the_shoulder_midpoint() -> None:
+    """The same derivation `MediaPipeBackend` performs, so the two backends agree on the neck.
+
+    If they disagreed, a rule tuned against fake frames would be tuned against a skeleton the real
+    backend never produces.
+    """
+    pose = make_pose(trunk_deg=18.0)
+    shoulders = midpoint_world(pose, KeypointName.LEFT_SHOULDER, KeypointName.RIGHT_SHOULDER)
+    assert world(pose[KeypointName.NECK]) == pytest.approx(shoulders, abs=1e-12)
+
+
+def test_neck_angle_is_additional_to_the_trunk() -> None:
+    """Forward head posture stacks on top of whatever the trunk is doing.
+
+    Ear ahead of the shoulders is what a craniovertebral angle measures (OP-27), so the builder
+    has to be able to produce it independently of trunk lean.
+    """
+    upright = make_pose(trunk_deg=0.0, neck_deg=0.0)
+    forward_head = make_pose(trunk_deg=0.0, neck_deg=35.0)
+    ear = KeypointName.LEFT_EAR
+    assert world(forward_head[ear])[0] > world(upright[ear])[0]
+
+
+def test_facing_left_mirrors_the_figure() -> None:
+    right = make_pose(trunk_deg=25.0, facing=Facing.RIGHT)
+    left = make_pose(trunk_deg=25.0, facing=Facing.LEFT)
+    assert world(right[KeypointName.NOSE])[0] == pytest.approx(-world(left[KeypointName.NOSE])[0])
+    # The trunk lean itself is unchanged: leaning forward is leaning forward whichever way you
+    # face. An implementation keying lean off raw x would report these as opposite postures —
+    # which is exactly the legacy laterality bug (FINDINGS §2.1), reproduced here as a guard.
+    assert trunk_angle(left) == pytest.approx(-25.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------------------------
+# Camera position
+# ---------------------------------------------------------------------------------------------
+
+
+def test_lateral_view_hides_shoulder_width_and_shows_the_lean() -> None:
+    pose = make_pose(trunk_deg=30.0, view=View.LATERAL)
+    shoulders = image_distance(pose[KeypointName.LEFT_SHOULDER], pose[KeypointName.RIGHT_SHOULDER])
+    assert shoulders == pytest.approx(0.0, abs=1e-9)
+    assert trunk_angle(pose) == pytest.approx(30.0)
+
+
+def test_frontal_view_shows_shoulder_width_and_hides_the_lean() -> None:
+    """The failure the original app invited and never guarded against.
+
+    It told users "this image must be taken from a side angle" and then assessed whatever arrived.
+    A 30° slump photographed head-on projects to almost no apparent lean, so the app would report
+    good posture with complete confidence. `view_confidence` (OP-31) exists to refuse this, and
+    this preset is what it gets tested against.
+    """
+    pose = make_pose(trunk_deg=30.0, view=View.FRONTAL)
+    shoulders = image_distance(pose[KeypointName.LEFT_SHOULDER], pose[KeypointName.RIGHT_SHOULDER])
+    torso = image_distance(pose[KeypointName.NECK], pose[KeypointName.LEFT_HIP])
+    assert shoulders / torso > 0.5
+
+    hip = midpoint_world(pose, KeypointName.LEFT_HIP, KeypointName.RIGHT_HIP)
+    neck = world(pose[KeypointName.NECK])
+    apparent_lean = math.degrees(math.atan2(neck[0] - hip[0], -(neck[1] - hip[1])))
+    assert apparent_lean == pytest.approx(0.0, abs=1e-9)
+
+
+# ---------------------------------------------------------------------------------------------
+# Scale, determinism, degradation
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("factor", [0.5, 1.0, 2.5])
+def test_angles_are_invariant_to_body_size(factor: float) -> None:
+    """The proof that the redesign fixed the original defect, in miniature.
+
+    The legacy engine compared raw pixel distances against literal thresholds, so the same posture
+    at a different distance or on a different-sized person got a different verdict. Angles in world
+    space cannot do that. The full Hypothesis version of this property is OP-34; this is the
+    builder's own guarantee that it is a fair test bed for it.
+    """
+    default = Anthropometry()
+    scaled = Anthropometry(
+        torso=default.torso * factor,
+        neck=default.neck * factor,
+        shoulder_width=default.shoulder_width * factor,
+        hip_width=default.hip_width * factor,
+        thigh=default.thigh * factor,
+        shank=default.shank * factor,
+    )
+    pose = make_pose(trunk_deg=27.0, thigh_deg=85.0, shank_deg=5.0, body=scaled)
+    assert trunk_angle(pose) == pytest.approx(27.0, abs=1e-9)
+    assert joint_angle(
+        pose, KeypointName.LEFT_HIP, KeypointName.LEFT_KNEE, KeypointName.LEFT_ANKLE
+    ) == pytest.approx(100.0, abs=1e-6)
+
+
+def test_output_is_byte_identical_across_calls() -> None:
+    """No clock, no randomness. Snapshot assertions downstream depend on this absolutely."""
+    assert make_pose(trunk_deg=12.0) == make_pose(trunk_deg=12.0)
+
+
+def test_omitted_keypoints_are_absent_rather_than_zeroed() -> None:
+    """Degradation tests need "not reported", which is a different fact from "low confidence"."""
+    pose = make_pose(omit=(KeypointName.LEFT_KNEE, KeypointName.RIGHT_KNEE))
+    assert KeypointName.LEFT_KNEE not in pose
+    assert KeypointName.RIGHT_KNEE not in pose
+    assert len(pose) == len(KeypointName) - 2
+
+
+def test_per_keypoint_confidence_can_express_occlusion_separately_from_absence() -> None:
+    """Low visibility with high presence means occluded; low presence means out of frame.
+
+    Two independent signals, and the reason MediaPipe was chosen over MoveNet (ADR-0002). The
+    builder has to be able to produce both or the status model (OP-25) has nothing to test on.
+    """
+    pose = make_pose(confidence={KeypointName.LEFT_WRIST: (0.1, 0.95)})
+    wrist = pose[KeypointName.LEFT_WRIST]
+    assert wrist.visibility == pytest.approx(0.1)
+    assert wrist.presence == pytest.approx(0.95)
+    assert pose[KeypointName.RIGHT_WRIST].visibility == pytest.approx(0.95)
+
+
+def test_image_coordinates_track_the_frame_size() -> None:
+    """Normalised coordinates are resolution-independent: the same figure at 4K reads the same."""
+    small = make_pose(trunk_deg=15.0, image_width=640, image_height=480)
+    large = make_pose(trunk_deg=15.0, image_width=3840, image_height=2880)
+    assert small[KeypointName.NOSE].x == pytest.approx(large[KeypointName.NOSE].x)
+    assert small[KeypointName.NOSE].y == pytest.approx(large[KeypointName.NOSE].y)
+
+
+def test_the_figure_fits_inside_the_frame() -> None:
+    """Not a correctness requirement, but a landmark outside [0, 1] would read as OUT_OF_FRAME to
+    the status model (OP-25) and make every preset look partially clipped."""
+    for landmark in make_pose(trunk_deg=32.0, thigh_deg=85.0, shank_deg=5.0).values():
+        assert 0.0 <= landmark.x <= 1.0
+        assert 0.0 <= landmark.y <= 1.0
+
+
+# ---------------------------------------------------------------------------------------------
+# make_pose_frame
+# ---------------------------------------------------------------------------------------------
+
+
+def test_frame_wraps_the_pose_with_a_constant_zero_latency() -> None:
+    """A synthetic frame has no inference to time, and a measured value would differ between runs
+    — which is precisely what would break the byte-identical guarantee."""
+    frame = make_pose_frame(trunk_deg=10.0)
+    assert frame.inference_ms == 0.0
+    assert frame.has_world_landmarks is True
+    assert make_pose_frame(trunk_deg=10.0) == frame

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,9 +104,21 @@ show_error_codes = true
 pretty = true
 exclude = ['^docs/archive/']
 
-# NOTE: `ignore_missing_imports` overrides for untyped third-party packages (cv2, mediapipe)
-# are added by OP-18, when the adapter first imports them. Declaring them now would trip
-# `warn_unused_configs` and train everyone to ignore mypy's output.
+# Untyped third-party packages, added in OP-18 when the adapter first imported them.
+#
+# `mediapipe` ships no type information and, being an optional extra (ADR-0002), is usually not
+# installed at all in the environment mypy runs in — CI installs the base package only. Either way
+# mypy cannot resolve it, and either way the answer is the same: trust the adapter's own
+# annotations and treat the library as Any.
+#
+# The blast radius is deliberately one module. `mediapipe` is imported inside two functions in
+# pose_backends/mediapipe_backend.py and nowhere else, so everything that crosses back into typed
+# code does so through RawDetection and RawLandmark, which are checked normally.
+#
+# `cv2` is here for the same reason and is reached only from the real-model tests and the CLI.
+[[tool.mypy.overrides]]
+module = ["mediapipe.*", "cv2.*"]
+ignore_missing_imports = true
 
 # ---------------------------------------------------------------------------
 # pytest


### PR DESCRIPTION
Follow-up to OP-18; no separate ticket. Base: `op-20-model-acquisition`.

Corrects two assertions in `test_mediapipe_model.py` that were written from the plan's predictions and are wrong about the real model. This is the first branch where `make fetch-model` exists, so it is the first point the real-model suite could run.

Kept separate from OP-18 because it also touches `test_backend_contract.py`, which OP-19 creates.

## Changes
- `test_warmup_makes_the_first_real_inference_materially_faster` replaced by `test_no_initialisation_cost_is_deferred_past_construction` and `test_warmup_does_not_disturb_subsequent_detection`.
- Per-fixture confident-landmark floors instead of a uniform 25, with the measured values recorded.
- New `test_presence_and_visibility_carry_different_information`.
- `MediaPipeBackend.warmup` docstring corrected.
- `test_backend_contract.py`: `np.asarray(photo, dtype=np.uint8)` so mypy's view of `cv2.imread` does not depend on whether the optional extra is installed.

## Notes
- `warmup()` saves nothing measurable. Measured 2026-07-27 (Apple M5, `pose_landmarker_full`, 1280×720): `mediapipe==0.10.18` in `RunningMode.IMAGE` builds its graph eagerly in `create_from_options` — construction ~31 ms, every inference ~23 ms including the first. `warmup()` is retained for the Protocol and for backends that do defer work.
- OP-18's acceptance criterion "second inference is materially faster than the first" is therefore not satisfiable against this library.
- `straight_armsfolded.jpg` clears 21 confident landmarks, not 25: the arms are folded, so both wrists and all six hand points are genuinely occluded.
- Across all fixtures, 34 landmarks are confidently present while 20–28 are confidently visible. The gap is the occluded set.
