### PR TITLE
OP-21: Landmark inspection CLI and model-validation workflow

### DIFF
--- a/.github/workflows/model-validation.yml
+++ b/.github/workflows/model-validation.yml
@@ -1,0 +1,129 @@
+# Real-model validation. MANUAL DISPATCH ONLY.
+#
+# Everything in pr.yml runs with no model weights, no container, no database and no secret, and
+# finishes in minutes. That is deliberate, and it is why the landmark mapping is tested against a
+# stub. But a stub agreeing with itself is not evidence that the mapping is right about a *real*
+# model, so those tests exist too — marked `pytest.mark.model`, deselected everywhere else, and
+# run here.
+#
+# WHY THERE IS NO `schedule:` TRIGGER
+# ----------------------------------
+# The plan is explicit that this must not run nightly, and the reasoning is worth keeping. A
+# scheduled job downloads 9 MB of weights and ~400 MB of wheels to re-answer a question whose
+# inputs are all pinned — the model by SHA256, mediapipe at 0.10.18, the fixtures in git. Nothing
+# can change between midnight and midnight. What a nightly run would actually produce is a
+# recurring notification that everyone learns to ignore, which is worse than no signal.
+#
+# It is invoked by hand when the adapter or the model pin changes, and later by the release
+# workflow. OP-111 hardens it further.
+
+name: model-validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      model_variant:
+        description: "Which model variant to validate"
+        required: false
+        default: full
+        type: choice
+        options: [lite, full, heavy]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: model-validation-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  validate:
+    name: validate (${{ inputs.model_variant }})
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-project
+        with:
+          python: ${{ env.PYTHON_VERSION }}
+
+      # The heavy dependency, installed only here. `--only-binary=:all:` because a source build of
+      # mediapipe would mean the wheel this project's entire platform bet rests on was not
+      # available — and that must fail loudly rather than be silently worked around. See ADR-0002.
+      #
+      # libgl1 and libglib2.0-0 are required because mediapipe 0.10.18 hard-depends on the
+      # non-headless opencv-contrib-python. Route A from the ADR: fine on a runner, wrong for the
+      # API image, which uses requirements-mediapipe.txt with --no-deps instead.
+      - name: Install system libraries for non-headless OpenCV
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends libgl1 libglib2.0-0
+
+      - name: Install mediapipe
+        # Single-quoted because `--only-binary=:all:` puts a `: ` inside the scalar, which YAML
+        # would otherwise read as a nested mapping and refuse to parse.
+        run: 'uv pip install --only-binary=:all: "mediapipe==0.10.18"'
+
+      # FIRST, before anything else runs. A corrupted or swapped model would otherwise produce a
+      # set of plausible-looking landmark diagnostics that describe a different model than the one
+      # this workflow claims to have validated.
+      - name: Fetch and verify the model
+        run: make fetch-model MODEL_VARIANT=${{ inputs.model_variant }}
+
+      - name: Verify the checksum independently
+        run: make verify-model MODEL_VARIANT=${{ inputs.model_variant }}
+
+      - name: Real-model tests
+        env:
+          MODEL_PATH: models/pose_landmarker_${{ inputs.model_variant }}.task
+        run: uv run pytest -m model -v
+
+      # Diagnostics, not assertions. The tests above decide pass or fail; this exists so a human
+      # comparing two model variants — or this engine against the legacy baseline — has the raw
+      # numbers rather than a green tick.
+      - name: Capture landmark and latency diagnostics
+        env:
+          MODEL_PATH: models/pose_landmarker_${{ inputs.model_variant }}.task
+        run: |
+          mkdir -p diagnostics
+          # `find` rather than a glob: fixtures/images also holds a README, and feeding that to the
+          # CLI would report "no pose detected" for a markdown file — a confusing line in a log
+          # whose whole purpose is to be read by a human comparing model variants.
+          find fixtures/images -type f \( -name '*.jpg' -o -name '*.jpeg' -o -name '*.png' \) \
+            | sort | while read -r image; do
+              name=$(basename "${image%.*}")
+              echo "== $name"
+              uv run python -m pose_backends.cli "$image" --json \
+                > "diagnostics/${name}.json" || echo "  (no pose detected)"
+            done
+          uv run python - <<'PY' | tee diagnostics/summary.md
+          import json, pathlib
+          rows = []
+          for path in sorted(pathlib.Path("diagnostics").glob("*.json")):
+              data = json.loads(path.read_text())
+              confident = sum(
+                  1 for lm in data["landmarks"].values() if lm["visibility"] >= 0.5
+              )
+              rows.append(
+                  (path.stem, data["landmark_count"], confident, data["inference_ms"])
+              )
+          print("| fixture | landmarks | visibility >= 0.5 | inference ms |")
+          print("| --- | ---: | ---: | ---: |")
+          for row in rows:
+              print("| {} | {} | {} | {:.1f} |".format(*row))
+          PY
+
+      - name: Summary
+        run: cat diagnostics/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@v7
+        # Unconditional, unlike pr.yml's failure-only report. The point of this workflow is the
+        # numbers; a green run whose diagnostics were discarded answered nothing.
+        if: always()
+        with:
+          name: model-diagnostics-${{ inputs.model_variant }}
+          path: diagnostics/
+          retention-days: 30

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,8 @@ Two coverage floors, chosen rather than defaulted:
 Clear a floor by writing a test, not by adding an exclusion. Generated code and type-only modules
 may be excluded; a difficult branch may not.
 
-`-m "not model"` deselects tests needing real model weights. CI never downloads them; they will run
-on demand in `model-validation.yml`, which arrives with the landmark CLI in OP-21.
+`-m "not model"` deselects tests needing real model weights. CI never downloads them; they run on
+demand in `model-validation.yml`.
 
 To run them locally you need the weights and the inference stack:
 

--- a/Makefile
+++ b/Makefile
@@ -69,9 +69,8 @@ fetch-model:
 	mv "$$tmp" "$(MODEL_TARGET)"; \
 	echo "OK  $(MODEL_TARGET)  $$actual"
 
-## Verify whatever is on disk. The model-validation workflow arriving in OP-21 will run this
-## before anything else, so a corrupted or swapped model fails the run instead of quietly
-## changing its results.
+## Verify whatever is on disk. model-validation.yml runs this before anything else, so a corrupted
+## or swapped model fails the workflow instead of quietly changing its results.
 verify-model:
 	@expected="$(expected_sha)"; \
 	if [ ! -f "$(MODEL_TARGET)" ]; then \

--- a/models/checksums.txt
+++ b/models/checksums.txt
@@ -4,11 +4,11 @@
 #
 #   * `make fetch-model`     — verifies a download before moving it into place
 #   * `make verify-model`    — verifies whatever is already on disk
+#   * `model-validation.yml` — verifies the hash before running anything
 #   * the API image build    — `ADD --checksum=sha256:<the full hash below>` (planned, OP-43)
-#   * `model-validation.yml` — verifies the hash before running anything (planned, OP-21)
 #
-# The last two do not exist yet; they are named so that when they arrive they reference this file
-# rather than pasting a hash of their own.
+# The image build does not exist yet; it is named so that when it arrives it references this file
+# rather than pasting a hash of its own.
 #
 # Format is exactly what `shasum -a 256` emits: `<hash>  <filename>`, one per line, `#` comments
 # ignored. Familiar and trivially greppable.

--- a/packages/pose-backends/src/pose_backends/cli.py
+++ b/packages/pose-backends/src/pose_backends/cli.py
@@ -1,0 +1,325 @@
+"""``python -m pose_backends.cli`` — run an image through a backend and print what came out.
+
+The first point in the rebuild where something real is visible: a photograph in, thirty-four
+measured landmarks out, with no web stack, no database, no frontend and no API key. That is worth
+having on its own, and it is worth having *early* — Epic C is about to spend a dozen tickets
+tuning thresholds, and inspecting landmark values by hand is how that work gets done.
+
+Its JSON output is also the new-engine half of the legacy comparison. `docs/archive/
+legacy-baseline.json` captured the old engine's verdicts on all eight fixtures before its weights
+and its TensorFlow 2.12 environment were removed; that capture cannot be repeated. So the schema
+here is versioned and changes deliberately, not incidentally.
+
+Design note: this module is the *only* place in the package that prints. `MediaPipeBackend` and
+`FakePoseBackend` return values and raise exceptions; presentation lives here. The legacy engine
+mixed the two — `posture_image.py` computed, printed and drew in one function — which is a large
+part of why none of it could be called from a web request.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import TYPE_CHECKING, Final
+
+from pose_backends.errors import PoseBackendError
+from pose_backends.fake import BACKEND_NAME as FAKE_NAME
+from pose_backends.fake import PosePreset
+from pose_backends.mediapipe_backend import BACKEND_NAME as MEDIAPIPE_NAME
+from pose_backends.registry import create_backend
+from posture_core import KeypointName
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence
+
+    from pose_backends.base import ImageBGR
+    from posture_core import Landmark, PoseFrame
+
+__all__ = ["OUTPUT_SCHEMA_VERSION", "main"]
+
+OUTPUT_SCHEMA_VERSION: Final = "1.0"
+"""Bumped deliberately when the JSON shape changes.
+
+Consumers exist outside this repository's test suite — the evaluation writeup in Epic H compares
+this output against a legacy capture that can never be regenerated. An unversioned format would
+make "the numbers changed" and "the format changed" indistinguishable after the fact.
+"""
+
+EXIT_OK: Final = 0
+EXIT_NO_POSE: Final = 1
+"""Distinct from a crash. "Nobody in this photo" is a *result*, and a script batching a directory
+of images needs to tell it apart from "the model file is missing"."""
+EXIT_ERROR: Final = 2
+
+# Confidence below which a landmark is reported but not trusted. Matches MediaPipe's own default
+# detection confidence.
+_CONFIDENT: Final = 0.5
+
+
+class DisplayStatus(StrEnum):
+    """How much to believe a landmark, for the table's rightmost column.
+
+    **Provisional, and deliberately shallow.** The real keypoint status model — with the
+    OK / LOW_CONFIDENCE / NOT_DETECTED / OUT_OF_FRAME distinction that ends the silent false
+    negative — is OP-25, and lives in `posture_core` where the rules can act on it. This is a
+    display convenience so the table is readable today; when OP-25 lands, this enum is deleted and
+    the column renders the real status instead.
+
+    Written down because the alternative is that a "temporary" duplicate of the status logic
+    quietly becomes a second source of truth.
+    """
+
+    OK = "ok"
+    OCCLUDED = "occluded"
+    """Low visibility, high presence: the model believes the point is in frame but cannot see it."""
+    OUT_OF_FRAME = "out_of_frame"
+    LOW_CONFIDENCE = "low_confidence"
+
+
+def _display_status(landmark: Landmark) -> DisplayStatus:
+    if landmark.presence < _CONFIDENT:
+        return DisplayStatus.OUT_OF_FRAME
+    if landmark.visibility < _CONFIDENT:
+        return DisplayStatus.OCCLUDED
+    if landmark.visibility < 0.8:
+        return DisplayStatus.LOW_CONFIDENCE
+    return DisplayStatus.OK
+
+
+@dataclass(frozen=True, slots=True)
+class _Options:
+    image: Path | None
+    backend: str
+    preset: str
+    model_path: Path | None
+    as_json: bool
+
+
+def _parse_args(argv: Sequence[str] | None) -> _Options:
+    parser = argparse.ArgumentParser(
+        prog="python -m pose_backends.cli",
+        description="Run an image through a pose backend and print the landmarks it produced.",
+        epilog=(
+            "Exit codes: 0 landmarks printed, 1 no pose detected, 2 the backend could not run. "
+            "The image argument is optional only for --backend fake, which never reads it."
+        ),
+    )
+    parser.add_argument(
+        "image",
+        nargs="?",
+        type=Path,
+        help="path to an image. Omit only with --backend fake.",
+    )
+    parser.add_argument(
+        "--backend",
+        default=MEDIAPIPE_NAME,
+        choices=[MEDIAPIPE_NAME, FAKE_NAME],
+        help=f"which backend to run (default: {MEDIAPIPE_NAME}).",
+    )
+    parser.add_argument(
+        "--preset",
+        default=PosePreset.STRAIGHT.value,
+        choices=[preset.value for preset in PosePreset],
+        help="scenario for --backend fake (default: straight).",
+    )
+    parser.add_argument(
+        "--model-path",
+        type=Path,
+        default=None,
+        help="override the model location. Falls back to $MODEL_PATH, then models/.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="emit machine-readable JSON instead of a table.",
+    )
+
+    parsed = parser.parse_args(argv)
+    return _Options(
+        image=parsed.image,
+        backend=parsed.backend,
+        preset=parsed.preset,
+        model_path=parsed.model_path,
+        as_json=parsed.as_json,
+    )
+
+
+def _load_image(path: Path) -> ImageBGR:
+    """Decode with OpenCV, which returns BGR — the channel order the Protocol specifies."""
+    if not path.is_file():
+        raise PoseBackendError(f"no such image: {path}")
+
+    try:
+        import cv2
+    except ImportError as exc:
+        raise PoseBackendError(
+            "reading an image needs OpenCV, which arrives with the mediapipe extra. "
+            "Install `pose-backends[mediapipe]`, or use --backend fake with no image."
+        ) from exc
+
+    import numpy as np
+
+    decoded = cv2.imread(str(path))
+    if decoded is None:
+        raise PoseBackendError(f"{path} is not an image OpenCV can decode.")
+    return np.asarray(decoded, dtype=np.uint8)
+
+
+def _blank_image() -> ImageBGR:
+    """What the fake backend gets. It ignores the contents entirely."""
+    import numpy as np
+
+    return np.zeros((480, 640, 3), dtype=np.uint8)
+
+
+def _image_for(options: _Options) -> ImageBGR:
+    """Decode the image, unless the chosen backend has no use for one.
+
+    ``FakePoseBackend`` ignores pixels by contract, so decoding for it would import OpenCV — and
+    OpenCV arrives only with the mediapipe extra. That would break the stated promise that
+    ``--backend fake`` runs on the base package alone, and it would break it *only* when a path
+    happened to be supplied, which is a miserable thing to debug.
+
+    A path that was given is still checked for existence, so ``no such image`` still fires and the
+    argument is not silently ignored.
+    """
+    if options.image is None:
+        return _blank_image()
+    if options.backend == FAKE_NAME:
+        if not options.image.is_file():
+            raise PoseBackendError(f"no such image: {options.image}")
+        return _blank_image()
+    return _load_image(options.image)
+
+
+def _as_dict(frame: PoseFrame) -> dict[str, object]:
+    """The versioned JSON shape. Keys are ordered for a readable diff, not for parsing."""
+    return {
+        "schema_version": OUTPUT_SCHEMA_VERSION,
+        "backend": frame.backend,
+        "inference_ms": round(frame.inference_ms, 3),
+        "image": {"width": frame.image_width, "height": frame.image_height},
+        "landmark_count": len(frame),
+        # Sorted by canonical name rather than by the order the adapter happened to build them, so
+        # two captures of the same image diff cleanly.
+        "landmarks": {
+            name.value: {
+                "x": round(landmark.x, 6),
+                "y": round(landmark.y, 6),
+                "x_world": None if landmark.x_world is None else round(landmark.x_world, 6),
+                "y_world": None if landmark.y_world is None else round(landmark.y_world, 6),
+                "z_world": None if landmark.z_world is None else round(landmark.z_world, 6),
+                "visibility": round(landmark.visibility, 4),
+                "presence": round(landmark.presence, 4),
+                "status": _display_status(landmark).value,
+            }
+            for name, landmark in sorted(frame.landmarks.items(), key=lambda item: item[0].value)
+        },
+    }
+
+
+_COLUMNS: Final = (
+    ("keypoint", 18),
+    ("x", 9),
+    ("y", 9),
+    ("x_world", 10),
+    ("y_world", 10),
+    ("z_world", 10),
+    ("vis", 7),
+    ("pres", 7),
+    ("status", 14),
+)
+
+
+def _format_table(frame: PoseFrame) -> str:
+    """A fixed-width table, hand-rolled.
+
+    No `rich`, no `tabulate`. This package is installed inside the API image, and a dependency
+    added for the sake of a developer tool would ship to production for the rest of the project's
+    life. Nine columns of `str.ljust` is not worth that.
+    """
+    header = "".join(title.ljust(width) for title, width in _COLUMNS).rstrip()
+    lines = [header, "-" * len(header)]
+
+    for name in sorted(KeypointName, key=lambda item: item.value):
+        landmark = frame.get(name)
+        if landmark is None:
+            # Reported as a row rather than skipped: "this backend did not give us a left heel" is
+            # exactly the kind of thing you are running this command to find out.
+            lines.append(name.value.ljust(_COLUMNS[0][1]) + "not reported")
+            continue
+
+        def number(value: float | None, width: int, places: int = 4) -> str:
+            return ("-" if value is None else f"{value:.{places}f}").ljust(width)
+
+        lines.append(
+            "".join(
+                (
+                    name.value.ljust(_COLUMNS[0][1]),
+                    number(landmark.x, _COLUMNS[1][1]),
+                    number(landmark.y, _COLUMNS[2][1]),
+                    number(landmark.x_world, _COLUMNS[3][1]),
+                    number(landmark.y_world, _COLUMNS[4][1]),
+                    number(landmark.z_world, _COLUMNS[5][1]),
+                    number(landmark.visibility, _COLUMNS[6][1], places=2),
+                    number(landmark.presence, _COLUMNS[7][1], places=2),
+                    _display_status(landmark).value,
+                )
+            ).rstrip()
+        )
+
+    lines.extend(
+        (
+            "",
+            f"backend        {frame.backend}",
+            f"image          {frame.image_width}x{frame.image_height}",
+            f"inference      {frame.inference_ms:.1f} ms",
+            f"landmarks      {len(frame)} of {len(KeypointName)}",
+            f"world space    {'yes' if frame.has_world_landmarks else 'no'}",
+        )
+    )
+    return "\n".join(lines)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Entry point. Returns an exit code rather than calling ``sys.exit``, so it is testable."""
+    options = _parse_args(argv)
+
+    if options.image is None and options.backend != FAKE_NAME:
+        print(f"error: an image is required for --backend {options.backend}.", file=sys.stderr)
+        return EXIT_ERROR
+
+    try:
+        backend = create_backend(
+            options.backend,
+            model_path=options.model_path,
+            preset=options.preset,
+        )
+        image = _image_for(options)
+        frame = backend.detect(image)
+    except PoseBackendError as exc:
+        # Only our own exception type. A narrow catch of something we defined still lets a genuine
+        # programming error escape with its traceback intact — which is the entire difference
+        # between this and the `except Exception` that made the legacy engine impossible to debug.
+        print(f"error: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if frame is None:
+        source = options.image if options.image is not None else f"the {options.preset} preset"
+        print(f"No pose detected in {source}.", file=sys.stderr)
+        return EXIT_NO_POSE
+
+    if options.as_json:
+        print(json.dumps(_as_dict(frame), indent=2))
+    else:
+        print(_format_table(frame))
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/packages/pose-backends/tests/test_cli.py
+++ b/packages/pose-backends/tests/test_cli.py
@@ -1,0 +1,245 @@
+"""Tests for the landmark inspection CLI.
+
+Driven through `main(argv)` rather than by spawning a subprocess: `main` returns an exit code
+instead of calling `sys.exit`, precisely so it can be called in-process. A subprocess test would
+be an order of magnitude slower and would assert almost nothing extra.
+
+Nearly all of these run on the fake backend, so the whole file needs no model and no OpenCV.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from pose_backends.cli import EXIT_ERROR, EXIT_NO_POSE, EXIT_OK, OUTPUT_SCHEMA_VERSION, main
+from posture_core import KeypointName
+
+
+def run(capsys: pytest.CaptureFixture[str], *argv: str) -> tuple[int, str, str]:
+    code = main(list(argv))
+    captured = capsys.readouterr()
+    return code, captured.out, captured.err
+
+
+# ---------------------------------------------------------------------------------------------
+# The table
+# ---------------------------------------------------------------------------------------------
+
+
+def test_prints_a_row_for_every_canonical_keypoint(capsys: pytest.CaptureFixture[str]) -> None:
+    """All 34, including any the backend did not report.
+
+    A missing keypoint is shown as `not reported` rather than omitted, because "this backend gave
+    us no left heel" is exactly the kind of thing someone runs this command to discover. A table
+    that silently shortens hides its most interesting result.
+    """
+    code, out, _ = run(capsys, "--backend", "fake")
+    assert code == EXIT_OK
+    for name in KeypointName:
+        assert name.value in out
+
+
+def test_reports_the_backend_latency_and_landmark_count(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, out, _ = run(capsys, "--backend", "fake")
+    assert "backend        fake" in out
+    assert "inference      0.0 ms" in out
+    assert "landmarks      34 of 34" in out
+    assert "world space    yes" in out
+
+
+def test_unreported_keypoints_are_shown_as_such(capsys: pytest.CaptureFixture[str]) -> None:
+    _, out, _ = run(capsys, "--backend", "fake", "--preset", "partial_occlusion")
+    assert "left_knee         not reported" in out
+    assert "landmarks      26 of 34" in out
+
+
+def test_occluded_keypoints_are_distinguished_from_confident_ones(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The visibility/presence split, made visible.
+
+    This column is the human-readable face of the signal that ends the silent false negative: a
+    point the model believes is in the frame but cannot see reads `occluded`, not `ok`.
+    """
+    _, out, _ = run(capsys, "--backend", "fake", "--preset", "partial_occlusion")
+    elbow_row = next(line for line in out.splitlines() if line.startswith("left_elbow"))
+    assert elbow_row.endswith("occluded")
+
+
+# ---------------------------------------------------------------------------------------------
+# JSON
+# ---------------------------------------------------------------------------------------------
+
+
+def test_json_output_is_valid_and_versioned(capsys: pytest.CaptureFixture[str]) -> None:
+    """The schema version is not decoration.
+
+    Epic H compares this output against `docs/archive/legacy-baseline.json`, a capture that cannot
+    be regenerated — the old weights and its TensorFlow 2.12 environment are gone. Without a
+    version stamp, "the numbers changed" and "the format changed" become indistinguishable after
+    the fact.
+    """
+    code, out, _ = run(capsys, "--backend", "fake", "--json")
+    assert code == EXIT_OK
+    payload = json.loads(out)
+    assert payload["schema_version"] == OUTPUT_SCHEMA_VERSION
+    assert payload["backend"] == "fake"
+    assert payload["landmark_count"] == 34
+    assert set(payload["landmarks"]) == {name.value for name in KeypointName}
+
+
+def test_json_landmarks_are_sorted_so_two_captures_diff_cleanly(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    _, out, _ = run(capsys, "--backend", "fake", "--json")
+    names = list(json.loads(out)["landmarks"])
+    assert names == sorted(names)
+
+
+def test_json_output_is_stable_across_runs(capsys: pytest.CaptureFixture[str]) -> None:
+    """A golden capture is worthless if re-running produces a diff for no reason."""
+    _, first, _ = run(capsys, "--backend", "fake", "--json")
+    _, second, _ = run(capsys, "--backend", "fake", "--json")
+    assert first == second
+
+
+def test_json_carries_both_coordinate_systems(capsys: pytest.CaptureFixture[str]) -> None:
+    _, out, _ = run(capsys, "--backend", "fake", "--json")
+    neck = json.loads(out)["landmarks"]["neck"]
+    assert set(neck) == {
+        "x",
+        "y",
+        "x_world",
+        "y_world",
+        "z_world",
+        "visibility",
+        "presence",
+        "status",
+    }
+
+
+# ---------------------------------------------------------------------------------------------
+# Selection and exit codes
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "preset", ["straight", "hunchback", "reclined", "kneeling", "frontal_view"]
+)
+def test_every_detectable_preset_can_be_selected(
+    preset: str, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code, _, _ = run(capsys, "--backend", "fake", "--preset", preset)
+    assert code == EXIT_OK
+
+
+def test_the_fake_backend_needs_neither_an_image_nor_a_model(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The demoable path on a machine with nothing installed but the base package."""
+    code, out, err = run(capsys, "--backend", "fake")
+    assert code == EXIT_OK
+    assert err == ""
+    assert out
+
+
+def test_no_pose_exits_one_with_a_clear_message(capsys: pytest.CaptureFixture[str]) -> None:
+    """Distinct from a crash.
+
+    A script batching a directory of photographs has to tell "nobody in this one" apart from "the
+    model file is missing", and an exit code is the only channel it has.
+    """
+    code, out, err = run(capsys, "--backend", "fake", "--preset", "no_person")
+    assert code == EXIT_NO_POSE
+    assert out == ""
+    assert "No pose detected" in err
+
+
+def test_a_real_backend_without_an_image_is_a_usage_error(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    code, _, err = run(capsys, "--backend", "mediapipe")
+    assert code == EXIT_ERROR
+    assert "an image is required" in err
+
+
+def test_a_missing_model_reports_the_remedy_rather_than_a_traceback(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    photo = tmp_path / "photo.jpg"
+    photo.write_bytes(b"not really a jpeg")
+    code, _, err = run(
+        capsys, str(photo), "--backend", "mediapipe", "--model-path", "/nonexistent/model.task"
+    )
+    assert code == EXIT_ERROR
+    assert "make fetch-model" in err
+
+
+def test_a_missing_image_is_reported_by_path(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    code, _, err = run(capsys, str(tmp_path / "absent.jpg"), "--backend", "fake")
+    assert code == EXIT_ERROR
+    assert "no such image" in err
+
+
+def test_an_unknown_preset_is_rejected_by_the_parser() -> None:
+    """argparse `choices`, so the error names the valid values without any code of ours."""
+    with pytest.raises(SystemExit):
+        main(["--backend", "fake", "--preset", "slouchy"])
+
+
+# ---------------------------------------------------------------------------------------------
+# Real model
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.model
+def test_a_real_photograph_produces_a_full_table(capsys: pytest.CaptureFixture[str]) -> None:
+    """The acceptance criterion for the whole ticket: a real image, a readable 34-row table."""
+    repo_root = Path(__file__).resolve().parents[3]
+    model = repo_root / "models" / "pose_landmarker_full.task"
+    photo = repo_root / "fixtures" / "images" / "hunchback_right.jpg"
+    if not model.is_file():
+        pytest.skip("no model — run `make fetch-model`")
+
+    code, out, _ = run(capsys, str(photo), "--model-path", str(model))
+    assert code == EXIT_OK
+    assert "backend        mediapipe" in out
+    assert "landmarks      34 of 34" in out
+    assert "world space    yes" in out
+    # Latency is reported, and it had better be a real measurement rather than the fake's 0.0.
+    latency = next(line for line in out.splitlines() if line.startswith("inference "))
+    assert float(latency.split()[1]) > 0.0
+
+
+def test_the_fake_backend_does_not_decode_an_image_it_was_given(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """`--backend fake` must not import OpenCV, even when a path is supplied.
+
+    OpenCV arrives only with the mediapipe extra, so decoding here would break the promise that
+    the fake backend runs on the base package alone — and break it only when a path happened to be
+    passed, which is a miserable thing to debug. Enforced by making the import itself fail.
+    """
+    monkeypatch.setitem(__import__("sys").modules, "cv2", None)
+    photo = tmp_path / "photo.jpg"
+    photo.write_bytes(b"not really a jpeg")
+
+    code, out, _ = run(capsys, str(photo), "--backend", "fake")
+    assert code == EXIT_OK
+    assert "backend        fake" in out
+
+
+def test_a_path_given_to_the_fake_backend_is_still_checked(
+    capsys: pytest.CaptureFixture[str], tmp_path: Path
+) -> None:
+    """Skipping the decode must not mean silently ignoring the argument."""
+    code, _, err = run(capsys, str(tmp_path / "absent.jpg"), "--backend", "fake")
+    assert code == EXIT_ERROR
+    assert "no such image" in err


### PR DESCRIPTION
**Base: `op-18b-model-test-corrections`** — last in the Epic B stack. **Epic B ends here.**

Closes OP-21.

## What this is

`python -m pose_backends.cli <image>` — a real photograph in, thirty-four measured landmarks out,
with no web stack, no database, no frontend and no API key. Plus `model-validation.yml`, the
manual-dispatch workflow that runs the real-model tests.

This is the first point in the rebuild where something real is visible.

## What it looks like

```
keypoint          x        y        x_world   y_world   z_world   vis    pres   status
--------------------------------------------------------------------------------------
left_shoulder     0.4937   0.2996   -0.2586   -0.2668   -0.1694   1.00   1.00   ok
neck              0.4979   0.2890   -0.2652   -0.2955   -0.0249   1.00   1.00   ok
right_elbow       0.3957   0.3861   -0.3679   -0.1027   0.1802    0.11   1.00   occluded
right_knee        0.3706   0.4867   -0.3680   0.1031    0.0953    0.16   1.00   occluded
...
backend        mediapipe
image          720x1280
inference      21.6 ms
landmarks      34 of 34
world space    yes
```

Note the `occluded` column on the far side of the body — that is the visibility/presence split
doing visible work on a real photograph, and it is the signal that will end the silent false
negative in Epic C.

## Design notes

**This module is the only place in the package that prints.** The adapters return values and raise;
presentation lives here. The legacy engine mixed the two — `posture_image.py` computed, printed and
drew in one function — which is a large part of why none of it could be called from a web request.

**Unreported keypoints are shown as `not reported`, not omitted.** "This backend gave us no left
heel" is exactly the kind of thing someone runs this command to discover; a table that silently
shortens hides its most interesting result.

**Exit codes are load-bearing.** `0` landmarks printed, `1` no pose detected, `2` the backend could
not run. A script batching a directory needs to tell "nobody in this photo" apart from "the model
file is missing", and an exit code is the only channel it has.

**`--json` output is versioned.** Epic H compares this against `docs/archive/legacy-baseline.json`,
a capture that cannot be regenerated — the old weights and its TensorFlow 2.12 environment are
gone. Without a version stamp, "the numbers changed" and "the format changed" become
indistinguishable after the fact.

**The `status` column is provisional and says so.** The real keypoint status model is OP-25 and
lives in `posture_core` where the rules can act on it. This is a four-value display convenience so
the table is readable today, marked for deletion, because otherwise a "temporary" duplicate of the
status logic quietly becomes a second source of truth.

**No `rich`, no `tabulate`.** This package is installed inside the API image, and a dependency added
for a developer tool would ship to production for the rest of the project's life. Nine columns of
`str.ljust` is not worth that.

## `model-validation.yml`

Manual dispatch only, and the absence of a `schedule:` is deliberate. Every input is pinned — the
model by SHA256, mediapipe at 0.10.18, the fixtures in git — so nothing can change between midnight
and midnight. What a nightly run would actually produce is a recurring notification everyone learns
to ignore.

It verifies the model hash **before** running anything, then runs the `model`-marked tests and
publishes per-fixture diagnostics as an artifact and a step summary:

| fixture | landmarks | visibility ≥ 0.5 | inference ms |
| --- | ---: | ---: | ---: |
| bench_feet_dangling | 34 | 28 | 22.6 |
| desk_hunch | 34 | 27 | 22.7 |
| hunchback_right | 34 | 25 | 23.1 |
| straight_armsfolded | 34 | 21 | 22.8 |

(Dry-run output from my machine; the workflow generates the same table.)

One YAML detail that cost me a debugging cycle: `--only-binary=:all:` puts a `: ` inside a scalar,
which YAML reads as a nested mapping and refuses to parse. The step is single-quoted, with a
comment saying why.
