### PR TITLE
OP-24: thresholds.py — every tunable in one injected frozen dataclass

### DIFF
--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -1,0 +1,191 @@
+"""Every tunable number in the rules engine, in one frozen, injected object.
+
+## Why this exists at all
+
+The inherited engine scattered its constants through the code it used them in — a `±100` pixel
+literal for arm crossing whose own inline comment admitted it "shall be replaced with a
+calculation which can adjust to different sizes of people", a hardcoded angle for spine
+classification, a foot check that was a tautology. Retuning any of them meant finding them,
+understanding the surrounding code, and hoping there was not a second copy. There usually was:
+about 250 lines were duplicated between the two posture scripts.
+
+Collecting them here changes three things:
+
+* **Tuning is a config change.** One object, one place, no code touched.
+* **Every rule test is parameterisable.** A boundary test can construct `Thresholds(slouch_deg=30)`
+  and assert behaviour at exactly 29.9 and 30.1 without monkeypatching a module global.
+* **There is no module global to patch.** Thresholds are passed in. A test that mutated a global
+  would leak into every test that ran after it, and the failure would land somewhere else
+  entirely.
+
+## Why injected rather than loaded here
+
+This package reads no files and no environment variables — that is the constraint that lets its
+suite run in seconds anywhere. The API layer loads its own values from the environment (OP-39) and
+passes the resulting object down. In OP-36 the defaults below move to
+`packages/posture-spec/rules.json`, so the Python engine and its TypeScript mirror load *the same*
+numbers and cannot drift; this dataclass then becomes the parsed shape of that file rather than
+the source of the values.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Final
+
+__all__ = ["DEFAULT_THRESHOLDS", "RULES_VERSION", "Thresholds"]
+
+RULES_VERSION: Final = "1.0.0"
+"""Stamped onto every report (OP-32).
+
+Two reports are only comparable if they were produced by the same rules at the same settings. A
+stored report with no version becomes uninterpretable the first time a threshold moves — you can
+no longer tell whether the user's posture changed or the yardstick did.
+"""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Thresholds:
+    """Every number a rule is allowed to compare against.
+
+    Defaults are starting points chosen from the clinical literature where one exists and from the
+    fixture set otherwise. They are not sacred, and the point of this class is that changing them
+    is cheap.
+    """
+
+    version: str = RULES_VERSION
+
+    # -- confidence ----------------------------------------------------------------------------
+    min_visibility: float = 0.5
+    """Below this, a landmark is reported but not trusted for measurement.
+
+    Matches MediaPipe's own default detection confidence. Raising it makes the engine abstain more
+    often, which is the safe direction: an abstention says "I couldn't assess this", a bad
+    measurement says something false with confidence.
+    """
+
+    min_presence: float = 0.5
+    """Below this, the landmark is treated as outside the frame rather than merely occluded.
+
+    The two signals are independent, and keeping their thresholds separate is what lets the API
+    tell a user "your knees are out of shot" rather than "your knees are unclear".
+    """
+
+    # -- trunk inclination (OP-26) -------------------------------------------------------------
+    trunk_upright_deg: float = 10.0
+    """Forward lean at or below this is neutral sitting, not a finding."""
+
+    trunk_slouch_deg: float = 20.0
+    """Forward lean beyond this is a slouch worth reporting."""
+
+    trunk_recline_deg: float = -20.0
+    """Backward lean beyond this (i.e. more negative) is reclining.
+
+    A separate threshold rather than a mirror of the slouch value, because the two are not
+    symmetric problems: reclining into a supportive backrest is mostly benign, slouching forward
+    unsupported is not.
+    """
+
+    # -- craniovertebral angle (OP-27) ---------------------------------------------------------
+    cva_forward_head_deg: float = 50.0
+    """Below this, forward head posture. The standard clinical cutoff.
+
+    Note the direction: a *smaller* craniovertebral angle is worse, which is the opposite of every
+    other angular threshold here and is worth stating twice.
+    """
+
+    cva_borderline_deg: float = 55.0
+    """Between this and the cutoff, worth mentioning but not calling a fault."""
+
+    # -- arms and elbows (OP-28) ---------------------------------------------------------------
+    arms_crossed_ratio: float = 0.15
+    """``|forearm - upper_arm| / torso_length`` below which the arms read as crossed.
+
+    Normalised by torso length, which is the entire fix for the legacy `±100` pixel literal: the
+    same crossed arms at twice the camera distance produced half the pixel difference and a
+    different verdict. Dividing by a length measured on the same body cancels the scale.
+    """
+
+    elbow_flexed_deg: float = 120.0
+    """Elbow angle below this counts as flexed."""
+
+    # -- knees (OP-29) -------------------------------------------------------------------------
+    knee_seated_min_deg: float = 70.0
+    knee_seated_max_deg: float = 120.0
+    """A hip-knee-ankle angle in this band is ordinary seated posture."""
+
+    knee_kneeling_max_deg: float = 60.0
+    """Below this the subject is kneeling rather than sitting."""
+
+    # -- heel contact (OP-30) ------------------------------------------------------------------
+    heel_contact_tolerance_m: float = 0.05
+    """How far above the lowest foot point a heel may sit and still count as grounded.
+
+    In metres, from world landmarks — which is why this metric is possible at all. The 18-point
+    COCO schema the legacy engine used had no foot landmarks, so its feet check was a tautology
+    that returned "on the floor" for a fixture whose subject's feet visibly dangle.
+    """
+
+    # -- view confidence (OP-31) ---------------------------------------------------------------
+    lateral_view_max_ratio: float = 0.35
+    """``shoulder_width / torso_length`` in image space, at or below which the view is lateral.
+
+    In a true side view the shoulders overlap and this approaches zero; face-on it approaches the
+    subject's real proportions. The original app *told* users to photograph themselves from the
+    side and then assessed whatever arrived — so a 30° slump shot head-on, which projects to
+    almost no apparent lean, was reported as good posture with full confidence.
+    """
+
+    frontal_view_min_ratio: float = 0.55
+    """At or above this the view is frontal and sagittal metrics must abstain."""
+
+    # -- scoring (OP-32) -----------------------------------------------------------------------
+    score_penalty_per_finding: float = 15.0
+    """Points deducted from 100 for each fault found.
+
+    Deliberately crude and deliberately documented as such: an overall score is a summary for the
+    user, not a measurement. The findings are the output that means something.
+    """
+
+    def __post_init__(self) -> None:
+        # Ordering constraints, checked because a mis-ordered pair does not raise anywhere else —
+        # it just produces a band that no value can fall into, so a rule silently never fires.
+        if not 0.0 <= self.min_visibility <= 1.0:
+            raise ValueError(f"min_visibility must be a probability, got {self.min_visibility}")
+        if not 0.0 <= self.min_presence <= 1.0:
+            raise ValueError(f"min_presence must be a probability, got {self.min_presence}")
+        if self.trunk_upright_deg > self.trunk_slouch_deg:
+            raise ValueError(
+                f"trunk_upright_deg ({self.trunk_upright_deg}) must not exceed "
+                f"trunk_slouch_deg ({self.trunk_slouch_deg}); nothing could fall between them"
+            )
+        if self.trunk_recline_deg >= 0.0:
+            raise ValueError(
+                f"trunk_recline_deg is a backward lean and must be negative, "
+                f"got {self.trunk_recline_deg}"
+            )
+        if self.cva_forward_head_deg >= self.cva_borderline_deg:
+            raise ValueError(
+                f"cva_forward_head_deg ({self.cva_forward_head_deg}) must be strictly below "
+                f"cva_borderline_deg ({self.cva_borderline_deg}) — a smaller craniovertebral "
+                "angle is worse, not better. Equal values leave the borderline band empty, so "
+                "that finding could never fire"
+            )
+        if self.knee_seated_min_deg >= self.knee_seated_max_deg:
+            raise ValueError("knee_seated_min_deg must be below knee_seated_max_deg")
+        if self.lateral_view_max_ratio >= self.frontal_view_min_ratio:
+            raise ValueError(
+                "lateral_view_max_ratio must be below frontal_view_min_ratio; the gap between "
+                "them is the ambiguous-view band, and it cannot be negative"
+            )
+        if self.score_penalty_per_finding < 0.0:
+            raise ValueError("score_penalty_per_finding must not be negative")
+
+
+DEFAULT_THRESHOLDS: Final = Thresholds()
+"""A shared instance of the defaults.
+
+Safe to share because the class is frozen — this is a constant, not a mutable global. Callers that
+want different values construct their own with :func:`dataclasses.replace`, which is what every
+boundary test does.
+"""

--- a/packages/posture-core/tests/test_thresholds.py
+++ b/packages/posture-core/tests/test_thresholds.py
@@ -1,0 +1,111 @@
+"""Tests for the threshold container.
+
+Mostly about the validation, because the values themselves are meant to change and pinning them
+here would just make retuning a two-file edit. What must not change is that a *contradictory* set
+of values fails loudly at construction rather than producing a rule that silently never fires.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from posture_core.thresholds import DEFAULT_THRESHOLDS, RULES_VERSION, Thresholds
+
+
+def test_defaults_construct() -> None:
+    assert Thresholds().version == RULES_VERSION
+
+
+def test_thresholds_are_immutable() -> None:
+    """So the shared DEFAULT_THRESHOLDS instance cannot become a mutable global by accident.
+
+    A test that nudged one value on the shared object would leak into every test after it, and the
+    failure would surface somewhere unrelated.
+    """
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        DEFAULT_THRESHOLDS.trunk_slouch_deg = 25.0  # type: ignore[misc]
+
+
+def test_a_variant_is_made_by_replacement_not_mutation() -> None:
+    """The pattern every boundary test uses.
+
+    The original value is captured rather than written as a literal. What is being asserted is
+    that the shared instance is *unchanged*, not what it happens to hold — and this module states
+    that the defaults are expected to be retuned, so a literal here would make every retune a
+    two-file edit for no added protection.
+    """
+    original = DEFAULT_THRESHOLDS.trunk_slouch_deg
+    strict = dataclasses.replace(DEFAULT_THRESHOLDS, trunk_slouch_deg=original - 5.0)
+    assert strict.trunk_slouch_deg == original - 5.0
+    assert DEFAULT_THRESHOLDS.trunk_slouch_deg == original
+    assert strict.min_visibility == DEFAULT_THRESHOLDS.min_visibility
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_confidence_thresholds_must_be_probabilities(value: float) -> None:
+    with pytest.raises(ValueError, match="probability"):
+        Thresholds(min_visibility=value)
+    with pytest.raises(ValueError, match="probability"):
+        Thresholds(min_presence=value)
+
+
+def test_an_inverted_trunk_band_is_rejected() -> None:
+    """Upright above slouch leaves a band nothing can fall into.
+
+    That is the failure this validation exists for: it raises nothing at runtime, produces no bad
+    number, and simply means one classification can never be reached. Silent dead code in a rules
+    engine is worse than a crash.
+    """
+    with pytest.raises(ValueError, match="nothing could fall between them"):
+        Thresholds(trunk_upright_deg=30.0, trunk_slouch_deg=20.0)
+
+
+def test_recline_must_be_a_negative_angle() -> None:
+    """It is a *backward* lean, and the sign convention is the whole point of the metric."""
+    with pytest.raises(ValueError, match="must be negative"):
+        Thresholds(trunk_recline_deg=20.0)
+
+
+def test_the_craniovertebral_ordering_is_enforced_because_smaller_is_worse() -> None:
+    """The one threshold in the file where a smaller value means worse posture.
+
+    Every other angular threshold runs the other way, so getting this backwards is an easy and
+    entirely silent mistake.
+    """
+    with pytest.raises(ValueError, match="smaller craniovertebral"):
+        Thresholds(cva_forward_head_deg=60.0, cva_borderline_deg=55.0)
+
+
+def test_equal_craniovertebral_thresholds_are_rejected_too() -> None:
+    """Equality is not a harmless edge case: it empties the borderline band.
+
+    With both set to 50, `value < 50` claims the major finding and `value < 50` can never be
+    reached again, so `forward_head_borderline` becomes unreachable. That is precisely the silent
+    dead rule this validation exists to prevent, so the comparison is strict.
+    """
+    with pytest.raises(ValueError, match="strictly below"):
+        Thresholds(cva_forward_head_deg=50.0, cva_borderline_deg=50.0)
+
+
+def test_an_inverted_knee_band_is_rejected() -> None:
+    with pytest.raises(ValueError, match="knee_seated_min_deg"):
+        Thresholds(knee_seated_min_deg=130.0, knee_seated_max_deg=120.0)
+
+
+def test_the_view_bands_must_leave_a_non_negative_ambiguous_gap() -> None:
+    with pytest.raises(ValueError, match="ambiguous-view band"):
+        Thresholds(lateral_view_max_ratio=0.6, frontal_view_min_ratio=0.5)
+
+
+def test_a_negative_score_penalty_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must not be negative"):
+        Thresholds(score_penalty_per_finding=-5.0)
+
+
+def test_every_field_has_a_default_so_a_caller_can_override_one_thing() -> None:
+    """A required field here would make `Thresholds(trunk_slouch_deg=25)` impossible and push
+    every test into restating the whole configuration."""
+    for field in dataclasses.fields(Thresholds):
+        assert field.default is not dataclasses.MISSING, field.name


### PR DESCRIPTION
Closes OP-24. Base: `op-23-geometry`.

Collects every tunable into one frozen dataclass, injected rather than global.

## Changes
- `posture_core.thresholds`: `Thresholds` (17 fields), `DEFAULT_THRESHOLDS`, `RULES_VERSION`.

## Notes
- Replaces constants scattered through the code that used them, including the `±100` pixel arm-crossing literal whose own comment said it "shall be replaced with a calculation which can adjust to different sizes of people".
- Injected, not global: boundary tests construct their own instance rather than monkeypatching, so a test cannot leak into the next one.
- No loading here. `posture_core` reads no files or environment variables; the API layer loads and passes down (OP-39), and OP-36 moves the defaults to `posture-spec/rules.json`.
- `__post_init__` rejects contradictory orderings — upright above slouch, positive recline, inverted knee band, view ratios with a negative gap. These produce a band no value can fall into, so the rule silently never fires.
- `cva_forward_head_deg` must be below `cva_borderline_deg`: a smaller craniovertebral angle is worse, the opposite of every other threshold here.
- Defaults are starting points, clinical where a standard exists. `arms_crossed_ratio` is revised against measurements in OP-28.

## Tests
12 tests, 100% coverage, mostly on the validation.
