### PR TITLE
OP-25: Keypoint resolver and the status model

### DIFF
--- a/packages/posture-core/src/posture_core/resolver.py
+++ b/packages/posture-core/src/posture_core/resolver.py
@@ -1,0 +1,218 @@
+"""Turning a raw :class:`~posture_core.PoseFrame` into landmarks a metric is allowed to use.
+
+Every metric begins the same way: name the keypoints it needs, and either get them — all present,
+all confident — or get a structured refusal it can return unchanged. Doing that once, here, is
+what keeps each metric module about geometry instead of about defensive checks, and it is what
+makes "we abstained, and here is why" the *default* behaviour rather than something each metric
+has to remember to do.
+
+The resolver is also where a frame's **orientation** is worked out, because that is interpretation
+of the frame rather than a property of any one metric. See :meth:`KeypointResolver.forward_axis`.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, TypeAlias
+
+import numpy as np
+
+from posture_core.geometry import UP, Vector3, norm, world_vec
+from posture_core.keypoints import KeypointName
+from posture_core.status import Gap, KeypointStatus, Metric, MetricStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from posture_core.keypoints import Landmark, PoseFrame
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["KeypointResolver", "Resolution", "Resolved", "Unresolved"]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Resolved:
+    """Every requested keypoint was present and confident."""
+
+    landmarks: Mapping[KeypointName, Landmark]
+    confidence: float
+    """The weakest input's visibility — see the note on :attr:`~posture_core.status.Metric`."""
+
+    def world(self, name: KeypointName) -> Vector3 | None:
+        return world_vec(self.landmarks[name])
+
+    def __getitem__(self, name: KeypointName) -> Landmark:
+        return self.landmarks[name]
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Unresolved:
+    """At least one requested keypoint is unusable, with the specifics retained.
+
+    Carries enough detail to become a :class:`~posture_core.status.Gap` without the metric having
+    to reconstruct anything — which is the point, because a metric that had to explain its own
+    absence would be a metric that could get the explanation wrong.
+    """
+
+    status: MetricStatus
+    problems: Mapping[KeypointName, KeypointStatus]
+
+    def as_metric(self, name: str, unit: str) -> Metric:
+        """The empty metric to return from a computation that cannot proceed."""
+        return Metric(
+            name=name,
+            value=None,
+            unit=unit,
+            status=self.status,
+            detail=self._detail(),
+            inputs=tuple(self.problems),
+        )
+
+    def as_gap(self, metric: str) -> Gap:
+        return Gap(
+            metric=metric, status=self.status, detail=self._detail(), keypoints=self.problems
+        )
+
+    def _detail(self) -> str:
+        """Phrased for the person in the photograph, not for a log line.
+
+        The whole value of the status model is that the user hears something actionable, so the
+        wording is grouped by remedy: reframe the shot, or improve the view of what is already in
+        it.
+        """
+        missing = sorted(
+            name.value.replace("_", " ")
+            for name, status in self.problems.items()
+            if status in (KeypointStatus.NOT_DETECTED, KeypointStatus.OUT_OF_FRAME)
+        )
+        unclear = sorted(
+            name.value.replace("_", " ")
+            for name, status in self.problems.items()
+            if status is KeypointStatus.LOW_CONFIDENCE
+        )
+
+        parts = []
+        if missing:
+            parts.append(f"could not see {_join(missing)} in the photo")
+        if unclear:
+            parts.append(f"{_join(unclear)} {'was' if len(unclear) == 1 else 'were'} unclear")
+        return "; ".join(parts) if parts else "required landmarks were unavailable"
+
+
+def _join(items: list[str]) -> str:
+    if len(items) == 1:
+        return items[0]
+    return f"{', '.join(items[:-1])} and {items[-1]}"
+
+
+Resolution: TypeAlias = Resolved | Unresolved
+
+
+class KeypointResolver:
+    """Reads one frame, under one set of thresholds.
+
+    Constructed per report rather than per metric so the per-keypoint status is computed once and
+    every metric in the report agrees about which landmarks were usable. Two metrics disagreeing
+    about whether the left knee was visible would be a genuinely confusing bug to chase.
+    """
+
+    __slots__ = ("_frame", "_statuses", "_thresholds")
+
+    def __init__(self, frame: PoseFrame, thresholds: Thresholds) -> None:
+        self._frame = frame
+        self._thresholds = thresholds
+        self._statuses: dict[KeypointName, KeypointStatus] = {
+            name: self._classify(frame.get(name)) for name in KeypointName
+        }
+
+    def _classify(self, landmark: Landmark | None) -> KeypointStatus:
+        if landmark is None:
+            return KeypointStatus.NOT_DETECTED
+        # Presence is checked first and separately: "not in the picture" is a stronger and more
+        # actionable statement than "hard to see", and a point that is out of frame is also
+        # necessarily low-visibility, so the other order would mask it.
+        if landmark.presence < self._thresholds.min_presence:
+            return KeypointStatus.OUT_OF_FRAME
+        if landmark.visibility < self._thresholds.min_visibility:
+            return KeypointStatus.LOW_CONFIDENCE
+        return KeypointStatus.OK
+
+    @property
+    def frame(self) -> PoseFrame:
+        return self._frame
+
+    def status(self, name: KeypointName) -> KeypointStatus:
+        return self._statuses[name]
+
+    @property
+    def statuses(self) -> Mapping[KeypointName, KeypointStatus]:
+        """Every keypoint's status, for the report's quality section."""
+        return dict(self._statuses)
+
+    def require(self, *names: KeypointName) -> Resolution:
+        """All of ``names``, or a structured explanation of why not.
+
+        A metric never inspects landmark confidence itself. It states its inputs and receives
+        either usable data or a refusal — so "abstain honestly" is the path of least resistance
+        rather than the path someone has to remember.
+        """
+        problems = {
+            name: self._statuses[name]
+            for name in names
+            if self._statuses[name] is not KeypointStatus.OK
+        }
+        if problems:
+            # A missing keypoint outranks an unclear one: it is the more fundamental obstacle and
+            # the one whose remedy — reframe the shot — subsumes the other.
+            structural = any(
+                status in (KeypointStatus.NOT_DETECTED, KeypointStatus.OUT_OF_FRAME)
+                for status in problems.values()
+            )
+            return Unresolved(
+                status=(
+                    MetricStatus.INSUFFICIENT_KEYPOINTS
+                    if structural
+                    else MetricStatus.LOW_CONFIDENCE
+                ),
+                problems=problems,
+            )
+
+        landmarks = {name: self._frame.landmarks[name] for name in names}
+        return Resolved(
+            landmarks=landmarks,
+            confidence=min(landmark.visibility for landmark in landmarks.values()),
+        )
+
+    def forward_axis(self) -> Vector3 | None:
+        """Which way the subject is facing, as a horizontal unit vector, or ``None``.
+
+        Signed lean is meaningless without this. Leaning 25° toward image-right is a slouch for
+        someone facing right and a recline for someone facing left, so the sign has to be taken
+        relative to the *subject*, not the frame.
+
+        Derived from the nose relative to the shoulder midpoint, with the vertical component
+        removed — the face points forward, and unlike the legacy engine's approach this needs no
+        hand-maintained laterality flag keyed off landmark indices. That flag was read from a
+        misdocumented config and made spine classification backwards for one facing direction
+        (FINDINGS §2.1); there is nothing here to get backwards.
+
+        ``None`` when the subject faces the camera squarely, where "forward" is along the view
+        axis and no sagittal measurement is meaningful anyway — which ``view_confidence`` (OP-31)
+        reports as its own gap.
+        """
+        nose = self._frame.get(KeypointName.NOSE)
+        neck = self._frame.get(KeypointName.NECK)
+        if nose is None or neck is None:
+            return None
+
+        nose_world, neck_world = world_vec(nose), world_vec(neck)
+        if nose_world is None or neck_world is None:
+            return None
+
+        direction = nose_world - neck_world
+        horizontal = direction - np.dot(direction, UP) * UP
+        length = norm(horizontal)
+        if length < 1e-6:
+            # The face points straight up or straight down: no usable horizontal facing.
+            return None
+        return np.asarray(horizontal / length, dtype=np.float64)

--- a/packages/posture-core/src/posture_core/status.py
+++ b/packages/posture-core/src/posture_core/status.py
@@ -1,0 +1,171 @@
+"""The vocabulary for "I could not assess this" — the correctness fix the whole rebuild turns on.
+
+## The defect being fixed
+
+The inherited engine's `checkPosition` returned `None` whenever anything went wrong: a missing
+keypoint, an exception it had swallowed, a geometry it could not evaluate. The caller rendered
+`None` as **"Straight back position."** So the system told users their posture was fine precisely
+when it had failed to assess them at all (FINDINGS §2.5).
+
+That is not a bug in one function. It is what happens when a codebase has no way to *say*
+"unknown" — the only channel available was the same one used for answers, so absence of evidence
+became evidence of absence.
+
+## The fix
+
+A metric that could not be computed carries ``value = None`` **and** a :class:`MetricStatus`
+explaining why, and produces a :class:`Gap` rather than a :class:`~posture_core.rules.Finding`.
+The API can then say "I couldn't assess your knees — try a wider shot" instead of inventing an
+answer. Nothing here is clever; it is just an honest type, and it is the cheapest high-value
+change in the project.
+
+## No bare `except Exception`
+
+Anywhere. A swallowed exception is how the original produced a `None` it could not explain. Where
+a computation can legitimately fail — coincident landmarks give a vector with no direction — the
+failure is caught **by its specific type** and converted into a status that names it.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import StrEnum
+from types import MappingProxyType
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from posture_core.keypoints import KeypointName
+
+__all__ = ["Gap", "KeypointStatus", "Metric", "MetricStatus"]
+
+
+class KeypointStatus(StrEnum):
+    """How usable a single landmark is.
+
+    Four states rather than a boolean, because the remedies differ and the user deserves to be
+    told which one applies. "Your knees are out of shot" and "your knees are behind the desk" ask
+    for different things from the person holding the camera.
+    """
+
+    OK = "ok"
+    LOW_CONFIDENCE = "low_confidence"
+    """Present and in frame, but the model is unsure. Usable for context, not for measurement."""
+
+    NOT_DETECTED = "not_detected"
+    """The backend did not report this keypoint at all — a different fact from low confidence.
+
+    Collapsing the two would make it impossible to tell "this backend has no heel landmark"
+    (a schema limitation, as with the 17-point escape hatch in ADR-0002) from "this photo does not
+    show a heel" (a framing problem the user can fix).
+    """
+
+    OUT_OF_FRAME = "out_of_frame"
+    """Low *presence*: the model does not believe the point is in the picture.
+
+    Distinguishable from occlusion only because MediaPipe reports presence and visibility
+    separately — one of the three reasons it was chosen (ADR-0002).
+    """
+
+
+class MetricStatus(StrEnum):
+    """Whether a metric's value can be believed."""
+
+    OK = "ok"
+
+    INSUFFICIENT_KEYPOINTS = "insufficient_keypoints"
+    """A landmark the metric needs was not reported, or was out of frame."""
+
+    LOW_CONFIDENCE = "low_confidence"
+    """Every needed landmark exists, but at least one is below the confidence threshold.
+
+    Kept separate from INSUFFICIENT_KEYPOINTS because it is recoverable by better lighting or a
+    clearer shot, whereas a missing keypoint usually needs a different framing.
+    """
+
+    UNDEFINED_GEOMETRY = "undefined_geometry"
+    """The landmarks are all present but describe no answer.
+
+    Not in the original ticket's list, and added because the situation is real: a backend can
+    collapse two landmarks onto the same point when a joint is fully occluded, and the angle
+    between a vector and nothing is a question with no answer rather than a zero. Folding it into
+    INSUFFICIENT_KEYPOINTS would have been a small lie in exactly the place this module exists to
+    stop telling small lies.
+    """
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Metric:
+    """One measurement, or one honest refusal to measure.
+
+    The invariant, enforced below: ``status is OK`` if and only if ``value is not None``. It is
+    checked rather than trusted because every downstream consumer — rules, the report, the API
+    response, the frontend — branches on it, and a metric that violated it would produce a
+    plausible-looking wrong answer at each of them.
+    """
+
+    name: str
+    value: float | None
+    unit: str
+    status: MetricStatus
+    detail: str
+    """Human-readable, and written for the person in the photograph rather than for a log."""
+
+    inputs: tuple[KeypointName, ...] = ()
+    """Which landmarks this measurement rests on. Carried so a Gap can name them."""
+
+    confidence: float | None = None
+    """The *weakest* input's visibility, not the average.
+
+    A measurement is only as trustworthy as the least trustworthy thing it was computed from.
+    Averaging would let one confidently-seen landmark launder an unseen one into a plausible
+    number — which is how a metric ends up reported with confidence it has not earned.
+    """
+
+    def __post_init__(self) -> None:
+        if (self.status is MetricStatus.OK) != (self.value is not None):
+            raise ValueError(
+                f"metric {self.name!r} has status {self.status} with value {self.value!r}; "
+                "a value and an OK status must accompany each other"
+            )
+
+    @property
+    def is_ok(self) -> bool:
+        return self.status is MetricStatus.OK
+
+    def as_gap(self, problems: Mapping[KeypointName, KeypointStatus] | None = None) -> Gap:
+        """The :class:`Gap` this metric produces when it could not be computed."""
+        if self.is_ok:
+            raise ValueError(f"metric {self.name!r} succeeded and has no gap to report")
+        return Gap(
+            metric=self.name,
+            status=self.status,
+            detail=self.detail,
+            keypoints=dict(problems or {}),
+        )
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Gap:
+    """Something the engine deliberately did not assess, and why.
+
+    Gaps are a **first-class part of the report**, not an error channel. A report with three
+    findings and two gaps is a more useful and more honest document than one with three findings
+    and silence — and the silence is what the original shipped.
+    """
+
+    metric: str
+    status: MetricStatus
+    detail: str
+    keypoints: Mapping[KeypointName, KeypointStatus] = dataclasses.field(default_factory=dict)
+    """The specific landmarks responsible, so the advice can be specific too."""
+
+    def __post_init__(self) -> None:
+        if self.status is MetricStatus.OK:
+            raise ValueError(f"gap for {self.metric!r} cannot have an OK status")
+        # Same guard `PoseFrame` applies, and for the same reason: `frozen=True` freezes the
+        # attribute binding, not the mapping bound to it, so without this a gap's keypoints stay
+        # editable after the gap has been produced. A gap is a statement about what the engine
+        # could not assess; it should not be revisable by whoever happens to hold it.
+        object.__setattr__(self, "keypoints", MappingProxyType(dict(self.keypoints)))

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -1,0 +1,191 @@
+"""Every tunable number in the rules engine, in one frozen, injected object.
+
+## Why this exists at all
+
+The inherited engine scattered its constants through the code it used them in — a `±100` pixel
+literal for arm crossing whose own inline comment admitted it "shall be replaced with a
+calculation which can adjust to different sizes of people", a hardcoded angle for spine
+classification, a foot check that was a tautology. Retuning any of them meant finding them,
+understanding the surrounding code, and hoping there was not a second copy. There usually was:
+about 250 lines were duplicated between the two posture scripts.
+
+Collecting them here changes three things:
+
+* **Tuning is a config change.** One object, one place, no code touched.
+* **Every rule test is parameterisable.** A boundary test can construct `Thresholds(slouch_deg=30)`
+  and assert behaviour at exactly 29.9 and 30.1 without monkeypatching a module global.
+* **There is no module global to patch.** Thresholds are passed in. A test that mutated a global
+  would leak into every test that ran after it, and the failure would land somewhere else
+  entirely.
+
+## Why injected rather than loaded here
+
+This package reads no files and no environment variables — that is the constraint that lets its
+suite run in seconds anywhere. The API layer loads its own values from the environment (OP-39) and
+passes the resulting object down. In OP-36 the defaults below move to
+`packages/posture-spec/rules.json`, so the Python engine and its TypeScript mirror load *the same*
+numbers and cannot drift; this dataclass then becomes the parsed shape of that file rather than
+the source of the values.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import Final
+
+__all__ = ["DEFAULT_THRESHOLDS", "RULES_VERSION", "Thresholds"]
+
+RULES_VERSION: Final = "1.0.0"
+"""Stamped onto every report (OP-32).
+
+Two reports are only comparable if they were produced by the same rules at the same settings. A
+stored report with no version becomes uninterpretable the first time a threshold moves — you can
+no longer tell whether the user's posture changed or the yardstick did.
+"""
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Thresholds:
+    """Every number a rule is allowed to compare against.
+
+    Defaults are starting points chosen from the clinical literature where one exists and from the
+    fixture set otherwise. They are not sacred, and the point of this class is that changing them
+    is cheap.
+    """
+
+    version: str = RULES_VERSION
+
+    # -- confidence ----------------------------------------------------------------------------
+    min_visibility: float = 0.5
+    """Below this, a landmark is reported but not trusted for measurement.
+
+    Matches MediaPipe's own default detection confidence. Raising it makes the engine abstain more
+    often, which is the safe direction: an abstention says "I couldn't assess this", a bad
+    measurement says something false with confidence.
+    """
+
+    min_presence: float = 0.5
+    """Below this, the landmark is treated as outside the frame rather than merely occluded.
+
+    The two signals are independent, and keeping their thresholds separate is what lets the API
+    tell a user "your knees are out of shot" rather than "your knees are unclear".
+    """
+
+    # -- trunk inclination (OP-26) -------------------------------------------------------------
+    trunk_upright_deg: float = 10.0
+    """Forward lean at or below this is neutral sitting, not a finding."""
+
+    trunk_slouch_deg: float = 20.0
+    """Forward lean beyond this is a slouch worth reporting."""
+
+    trunk_recline_deg: float = -20.0
+    """Backward lean beyond this (i.e. more negative) is reclining.
+
+    A separate threshold rather than a mirror of the slouch value, because the two are not
+    symmetric problems: reclining into a supportive backrest is mostly benign, slouching forward
+    unsupported is not.
+    """
+
+    # -- craniovertebral angle (OP-27) ---------------------------------------------------------
+    cva_forward_head_deg: float = 50.0
+    """Below this, forward head posture. The standard clinical cutoff.
+
+    Note the direction: a *smaller* craniovertebral angle is worse, which is the opposite of every
+    other angular threshold here and is worth stating twice.
+    """
+
+    cva_borderline_deg: float = 55.0
+    """Between this and the cutoff, worth mentioning but not calling a fault."""
+
+    # -- arms and elbows (OP-28) ---------------------------------------------------------------
+    arms_crossed_ratio: float = 0.15
+    """``|forearm - upper_arm| / torso_length`` below which the arms read as crossed.
+
+    Normalised by torso length, which is the entire fix for the legacy `±100` pixel literal: the
+    same crossed arms at twice the camera distance produced half the pixel difference and a
+    different verdict. Dividing by a length measured on the same body cancels the scale.
+    """
+
+    elbow_flexed_deg: float = 120.0
+    """Elbow angle below this counts as flexed."""
+
+    # -- knees (OP-29) -------------------------------------------------------------------------
+    knee_seated_min_deg: float = 70.0
+    knee_seated_max_deg: float = 120.0
+    """A hip-knee-ankle angle in this band is ordinary seated posture."""
+
+    knee_kneeling_max_deg: float = 60.0
+    """Below this the subject is kneeling rather than sitting."""
+
+    # -- heel contact (OP-30) ------------------------------------------------------------------
+    heel_contact_tolerance_m: float = 0.05
+    """How far above the lowest foot point a heel may sit and still count as grounded.
+
+    In metres, from world landmarks — which is why this metric is possible at all. The 18-point
+    COCO schema the legacy engine used had no foot landmarks, so its feet check was a tautology
+    that returned "on the floor" for a fixture whose subject's feet visibly dangle.
+    """
+
+    # -- view confidence (OP-31) ---------------------------------------------------------------
+    lateral_view_max_ratio: float = 0.35
+    """``shoulder_width / torso_length`` in image space, at or below which the view is lateral.
+
+    In a true side view the shoulders overlap and this approaches zero; face-on it approaches the
+    subject's real proportions. The original app *told* users to photograph themselves from the
+    side and then assessed whatever arrived — so a 30° slump shot head-on, which projects to
+    almost no apparent lean, was reported as good posture with full confidence.
+    """
+
+    frontal_view_min_ratio: float = 0.55
+    """At or above this the view is frontal and sagittal metrics must abstain."""
+
+    # -- scoring (OP-32) -----------------------------------------------------------------------
+    score_penalty_per_finding: float = 15.0
+    """Points deducted from 100 for each fault found.
+
+    Deliberately crude and deliberately documented as such: an overall score is a summary for the
+    user, not a measurement. The findings are the output that means something.
+    """
+
+    def __post_init__(self) -> None:
+        # Ordering constraints, checked because a mis-ordered pair does not raise anywhere else —
+        # it just produces a band that no value can fall into, so a rule silently never fires.
+        if not 0.0 <= self.min_visibility <= 1.0:
+            raise ValueError(f"min_visibility must be a probability, got {self.min_visibility}")
+        if not 0.0 <= self.min_presence <= 1.0:
+            raise ValueError(f"min_presence must be a probability, got {self.min_presence}")
+        if self.trunk_upright_deg > self.trunk_slouch_deg:
+            raise ValueError(
+                f"trunk_upright_deg ({self.trunk_upright_deg}) must not exceed "
+                f"trunk_slouch_deg ({self.trunk_slouch_deg}); nothing could fall between them"
+            )
+        if self.trunk_recline_deg >= 0.0:
+            raise ValueError(
+                f"trunk_recline_deg is a backward lean and must be negative, "
+                f"got {self.trunk_recline_deg}"
+            )
+        if self.cva_forward_head_deg >= self.cva_borderline_deg:
+            raise ValueError(
+                f"cva_forward_head_deg ({self.cva_forward_head_deg}) must be strictly below "
+                f"cva_borderline_deg ({self.cva_borderline_deg}) — a smaller craniovertebral "
+                "angle is worse, not better. Equal values leave the borderline band empty, so "
+                "that finding could never fire"
+            )
+        if self.knee_seated_min_deg >= self.knee_seated_max_deg:
+            raise ValueError("knee_seated_min_deg must be below knee_seated_max_deg")
+        if self.lateral_view_max_ratio >= self.frontal_view_min_ratio:
+            raise ValueError(
+                "lateral_view_max_ratio must be below frontal_view_min_ratio; the gap between "
+                "them is the ambiguous-view band, and it cannot be negative"
+            )
+        if self.score_penalty_per_finding < 0.0:
+            raise ValueError("score_penalty_per_finding must not be negative")
+
+
+DEFAULT_THRESHOLDS: Final = Thresholds()
+"""A shared instance of the defaults.
+
+Safe to share because the class is frozen — this is a constant, not a mutable global. Callers that
+want different values construct their own with :func:`dataclasses.replace`, which is what every
+boundary test does.
+"""

--- a/packages/posture-core/tests/test_resolver.py
+++ b/packages/posture-core/tests/test_resolver.py
@@ -1,0 +1,350 @@
+"""Tests for the keypoint resolver and the status model.
+
+This is the layer that decides whether a metric is allowed to produce a number at all, so its
+tests are the ones that pin down the project's central correctness claim: the engine says
+"I could not assess this" instead of quietly saying "you look fine".
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import numpy as np
+import pytest
+
+from posture_core import KeypointName, Landmark, PoseFrame
+from posture_core.resolver import KeypointResolver, Resolved, Unresolved
+from posture_core.status import Gap, KeypointStatus, Metric, MetricStatus
+from posture_core.synthetic import Facing, View, make_pose
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+K = KeypointName
+
+
+def frame_from(landmarks: dict[KeypointName, Landmark]) -> PoseFrame:
+    return PoseFrame(
+        landmarks=landmarks,
+        image_width=640,
+        image_height=480,
+        backend="test",
+        inference_ms=0.0,
+    )
+
+
+def resolver_for(**pose_kwargs: object) -> KeypointResolver:
+    return KeypointResolver(frame_from(make_pose(**pose_kwargs)), DEFAULT_THRESHOLDS)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------------------------
+# Keypoint classification
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_confident_landmark_is_ok() -> None:
+    assert resolver_for().status(K.LEFT_HIP) is KeypointStatus.OK
+
+
+def test_an_unreported_landmark_is_not_detected_rather_than_low_confidence() -> None:
+    """Two different facts with two different remedies.
+
+    Collapsing them makes it impossible to distinguish "this backend has no heel landmark" — a
+    schema limitation, as with the 17-point escape hatch in ADR-0002 — from "this photo does not
+    show a heel", which the person holding the camera can fix.
+    """
+    resolver = resolver_for(omit=(K.LEFT_HEEL,))
+    assert resolver.status(K.LEFT_HEEL) is KeypointStatus.NOT_DETECTED
+
+
+def test_low_visibility_with_high_presence_reads_as_low_confidence() -> None:
+    """Occluded: the model believes the point is in the picture but cannot see it clearly."""
+    resolver = resolver_for(confidence={K.LEFT_WRIST: (0.2, 0.95)})
+    assert resolver.status(K.LEFT_WRIST) is KeypointStatus.LOW_CONFIDENCE
+
+
+def test_low_presence_reads_as_out_of_frame_even_when_visibility_is_high() -> None:
+    """Presence is checked first, and the order matters.
+
+    A point outside the picture is necessarily also hard to see, so checking visibility first
+    would mask the stronger and more actionable statement. "Your knees are out of shot" tells the
+    user to step back; "your knees are unclear" tells them to turn on a light.
+    """
+    resolver = resolver_for(confidence={K.LEFT_ANKLE: (0.99, 0.1)})
+    assert resolver.status(K.LEFT_ANKLE) is KeypointStatus.OUT_OF_FRAME
+
+
+def test_thresholds_are_injected_not_hardcoded() -> None:
+    landmarks = make_pose(confidence={K.LEFT_WRIST: (0.6, 0.9)})
+    lenient = KeypointResolver(frame_from(landmarks), DEFAULT_THRESHOLDS)
+    strict = KeypointResolver(
+        frame_from(landmarks), dataclasses.replace(DEFAULT_THRESHOLDS, min_visibility=0.8)
+    )
+    assert lenient.status(K.LEFT_WRIST) is KeypointStatus.OK
+    assert strict.status(K.LEFT_WRIST) is KeypointStatus.LOW_CONFIDENCE
+
+
+def test_every_canonical_keypoint_has_a_status() -> None:
+    """Including the ones the frame never contained, which is what makes the report's quality
+    section able to enumerate what was missing rather than only what was present."""
+    assert set(resolver_for(omit=(K.LEFT_HEEL, K.RIGHT_HEEL)).statuses) == set(KeypointName)
+
+
+# ---------------------------------------------------------------------------------------------
+# require()
+# ---------------------------------------------------------------------------------------------
+
+
+def test_require_returns_the_landmarks_when_all_are_usable() -> None:
+    resolution = resolver_for().require(K.LEFT_HIP, K.RIGHT_HIP, K.NECK)
+    assert isinstance(resolution, Resolved)
+    assert set(resolution.landmarks) == {K.LEFT_HIP, K.RIGHT_HIP, K.NECK}
+    assert resolution.world(K.NECK) is not None
+
+
+def test_confidence_is_the_weakest_input_not_the_average() -> None:
+    """A measurement is only as good as the least trustworthy thing it rests on.
+
+    Averaging would let one confidently-seen landmark launder a barely-seen one into a number that
+    looks well-supported — which is precisely how a metric comes to be reported with confidence it
+    has not earned.
+    """
+    resolver = KeypointResolver(
+        frame_from(make_pose(confidence={K.LEFT_HIP: (0.55, 0.99)})), DEFAULT_THRESHOLDS
+    )
+    resolution = resolver.require(K.LEFT_HIP, K.RIGHT_HIP)
+    assert isinstance(resolution, Resolved)
+    assert resolution.confidence == pytest.approx(0.55)
+
+
+def test_a_missing_keypoint_makes_the_metric_insufficient() -> None:
+    resolution = resolver_for(omit=(K.LEFT_KNEE,)).require(K.LEFT_HIP, K.LEFT_KNEE, K.LEFT_ANKLE)
+    assert isinstance(resolution, Unresolved)
+    assert resolution.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert resolution.problems == {K.LEFT_KNEE: KeypointStatus.NOT_DETECTED}
+
+
+def test_an_unclear_keypoint_makes_the_metric_low_confidence() -> None:
+    """Kept separate from a missing one because it is recoverable by better light, not reframing."""
+    resolution = resolver_for(confidence={K.LEFT_KNEE: (0.2, 0.95)}).require(
+        K.LEFT_HIP, K.LEFT_KNEE
+    )
+    assert isinstance(resolution, Unresolved)
+    assert resolution.status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_a_missing_keypoint_outranks_an_unclear_one() -> None:
+    """Reframing the shot subsumes improving the view of what is already in it, so the more
+    fundamental obstacle is the one reported."""
+    resolution = resolver_for(omit=(K.LEFT_ANKLE,), confidence={K.LEFT_KNEE: (0.2, 0.95)}).require(
+        K.LEFT_HIP, K.LEFT_KNEE, K.LEFT_ANKLE
+    )
+    assert isinstance(resolution, Unresolved)
+    assert resolution.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+
+
+def test_only_the_problem_keypoints_are_reported() -> None:
+    """A gap that listed every input would bury the one thing the user can act on."""
+    resolution = resolver_for(omit=(K.LEFT_KNEE,)).require(K.LEFT_HIP, K.LEFT_KNEE, K.LEFT_ANKLE)
+    assert isinstance(resolution, Unresolved)
+    assert set(resolution.problems) == {K.LEFT_KNEE}
+
+
+def test_the_explanation_names_the_landmarks_in_plain_language() -> None:
+    """Written for the person in the photograph, not for a log line.
+
+    The entire value of the status model is that the user hears something actionable. A gap saying
+    `INSUFFICIENT_KEYPOINTS: KeypointName.LEFT_KNEE` would be technically honest and useless.
+    """
+    resolution = resolver_for(omit=(K.LEFT_KNEE, K.RIGHT_KNEE)).require(K.LEFT_KNEE, K.RIGHT_KNEE)
+    assert isinstance(resolution, Unresolved)
+    gap = resolution.as_gap("knee_flexion_deg")
+    assert "could not see left knee and right knee" in gap.detail
+
+
+def test_unresolved_converts_to_an_empty_metric_carrying_its_reason() -> None:
+    resolution = resolver_for(omit=(K.LEFT_KNEE,)).require(K.LEFT_KNEE)
+    assert isinstance(resolution, Unresolved)
+    metric = resolution.as_metric("knee_flexion_deg", "deg")
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert metric.is_ok is False
+
+
+# ---------------------------------------------------------------------------------------------
+# Orientation
+# ---------------------------------------------------------------------------------------------
+
+
+def test_forward_axis_follows_the_subject_not_the_frame() -> None:
+    """The replacement for the legacy laterality flag.
+
+    That flag was read from a misdocumented config and made spine classification backwards for one
+    facing direction. Deriving facing from the nose leaves nothing to get backwards.
+    """
+    facing_right = resolver_for(facing=Facing.RIGHT).forward_axis()
+    facing_left = resolver_for(facing=Facing.LEFT).forward_axis()
+    assert facing_right is not None and facing_left is not None
+    assert facing_right[0] == pytest.approx(1.0, abs=1e-6)
+    assert facing_left[0] == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_forward_axis_is_horizontal_and_unit_length() -> None:
+    axis = resolver_for(trunk_deg=35.0).forward_axis()
+    assert axis is not None
+    assert float(np.linalg.norm(axis)) == pytest.approx(1.0)
+    assert axis[1] == pytest.approx(0.0, abs=1e-9)
+
+
+def test_forward_axis_survives_a_deep_slouch() -> None:
+    """A slouching subject's face tilts downward, and the vertical component is removed rather
+    than allowed to shrink the horizontal one to nothing."""
+    axis = resolver_for(trunk_deg=45.0, neck_deg=40.0).forward_axis()
+    assert axis is not None
+    assert axis[0] == pytest.approx(1.0, abs=1e-6)
+
+
+def test_forward_axis_points_at_the_camera_in_a_frontal_view() -> None:
+    """Correct, and the reason sagittal metrics must abstain on such a photo (OP-31): the lean is
+    along the view axis, so it projects to nothing."""
+    axis = resolver_for(view=View.FRONTAL).forward_axis()
+    assert axis is not None
+    assert axis[2] == pytest.approx(-1.0, abs=1e-6)
+
+
+def test_forward_axis_is_none_without_a_nose_or_a_neck() -> None:
+    assert resolver_for(omit=(K.NOSE,)).forward_axis() is None
+    assert resolver_for(omit=(K.NECK,)).forward_axis() is None
+
+
+def test_forward_axis_is_none_when_the_face_points_straight_up() -> None:
+    """No horizontal component means no usable facing, and a normalised near-zero vector would be
+    numerical noise pointing in an arbitrary direction — which would then silently set the sign of
+    every lean measurement."""
+    landmarks = dict(make_pose())
+    neck = landmarks[K.NECK]
+    landmarks[K.NOSE] = Landmark(
+        x=neck.x,
+        y=neck.y - 0.1,
+        visibility=0.9,
+        presence=0.9,
+        x_world=neck.x_world,
+        y_world=(neck.y_world or 0.0) - 0.2,
+        z_world=neck.z_world,
+    )
+    assert KeypointResolver(frame_from(landmarks), DEFAULT_THRESHOLDS).forward_axis() is None
+
+
+def test_resolved_exposes_landmarks_by_subscript_and_the_frame_is_readable() -> None:
+    """Both are conveniences the metric modules use on every call, so both are worth pinning."""
+    resolver = resolver_for()
+    resolution = resolver.require(K.LEFT_HIP)
+    assert isinstance(resolution, Resolved)
+    assert resolution[K.LEFT_HIP] is resolver.frame.landmarks[K.LEFT_HIP]
+
+
+def test_a_single_unclear_landmark_is_described_in_the_singular() -> None:
+    """Grammar, because the string is shown to a person. "left wrist were unclear" reads as a bug
+    in the product even when the assessment behind it is correct."""
+    resolution = resolver_for(confidence={K.LEFT_WRIST: (0.2, 0.95)}).require(K.LEFT_WRIST)
+    assert isinstance(resolution, Unresolved)
+    assert "left wrist was unclear" in resolution.as_gap("elbow_flexion_deg").detail
+
+
+def test_both_kinds_of_problem_are_reported_together() -> None:
+    resolution = resolver_for(omit=(K.LEFT_ANKLE,), confidence={K.LEFT_KNEE: (0.2, 0.95)}).require(
+        K.LEFT_KNEE, K.LEFT_ANKLE
+    )
+    assert isinstance(resolution, Unresolved)
+    detail = resolution.as_gap("knee_flexion_deg").detail
+    assert "could not see left ankle" in detail
+    assert "left knee was unclear" in detail
+
+
+def test_forward_axis_is_none_without_world_landmarks() -> None:
+    flat = {
+        name: Landmark(x=landmark.x, y=landmark.y, visibility=0.9, presence=0.9)
+        for name, landmark in make_pose().items()
+    }
+    assert KeypointResolver(frame_from(flat), DEFAULT_THRESHOLDS).forward_axis() is None
+
+
+# ---------------------------------------------------------------------------------------------
+# Metric and Gap invariants
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_metric_cannot_be_ok_without_a_value() -> None:
+    """The invariant every downstream consumer branches on.
+
+    Rules, report, API response and frontend all ask "is this OK?" and then read the value. A
+    metric that answered yes and carried `None` would produce a different plausible wrong answer
+    at each of them.
+    """
+    with pytest.raises(ValueError, match="must accompany each other"):
+        Metric(name="x", value=None, unit="deg", status=MetricStatus.OK, detail="")
+
+
+def test_a_metric_cannot_carry_a_value_it_says_it_could_not_measure() -> None:
+    with pytest.raises(ValueError, match="must accompany each other"):
+        Metric(
+            name="x",
+            value=12.0,
+            unit="deg",
+            status=MetricStatus.INSUFFICIENT_KEYPOINTS,
+            detail="",
+        )
+
+
+def test_a_successful_metric_has_no_gap() -> None:
+    metric = Metric(name="x", value=1.0, unit="deg", status=MetricStatus.OK, detail="")
+    with pytest.raises(ValueError, match="no gap to report"):
+        metric.as_gap()
+
+
+def test_a_gap_cannot_claim_everything_was_fine() -> None:
+    with pytest.raises(ValueError, match="cannot have an OK status"):
+        Gap(metric="x", status=MetricStatus.OK, detail="")
+
+
+def test_a_failed_metric_converts_itself_into_a_gap() -> None:
+    """The other direction of the same conversion: a metric that abstained knows how to say so.
+
+    Both directions exist because the report is assembled from metrics (OP-32) while the API's
+    user-facing quality section is assembled from gaps, and neither should have to reconstruct the
+    other's reasoning.
+    """
+    metric = Metric(
+        name="knee_flexion_deg",
+        value=None,
+        unit="deg",
+        status=MetricStatus.INSUFFICIENT_KEYPOINTS,
+        detail="could not see left knee in the photo",
+        inputs=(K.LEFT_KNEE,),
+    )
+    gap = metric.as_gap({K.LEFT_KNEE: KeypointStatus.NOT_DETECTED})
+    assert gap.metric == "knee_flexion_deg"
+    assert gap.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert gap.keypoints == {K.LEFT_KNEE: KeypointStatus.NOT_DETECTED}
+
+
+def test_a_gaps_keypoints_cannot_be_edited_after_it_is_produced() -> None:
+    """The same trap `frozen=True` leaves open on `PoseFrame`.
+
+    Freezing a dataclass freezes the attribute binding, not the mapping bound to it. A gap is a
+    statement about what the engine could not assess, and it should not be revisable by whoever
+    happens to be holding it.
+    """
+    gap = Gap(
+        metric="knee_flexion_deg",
+        status=MetricStatus.INSUFFICIENT_KEYPOINTS,
+        detail="could not see left knee in the photo",
+        keypoints={K.LEFT_KNEE: KeypointStatus.NOT_DETECTED},
+    )
+    with pytest.raises(TypeError):
+        gap.keypoints[K.RIGHT_KNEE] = KeypointStatus.NOT_DETECTED  # type: ignore[index]
+
+
+def test_a_gap_is_detached_from_the_mapping_it_was_built_from() -> None:
+    source = {K.LEFT_KNEE: KeypointStatus.NOT_DETECTED}
+    gap = Gap(metric="x", status=MetricStatus.INSUFFICIENT_KEYPOINTS, detail="", keypoints=source)
+    source[K.RIGHT_KNEE] = KeypointStatus.NOT_DETECTED
+    assert set(gap.keypoints) == {K.LEFT_KNEE}

--- a/packages/posture-core/tests/test_thresholds.py
+++ b/packages/posture-core/tests/test_thresholds.py
@@ -1,0 +1,111 @@
+"""Tests for the threshold container.
+
+Mostly about the validation, because the values themselves are meant to change and pinning them
+here would just make retuning a two-file edit. What must not change is that a *contradictory* set
+of values fails loudly at construction rather than producing a rule that silently never fires.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from posture_core.thresholds import DEFAULT_THRESHOLDS, RULES_VERSION, Thresholds
+
+
+def test_defaults_construct() -> None:
+    assert Thresholds().version == RULES_VERSION
+
+
+def test_thresholds_are_immutable() -> None:
+    """So the shared DEFAULT_THRESHOLDS instance cannot become a mutable global by accident.
+
+    A test that nudged one value on the shared object would leak into every test after it, and the
+    failure would surface somewhere unrelated.
+    """
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        DEFAULT_THRESHOLDS.trunk_slouch_deg = 25.0  # type: ignore[misc]
+
+
+def test_a_variant_is_made_by_replacement_not_mutation() -> None:
+    """The pattern every boundary test uses.
+
+    The original value is captured rather than written as a literal. What is being asserted is
+    that the shared instance is *unchanged*, not what it happens to hold — and this module states
+    that the defaults are expected to be retuned, so a literal here would make every retune a
+    two-file edit for no added protection.
+    """
+    original = DEFAULT_THRESHOLDS.trunk_slouch_deg
+    strict = dataclasses.replace(DEFAULT_THRESHOLDS, trunk_slouch_deg=original - 5.0)
+    assert strict.trunk_slouch_deg == original - 5.0
+    assert DEFAULT_THRESHOLDS.trunk_slouch_deg == original
+    assert strict.min_visibility == DEFAULT_THRESHOLDS.min_visibility
+
+
+@pytest.mark.parametrize("value", [-0.1, 1.1])
+def test_confidence_thresholds_must_be_probabilities(value: float) -> None:
+    with pytest.raises(ValueError, match="probability"):
+        Thresholds(min_visibility=value)
+    with pytest.raises(ValueError, match="probability"):
+        Thresholds(min_presence=value)
+
+
+def test_an_inverted_trunk_band_is_rejected() -> None:
+    """Upright above slouch leaves a band nothing can fall into.
+
+    That is the failure this validation exists for: it raises nothing at runtime, produces no bad
+    number, and simply means one classification can never be reached. Silent dead code in a rules
+    engine is worse than a crash.
+    """
+    with pytest.raises(ValueError, match="nothing could fall between them"):
+        Thresholds(trunk_upright_deg=30.0, trunk_slouch_deg=20.0)
+
+
+def test_recline_must_be_a_negative_angle() -> None:
+    """It is a *backward* lean, and the sign convention is the whole point of the metric."""
+    with pytest.raises(ValueError, match="must be negative"):
+        Thresholds(trunk_recline_deg=20.0)
+
+
+def test_the_craniovertebral_ordering_is_enforced_because_smaller_is_worse() -> None:
+    """The one threshold in the file where a smaller value means worse posture.
+
+    Every other angular threshold runs the other way, so getting this backwards is an easy and
+    entirely silent mistake.
+    """
+    with pytest.raises(ValueError, match="smaller craniovertebral"):
+        Thresholds(cva_forward_head_deg=60.0, cva_borderline_deg=55.0)
+
+
+def test_equal_craniovertebral_thresholds_are_rejected_too() -> None:
+    """Equality is not a harmless edge case: it empties the borderline band.
+
+    With both set to 50, `value < 50` claims the major finding and `value < 50` can never be
+    reached again, so `forward_head_borderline` becomes unreachable. That is precisely the silent
+    dead rule this validation exists to prevent, so the comparison is strict.
+    """
+    with pytest.raises(ValueError, match="strictly below"):
+        Thresholds(cva_forward_head_deg=50.0, cva_borderline_deg=50.0)
+
+
+def test_an_inverted_knee_band_is_rejected() -> None:
+    with pytest.raises(ValueError, match="knee_seated_min_deg"):
+        Thresholds(knee_seated_min_deg=130.0, knee_seated_max_deg=120.0)
+
+
+def test_the_view_bands_must_leave_a_non_negative_ambiguous_gap() -> None:
+    with pytest.raises(ValueError, match="ambiguous-view band"):
+        Thresholds(lateral_view_max_ratio=0.6, frontal_view_min_ratio=0.5)
+
+
+def test_a_negative_score_penalty_is_rejected() -> None:
+    with pytest.raises(ValueError, match="must not be negative"):
+        Thresholds(score_penalty_per_finding=-5.0)
+
+
+def test_every_field_has_a_default_so_a_caller_can_override_one_thing() -> None:
+    """A required field here would make `Thresholds(trunk_slouch_deg=25)` impossible and push
+    every test into restating the whole configuration."""
+    for field in dataclasses.fields(Thresholds):
+        assert field.default is not dataclasses.MISSING, field.name


### PR DESCRIPTION
Closes OP-25. Base: `op-24-thresholds`.

Adds the vocabulary for "could not assess", and the resolver that produces it.

## Changes
- `posture_core.status`: `KeypointStatus` (`OK`/`LOW_CONFIDENCE`/`NOT_DETECTED`/`OUT_OF_FRAME`), `MetricStatus`, `Metric`, `Gap`.
- `posture_core.resolver`: `KeypointResolver`, `Resolved`, `Unresolved`, `forward_axis()`.

## Notes
- Addresses FINDINGS §2.5. `checkPosition` returned `None` for a missing keypoint, a swallowed exception and an uncomputable geometry alike, and the caller rendered `None` as "Straight back position". A metric now carries `value=None` with a status explaining why, and produces a `Gap` rather than a `Finding`.
- Four keypoint states rather than a boolean because the remedies differ: out of frame means reframe, low confidence means light it better. Distinguishable only because MediaPipe reports presence and visibility separately.
- `Metric.__post_init__` enforces `status is OK ⟺ value is not None`. Every downstream consumer branches on it.
- Metrics never inspect confidence themselves: they name their inputs and receive either landmarks or a structured refusal. Abstention is the default path rather than something each metric must remember.
- Precedence: a missing keypoint outranks an unclear one. Confidence is the minimum across inputs, not the mean.
- Refusal text is written for the end user — "could not see left knee and right knee in the photo" — including singular/plural agreement.
- `forward_axis()` derives facing from the nose rather than a laterality flag (FINDINGS §2.1). Returns `None` when it cannot tell.
- `MetricStatus.UNDEFINED_GEOMETRY` is an addition to the ticket's three, for coincident landmarks. Folding it into `INSUFFICIENT_KEYPOINTS` would misdescribe the cause.

## Tests
39 tests, 100% coverage.
