### PR TITLE
OP-26: trunk_inclination_deg — signed torso lean in world space

### DIFF
--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -1,0 +1,17 @@
+"""The measurements. One module per metric, one function per metric, no shared mutable state.
+
+Every metric has the same signature — ``(resolver, thresholds) -> Metric`` — which is what lets
+``report.py`` (OP-32) run all of them from a list without knowing anything about any of them.
+Adding a metric is adding a module and one entry to that list.
+
+Each returns a :class:`~posture_core.status.Metric` whether or not it succeeded. None of them
+raise for missing or unusable data, and none of them catch anything broader than
+:class:`~posture_core.geometry.DegenerateVectorError`. A genuine programming error crashes, loudly,
+rather than being reported to the user as "we could not measure this".
+"""
+
+from __future__ import annotations
+
+from posture_core.metrics.trunk import trunk_inclination_deg
+
+__all__ = ["trunk_inclination_deg"]

--- a/packages/posture-core/src/posture_core/metrics/_support.py
+++ b/packages/posture-core/src/posture_core/metrics/_support.py
@@ -1,0 +1,100 @@
+"""Shared plumbing for the metric modules.
+
+Three jobs, all of them about making the honest path the easy one:
+
+* wrap a computation so that a :class:`~posture_core.geometry.DegenerateVectorError` becomes a
+  status rather than a traceback — **caught by its specific type**, never as ``except Exception``;
+* fetch world coordinates, or abstain with an explanation if the backend has none;
+* build the ``Metric`` so no metric module writes the ``value``/``status`` pairing by hand and
+  risks getting the invariant wrong.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from posture_core.geometry import DegenerateVectorError, Vector3, world_vec
+from posture_core.status import Metric, MetricStatus
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping
+
+    from posture_core.keypoints import KeypointName
+    from posture_core.resolver import Resolved
+
+__all__ = ["abstain", "measure", "world_points"]
+
+
+def abstain(
+    name: str,
+    unit: str,
+    detail: str,
+    inputs: tuple[KeypointName, ...] = (),
+    status: MetricStatus = MetricStatus.UNDEFINED_GEOMETRY,
+) -> Metric:
+    """A metric that declines to answer, with a reason a person can act on."""
+    return Metric(name=name, value=None, unit=unit, status=status, detail=detail, inputs=inputs)
+
+
+def world_points(
+    name: str, unit: str, resolution: Resolved
+) -> Mapping[KeypointName, Vector3] | Metric:
+    """Metric-space coordinates for every resolved landmark, or a metric explaining their absence.
+
+    Returning the abstention rather than raising keeps the caller's shape uniform: a metric module
+    checks ``isinstance(..., Metric)`` once and is otherwise free of branching.
+
+    A backend with no metric 3D is not a broken backend — ADR-0002 keeps a 2D-only escape hatch —
+    but every metric in this package is defined in world space, where scale invariance is free.
+    The image-space fallback ADR-0005 describes would only be needed if that hatch were ever taken,
+    and OP-16's spike descoped it. So this abstains loudly instead of silently computing angles in
+    a space stretched by the frame's aspect ratio.
+    """
+    points: dict[KeypointName, Vector3] = {}
+    for keypoint, landmark in resolution.landmarks.items():
+        vector = world_vec(landmark)
+        if vector is None:
+            return abstain(
+                name,
+                unit,
+                "this backend reports no world coordinates, and every metric here is measured "
+                "in metres — see ADR-0005",
+                inputs=tuple(resolution.landmarks),
+            )
+        points[keypoint] = vector
+    return points
+
+
+def measure(
+    name: str,
+    unit: str,
+    resolution: Resolved,
+    compute: Callable[[], float],
+    describe: Callable[[float], str],
+) -> Metric:
+    """Run ``compute``, turning an undefined geometry into an explicit status.
+
+    The ``except`` clause names :class:`~posture_core.geometry.DegenerateVectorError` and nothing
+    else. A bare ``except Exception`` here would swallow a genuine programming error — an index
+    typo, a ``None`` where a vector was expected — and report it to the user as "we could not
+    measure this", which is exactly the failure mode this package exists to eliminate. A real bug
+    should crash loudly and be fixed.
+    """
+    try:
+        value = compute()
+    except DegenerateVectorError as exc:
+        return abstain(
+            name,
+            unit,
+            f"the landmarks needed for this measurement overlap, so it has no answer ({exc})",
+            inputs=tuple(resolution.landmarks),
+        )
+    return Metric(
+        name=name,
+        value=value,
+        unit=unit,
+        status=MetricStatus.OK,
+        detail=describe(value),
+        inputs=tuple(resolution.landmarks),
+        confidence=resolution.confidence,
+    )

--- a/packages/posture-core/src/posture_core/metrics/trunk.py
+++ b/packages/posture-core/src/posture_core/metrics/trunk.py
@@ -1,0 +1,99 @@
+"""``trunk_inclination_deg`` — how far forward or back the torso leans, in world space.
+
+The project's central measurement, and the direct replacement for the legacy ``checkPosition``.
+Three defects disappear here at once:
+
+* **The ear-index inversion (FINDINGS §2.1).** ``API/config`` declared landmark 16 as the left ear
+  and the code commented it as the right; the laterality flag ``f`` — which decided whether to
+  apply ``degrees = 180 - degrees`` — was keyed off that misreading, so spine classification came
+  out backwards for subjects facing one way. Here the sign comes from
+  :meth:`~posture_core.resolver.KeypointResolver.forward_axis`, derived from the nose. There is no
+  hand-maintained flag to get backwards.
+* **The silent false negative (FINDINGS §2.5).** ``checkPosition`` returned ``None`` on failure and
+  the caller printed "Straight back position." Here a missing hip produces a gap that says so.
+* **Pixel thresholds (FINDINGS §2.6).** The angle is computed from world landmarks in metres, so
+  the same posture at twice the camera distance gives the same number. Not normalised — measured
+  in a space where scale never entered.
+
+Sign convention: **positive is forward**, negative is reclining, zero is upright. Both directions
+matter and are different postures, which is why the underlying primitive is signed.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.geometry import midpoint, signed_angle_to_vertical
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import abstain, measure, world_points
+from posture_core.resolver import Resolved
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["NAME", "trunk_inclination_deg"]
+
+NAME: Final = "trunk_inclination_deg"
+UNIT: Final = "deg"
+
+REQUIRED: Final = (
+    KeypointName.LEFT_HIP,
+    KeypointName.RIGHT_HIP,
+    KeypointName.LEFT_SHOULDER,
+    KeypointName.RIGHT_SHOULDER,
+)
+"""Both hips and both shoulders, rather than ``NECK`` and a single hip.
+
+Midpoints of a pair are far steadier than either member: a lateral view puts one shoulder behind
+the other, and the further one is routinely the less confident of the two. Averaging keeps the
+torso axis on the body's midline instead of letting it swing toward whichever side the model saw
+best.
+"""
+
+
+def trunk_inclination_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """Signed angle of the hip-midpoint→shoulder-midpoint axis away from vertical."""
+    resolution = resolver.require(*REQUIRED)
+    if not isinstance(resolution, Resolved):
+        return resolution.as_metric(NAME, UNIT)
+
+    points = world_points(NAME, UNIT, resolution)
+    if isinstance(points, Metric):
+        return points
+
+    forward = resolver.forward_axis()
+    if forward is None:
+        # Without a facing direction the *magnitude* of the lean is still computable, but its sign
+        # is not — and an unsigned trunk angle would report a recline as a slouch. Refusing is the
+        # only honest option: half an answer here is worse than none, because the half that is
+        # missing is the half that decides the advice.
+        return abstain(
+            NAME,
+            UNIT,
+            "could not tell which way you are facing, so a forward lean cannot be told apart "
+            "from leaning back",
+            inputs=REQUIRED,
+        )
+
+    hips = midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP])
+    shoulders = midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER])
+
+    return measure(
+        NAME,
+        UNIT,
+        resolution,
+        compute=lambda: signed_angle_to_vertical(shoulders - hips, forward),
+        describe=lambda value: _describe(value, thresholds),
+    )
+
+
+def _describe(value: float, thresholds: Thresholds) -> str:
+    if value >= thresholds.trunk_slouch_deg:
+        return f"leaning {value:.0f}° forward — a pronounced slouch"
+    if value > thresholds.trunk_upright_deg:
+        return f"leaning {value:.0f}° forward — slightly hunched"
+    if value <= thresholds.trunk_recline_deg:
+        return f"leaning {abs(value):.0f}° back"
+    return f"upright, within {abs(value):.0f}° of vertical"

--- a/packages/posture-core/tests/builders.py
+++ b/packages/posture-core/tests/builders.py
@@ -1,0 +1,110 @@
+"""Test scaffolding: build a resolver around an analytic stick figure in one line.
+
+The figure itself comes from :mod:`posture_core.synthetic`, which is shipped code because
+``FakePoseBackend`` depends on it too (OP-19). What lives here is only the *test-facing* wrapper —
+frame construction, resolver construction, threshold overrides — so a metric test reads as a
+statement about posture:
+
+    assert value_of(trunk_inclination_deg, trunk_deg=35) == approx(35, abs=1.0)
+
+That is the whole ambition. A metric checked against a photograph can only be compared to somebody's
+guess at the true angle; a metric checked against a figure *constructed* at 35° has a known-correct
+answer, so the test is a statement about geometry rather than about eyeballing a JPEG.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import TYPE_CHECKING, Any
+
+from posture_core import PoseFrame
+from posture_core.resolver import KeypointResolver
+from posture_core.status import Metric
+from posture_core.synthetic import make_pose
+from posture_core.thresholds import DEFAULT_THRESHOLDS, Thresholds
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from posture_core.keypoints import KeypointName, Landmark
+
+__all__ = [
+    "frame",
+    "landmarks_of",
+    "metric_of",
+    "resolver",
+    "unclear",
+    "value_of",
+    "with_thresholds",
+    "without",
+]
+
+# A seated side-on subject: thigh near horizontal, shank near vertical. The posture the whole
+# application is aimed at, and the baseline every metric test departs from.
+SEATED: dict[str, float] = {"thigh_deg": 85.0, "shank_deg": 5.0}
+
+
+def frame(*, image_width: int = 640, image_height: int = 480, **pose_kwargs: Any) -> PoseFrame:
+    """A `PoseFrame` around a synthetic figure. Seated unless the caller says otherwise."""
+    kwargs: dict[str, Any] = {**SEATED, **pose_kwargs}
+    return PoseFrame(
+        landmarks=make_pose(image_width=image_width, image_height=image_height, **kwargs),
+        image_width=image_width,
+        image_height=image_height,
+        backend="synthetic",
+        inference_ms=0.0,
+    )
+
+
+def resolver(
+    *, thresholds: Thresholds = DEFAULT_THRESHOLDS, **pose_kwargs: Any
+) -> KeypointResolver:
+    return KeypointResolver(frame(**pose_kwargs), thresholds)
+
+
+def metric_of(
+    compute: Callable[[KeypointResolver, Thresholds], Metric],
+    *,
+    thresholds: Thresholds = DEFAULT_THRESHOLDS,
+    **pose_kwargs: Any,
+) -> Metric:
+    """Run one metric against a figure described by keyword arguments."""
+    return compute(resolver(thresholds=thresholds, **pose_kwargs), thresholds)
+
+
+def value_of(
+    compute: Callable[[KeypointResolver, Thresholds], Metric],
+    *,
+    thresholds: Thresholds = DEFAULT_THRESHOLDS,
+    **pose_kwargs: Any,
+) -> float:
+    """The metric's value, asserting it actually produced one.
+
+    Asserting rather than returning ``None`` keeps the failure at the line that expected a number.
+    A test that silently compared ``None`` to an expected angle would fail with a confusing
+    TypeError several frames away from the thing that went wrong.
+    """
+    metric = metric_of(compute, thresholds=thresholds, **pose_kwargs)
+    assert metric.value is not None, f"{metric.name} abstained: {metric.status} — {metric.detail}"
+    return metric.value
+
+
+def with_thresholds(**overrides: Any) -> Thresholds:
+    """Defaults with a few values changed — the pattern every boundary test uses."""
+    return dataclasses.replace(DEFAULT_THRESHOLDS, **overrides)
+
+
+def without(*names: KeypointName) -> dict[str, Any]:
+    """Keyword arguments that drop keypoints entirely, for degradation tests."""
+    return {"omit": names}
+
+
+def unclear(
+    *names: KeypointName, visibility: float = 0.2, presence: float = 0.95
+) -> dict[str, Any]:
+    """Keyword arguments that make keypoints occluded — visible-but-unclear, still in frame."""
+    return {"confidence": dict.fromkeys(names, (visibility, presence))}
+
+
+def landmarks_of(**pose_kwargs: Any) -> dict[KeypointName, Landmark]:
+    return make_pose(**{**SEATED, **pose_kwargs})

--- a/packages/posture-core/tests/test_trunk.py
+++ b/packages/posture-core/tests/test_trunk.py
@@ -1,0 +1,213 @@
+"""Tests for `trunk_inclination_deg`, the project's central measurement.
+
+Every assertion is against a figure built at a known angle, so these are statements about geometry
+rather than about somebody's reading of a photograph.
+"""
+
+from __future__ import annotations
+
+import pytest
+from builders import metric_of, resolver, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core.metrics.trunk import NAME
+from posture_core.metrics.trunk import trunk_inclination_deg as trunk
+from posture_core.status import MetricStatus
+from posture_core.synthetic import Anthropometry, Facing, View
+
+
+@pytest.mark.parametrize("requested", [-30.0, -12.0, 0.0, 8.0, 25.0, 45.0])
+def test_the_measured_angle_is_the_angle_the_figure_was_built_at(requested: float) -> None:
+    assert value_of(trunk, trunk_deg=requested) == pytest.approx(requested, abs=1e-6)
+
+
+def test_forward_lean_is_positive_and_reclining_is_negative() -> None:
+    """The sign is the advice.
+
+    A slouch and a recline are different postures needing different suggestions, and an
+    implementation that took `abs()` somewhere would collapse them into one verdict while still
+    producing a plausible number.
+    """
+    assert value_of(trunk, trunk_deg=25.0) > 0
+    assert value_of(trunk, trunk_deg=-25.0) < 0
+
+
+def test_the_verdict_does_not_depend_on_which_way_the_subject_faces() -> None:
+    """The legacy engine's defining bug, reproduced as a guard.
+
+    `API/config` declared landmark 16 as the left ear, `posture_image.py` commented it as the
+    right, and the laterality flag keyed off that misreading decided whether to apply
+    `degrees = 180 - degrees`. Spine classification therefore came out backwards for subjects
+    facing one direction. Here facing is derived from the nose, so there is nothing to invert.
+    """
+    facing_right = value_of(trunk, trunk_deg=30.0, facing=Facing.RIGHT)
+    facing_left = value_of(trunk, trunk_deg=30.0, facing=Facing.LEFT)
+    assert facing_right == pytest.approx(facing_left, abs=1e-6)
+    assert facing_right == pytest.approx(30.0, abs=1e-6)
+
+
+@pytest.mark.parametrize("scale", [0.4, 1.0, 2.5])
+def test_the_angle_does_not_move_with_body_size(scale: float) -> None:
+    """FINDINGS §2.6, fixed by construction rather than by normalisation.
+
+    The legacy engine compared raw pixel distances against literal thresholds, so identical posture
+    at twice the camera distance produced a different verdict. Measuring an angle in metric world
+    space means scale never enters the calculation at all.
+    """
+    default = Anthropometry()
+    stretched = Anthropometry(
+        torso=default.torso * scale,
+        neck=default.neck * scale,
+        shoulder_width=default.shoulder_width * scale,
+        hip_width=default.hip_width * scale,
+    )
+    assert value_of(trunk, trunk_deg=27.0, body=stretched) == pytest.approx(27.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(("width", "height"), [(640, 480), (1920, 1080), (720, 1280)])
+def test_the_angle_does_not_move_with_frame_size_or_aspect_ratio(width: int, height: int) -> None:
+    assert value_of(trunk, trunk_deg=22.0, image_width=width, image_height=height) == pytest.approx(
+        22.0, abs=1e-6
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# Description
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("angle", "expected"),
+    [
+        (3.0, "upright"),
+        (15.0, "slightly hunched"),
+        (35.0, "pronounced slouch"),
+        (-30.0, "leaning 30° back"),
+    ],
+)
+def test_the_description_reflects_the_configured_bands(angle: float, expected: str) -> None:
+    assert expected in metric_of(trunk, trunk_deg=angle).detail
+
+
+def test_the_bands_come_from_the_injected_thresholds() -> None:
+    """Not from literals in the metric, which is the point of OP-24.
+
+    A stricter deployment can call 12° a slouch without anyone editing this module.
+    """
+    strict = with_thresholds(trunk_upright_deg=5.0, trunk_slouch_deg=12.0)
+    assert "pronounced slouch" in metric_of(trunk, trunk_deg=15.0, thresholds=strict).detail
+    assert "slightly hunched" in metric_of(trunk, trunk_deg=15.0).detail
+
+
+# ---------------------------------------------------------------------------------------------
+# Abstention
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_missing_hip_produces_a_gap_rather_than_a_number() -> None:
+    """The replacement for "Straight back position."
+
+    The legacy engine returned None here and its caller rendered that as good posture. What the
+    user must now receive is a specific statement about what could not be seen.
+    """
+    metric = metric_of(trunk, **without(K.LEFT_HIP))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "left hip" in metric.detail
+
+
+def test_an_unclear_shoulder_abstains_as_low_confidence() -> None:
+    metric = metric_of(trunk, **unclear(K.RIGHT_SHOULDER))
+    assert metric.value is None
+    assert metric.status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_an_unknown_facing_abstains_rather_than_reporting_an_unsigned_lean() -> None:
+    """Half an answer is worse than none when the missing half decides the advice.
+
+    Without a facing direction the magnitude of the lean is still computable — and reporting it
+    would present a recline as a slouch.
+    """
+    metric = metric_of(trunk, trunk_deg=30.0, **without(K.NOSE))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+    assert "which way you are facing" in metric.detail
+
+
+def test_a_frontal_view_still_recovers_the_lean_because_the_landmarks_are_three_dimensional() -> (
+    None
+):
+    """Measured, not assumed — and it corrects an assumption the plan made.
+
+    The intuition is that a slump photographed head-on projects into depth and vanishes, so the
+    sagittal angle should read near zero. That is true of a *2D* engine, and it was the reasoning
+    behind `view_confidence`. It is not true here: world landmarks are metric 3D, so the facing
+    axis comes out along the view direction and the full 30° is recovered.
+
+    The consequence is worth stating plainly, because it changes what OP-31 is for. A frontal view
+    does not make this measurement impossible — it makes it *less reliable*, since MediaPipe's
+    depth estimate is far weaker along the camera axis than across it. So `view_confidence` should
+    downgrade confidence on a frontal shot rather than suppress the finding outright.
+    """
+    metric = metric_of(trunk, trunk_deg=30.0, view=View.FRONTAL)
+    assert metric.value is not None
+    assert metric.value == pytest.approx(30.0, abs=1e-6)
+
+
+def test_nothing_raises_when_every_input_is_dropped() -> None:
+    """Degradation must be quiet at the boundary and loud in the report, never an exception."""
+    metric = metric_of(trunk, **without(K.LEFT_HIP, K.RIGHT_HIP, K.LEFT_SHOULDER, K.RIGHT_SHOULDER))
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+
+
+def test_the_metric_records_what_it_measured_from() -> None:
+    metric = metric_of(trunk, trunk_deg=10.0)
+    assert metric.name == NAME
+    assert metric.unit == "deg"
+    assert set(metric.inputs) == {K.LEFT_HIP, K.RIGHT_HIP, K.LEFT_SHOULDER, K.RIGHT_SHOULDER}
+
+
+def test_confidence_is_carried_through_from_the_weakest_input() -> None:
+    metric = metric_of(trunk, **unclear(K.RIGHT_HIP, visibility=0.6))
+    assert metric.confidence == pytest.approx(0.6)
+
+
+def test_a_two_dimensional_backend_abstains_instead_of_guessing_in_pixels() -> None:
+    """ADR-0005's fallback path is not implemented, and says so rather than quietly computing an
+    angle in a space stretched by the aspect ratio."""
+    from posture_core import Landmark, PoseFrame
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+    flat = {
+        name: Landmark(x=landmark.x, y=landmark.y, visibility=0.95, presence=0.98)
+        for name, landmark in resolver(trunk_deg=20.0).frame.landmarks.items()
+    }
+    metric = trunk(
+        KeypointResolver(
+            PoseFrame(
+                landmarks=flat,
+                image_width=640,
+                image_height=480,
+                backend="flat",
+                inference_ms=0.0,
+            ),
+            DEFAULT_THRESHOLDS,
+        ),
+        DEFAULT_THRESHOLDS,
+    )
+    assert metric.value is None
+    assert "world coordinates" in metric.detail
+
+
+def test_coincident_landmarks_abstain_with_undefined_geometry() -> None:
+    """A torso of zero length gives a vector with no direction, which is not an angle of zero.
+
+    Real backends produce this: a fully occluded joint can collapse two landmarks onto the same
+    point. The distinction matters because zero degrees means "sitting perfectly upright", which
+    is a specific and reassuring claim to make about a measurement that does not exist.
+    """
+    metric = metric_of(trunk, trunk_deg=20.0, body=Anthropometry(torso=0.0))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+    assert "overlap" in metric.detail


### PR DESCRIPTION
Closes OP-26, and delivers OP-33. Base: `op-25-status-model`.

Adds the project's central measurement, the `metrics/` package layout, and the shared test builders.

## Changes
- `posture_core.metrics.trunk`: `trunk_inclination_deg` — signed angle of hip-midpoint → shoulder-midpoint from vertical, in world space.
- `posture_core.metrics._support`: `abstain`, `measure`, `world_points`.
- `packages/posture-core/tests/builders.py`: `frame`, `resolver`, `metric_of`, `value_of`, `with_thresholds`, `without`, `unclear`, `landmarks_of` (OP-33). `flat_resolver` is added later, in OP-27, when the first metric needed a 2D-backend abstention test.

## Notes
- Sign comes from `resolver.forward_axis()`, so the verdict does not depend on which way the subject faces (FINDINGS §2.1).
- Uses both hips and both shoulders rather than `NECK` and one hip. In a lateral view the far shoulder is the less confident of the two; midpoints keep the torso axis on the body's midline.
- Abstains when `forward_axis()` is `None`, even though the magnitude is computable. An unsigned trunk angle reports a recline as a slouch.
- Measured in metric world space, so scale never enters. Tested across a 6× body-size range and three aspect ratios at 1e-6.
- A frontal view returns the full lean, not zero. World landmarks are metric 3D, so the facing axis lies along the view direction and the angle is recovered — a figure built at 30° measures 30.0° head-on. The plan assumed otherwise; that assumption holds for a 2D engine. The consequence is handled in OP-31.
- A 2D backend abstains rather than falling back to image space. ADR-0005's fallback is unimplemented and OP-16 descoped the backend that would need it.

## OP-33
`tests/builders.py` ships here because the first metric test needed it. It is the test-facing layer over `posture_core.synthetic`, which arrived in OP-19 as production code.

## Tests
19 tests, 100% coverage.
