### PR TITLE
OP-27: craniovertebral_angle_deg — forward head posture

### DIFF
--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -12,6 +12,7 @@ rather than being reported to the user as "we could not measure this".
 
 from __future__ import annotations
 
+from posture_core.metrics.head import craniovertebral_angle_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
 
-__all__ = ["trunk_inclination_deg"]
+__all__ = ["craniovertebral_angle_deg", "trunk_inclination_deg"]

--- a/packages/posture-core/src/posture_core/metrics/head.py
+++ b/packages/posture-core/src/posture_core/metrics/head.py
@@ -1,0 +1,100 @@
+"""``craniovertebral_angle_deg`` — forward head posture, measured the way clinicians measure it.
+
+The craniovertebral angle is the angle at C7 between the **horizontal** and the line from C7 to
+the ear. Head balanced over the shoulders gives a large angle; head jutting forward gives a small
+one. Below about 50° is the standard cutoff for forward head posture.
+
+**Smaller is worse here**, which is the opposite of every other angular threshold in the project
+and the single easiest thing to get backwards.
+
+## What this replaces
+
+``evaluate_neck_posture`` in the legacy engine compared the *y* coordinate of the shoulder
+midpoint against the *y* coordinate of COCO keypoint 1 — and COCO keypoint 1 **was** the shoulder
+midpoint, synthesised from the two shoulders rather than observed. It compared a point against
+itself, so it could only ever return one answer regardless of the photograph (FINDINGS §2.2).
+Making the neck's derivation explicit in the adapter (ADR-0002) is what exposed that; measuring an
+actual angle to an actual ear is what fixes it.
+
+## A deliberate property
+
+A subject who leans their whole trunk forward while keeping their head in line with it still
+scores a reduced angle, because the reference is gravity rather than the torso. That is correct:
+forward head posture is defined against the vertical, and the load on the neck depends on where
+the head is in space, not on where it is relative to a tilted spine.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.geometry import angle_between, midpoint
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import abstain, measure, world_points
+from posture_core.resolver import Resolved
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["NAME", "craniovertebral_angle_deg"]
+
+NAME: Final = "craniovertebral_angle_deg"
+UNIT: Final = "deg"
+
+REQUIRED: Final = (
+    KeypointName.LEFT_EAR,
+    KeypointName.RIGHT_EAR,
+    KeypointName.LEFT_SHOULDER,
+    KeypointName.RIGHT_SHOULDER,
+)
+"""Both ears and both shoulders.
+
+The ear *midpoint* rather than whichever ear the camera happens to favour: in a lateral view the
+far ear is occluded and its position is largely inferred, so taking one side would make the
+measurement depend on which way the subject sat. The shoulder midpoint stands in for C7, which is
+the same derivation the adapter uses for ``NECK`` (ADR-0002).
+"""
+
+
+def craniovertebral_angle_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    resolution = resolver.require(*REQUIRED)
+    if not isinstance(resolution, Resolved):
+        return resolution.as_metric(NAME, UNIT)
+
+    points = world_points(NAME, UNIT, resolution)
+    if isinstance(points, Metric):
+        return points
+
+    forward = resolver.forward_axis()
+    if forward is None:
+        return abstain(
+            NAME,
+            UNIT,
+            "could not tell which way you are facing, so head position relative to your "
+            "shoulders cannot be measured",
+            inputs=REQUIRED,
+        )
+
+    c7 = midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER])
+    ear = midpoint(points[KeypointName.LEFT_EAR], points[KeypointName.RIGHT_EAR])
+
+    return measure(
+        NAME,
+        UNIT,
+        resolution,
+        # Unsigned: the angle to the horizontal is what the clinical measure is defined as, and
+        # values above 90° simply mean the head sits behind the shoulders, which is unusual but
+        # not an error.
+        compute=lambda: angle_between(ear - c7, forward),
+        describe=lambda value: _describe(value, thresholds),
+    )
+
+
+def _describe(value: float, thresholds: Thresholds) -> str:
+    if value < thresholds.cva_forward_head_deg:
+        return f"head is well forward of your shoulders (craniovertebral angle {value:.0f}°)"
+    if value < thresholds.cva_borderline_deg:
+        return f"head is slightly forward (craniovertebral angle {value:.0f}°)"
+    return f"head is balanced over your shoulders (craniovertebral angle {value:.0f}°)"

--- a/packages/posture-core/tests/builders.py
+++ b/packages/posture-core/tests/builders.py
@@ -29,6 +29,7 @@ if TYPE_CHECKING:
     from posture_core.keypoints import KeypointName, Landmark
 
 __all__ = [
+    "flat_resolver",
     "frame",
     "landmarks_of",
     "metric_of",
@@ -108,3 +109,36 @@ def unclear(
 
 def landmarks_of(**pose_kwargs: Any) -> dict[KeypointName, Landmark]:
     return make_pose(**{**SEATED, **pose_kwargs})
+
+
+def flat_resolver(
+    *, thresholds: Thresholds = DEFAULT_THRESHOLDS, **pose_kwargs: Any
+) -> KeypointResolver:
+    """A resolver over a frame with **no world coordinates**.
+
+    Stands in for the 2D-only backend ADR-0002 keeps as an escape hatch. Every metric here is
+    defined in metric world space, so each one must abstain loudly rather than quietly computing
+    an angle in a pixel space stretched by the frame's aspect ratio.
+    """
+    from posture_core import Landmark as _Landmark
+
+    original = frame(**pose_kwargs)
+    flat = {
+        name: _Landmark(
+            x=landmark.x,
+            y=landmark.y,
+            visibility=landmark.visibility,
+            presence=landmark.presence,
+        )
+        for name, landmark in original.landmarks.items()
+    }
+    return KeypointResolver(
+        PoseFrame(
+            landmarks=flat,
+            image_width=original.image_width,
+            image_height=original.image_height,
+            backend="flat",
+            inference_ms=0.0,
+        ),
+        thresholds,
+    )

--- a/packages/posture-core/tests/test_head.py
+++ b/packages/posture-core/tests/test_head.py
@@ -1,0 +1,125 @@
+"""Tests for `craniovertebral_angle_deg`."""
+
+from __future__ import annotations
+
+import pytest
+from builders import flat_resolver, metric_of, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core.metrics.head import craniovertebral_angle_deg as cva
+from posture_core.status import MetricStatus
+from posture_core.synthetic import Anthropometry, Facing
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+
+@pytest.mark.parametrize(
+    ("trunk", "neck", "expected"),
+    [
+        (0.0, 0.0, 90.0),  # head directly above C7
+        (0.0, 30.0, 60.0),  # head pushed forward
+        (0.0, 45.0, 45.0),  # forward head posture
+        (20.0, 20.0, 50.0),  # trunk and neck both contribute
+        (0.0, -20.0, 110.0),  # head behind the shoulders
+    ],
+)
+def test_the_angle_is_measured_from_the_horizontal(
+    trunk: float, neck: float, expected: float
+) -> None:
+    """The clinical definition: 90° minus how far the C7-to-ear line has tipped from vertical.
+
+    Constructing the figure at known angles makes the expected value arithmetic rather than
+    judgement, which is the whole reason the builder exists.
+    """
+    assert value_of(cva, trunk_deg=trunk, neck_deg=neck) == pytest.approx(expected, abs=1e-6)
+
+
+def test_smaller_is_worse_which_is_backwards_from_every_other_threshold() -> None:
+    """Stated as a test because it is the single easiest thing in the package to invert.
+
+    Every other angular threshold here means "more is worse". This one does not, and an
+    implementation that got it the wrong way round would report the healthiest posture as the
+    worst while producing entirely plausible numbers.
+    """
+    upright = value_of(cva, neck_deg=0.0)
+    jutting = value_of(cva, neck_deg=40.0)
+    assert jutting < upright
+
+
+def test_trunk_lean_reduces_the_angle_even_with_the_head_aligned_to_the_spine() -> None:
+    """Deliberate, not a leak.
+
+    The reference is gravity, not the torso. Forward head posture is defined against the vertical,
+    and the load on the neck depends on where the head is in space rather than on where it sits
+    relative to a spine that is itself tilted.
+    """
+    aligned_upright = value_of(cva, trunk_deg=0.0, neck_deg=0.0)
+    aligned_leaning = value_of(cva, trunk_deg=30.0, neck_deg=0.0)
+    assert aligned_leaning < aligned_upright
+
+
+def test_the_measurement_is_independent_of_facing_direction() -> None:
+    assert value_of(cva, neck_deg=35.0, facing=Facing.RIGHT) == pytest.approx(
+        value_of(cva, neck_deg=35.0, facing=Facing.LEFT), abs=1e-6
+    )
+
+
+@pytest.mark.parametrize("scale", [0.5, 1.0, 2.0])
+def test_the_angle_does_not_move_with_body_size(scale: float) -> None:
+    default = Anthropometry()
+    scaled = Anthropometry(
+        torso=default.torso * scale,
+        neck=default.neck * scale,
+        shoulder_width=default.shoulder_width * scale,
+        head_width=default.head_width * scale,
+    )
+    assert value_of(cva, neck_deg=30.0, body=scaled) == pytest.approx(60.0, abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("neck", "expected"),
+    [
+        (0.0, "balanced over your shoulders"),
+        (36.0, "slightly forward"),
+        (45.0, "well forward"),
+    ],
+)
+def test_the_description_reflects_the_configured_bands(neck: float, expected: str) -> None:
+    assert expected in metric_of(cva, neck_deg=neck).detail
+
+
+def test_the_cutoff_comes_from_the_injected_thresholds() -> None:
+    lenient = with_thresholds(cva_forward_head_deg=40.0, cva_borderline_deg=45.0)
+    assert "well forward" in metric_of(cva, neck_deg=45.0).detail
+    assert "balanced" in metric_of(cva, neck_deg=45.0, thresholds=lenient).detail
+
+
+def test_a_missing_ear_produces_a_gap() -> None:
+    metric = metric_of(cva, **without(K.LEFT_EAR))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "left ear" in metric.detail
+
+
+def test_an_unclear_ear_abstains_as_low_confidence() -> None:
+    metric = metric_of(cva, **unclear(K.RIGHT_EAR))
+    assert metric.status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_an_unknown_facing_abstains() -> None:
+    metric = metric_of(cva, **without(K.NOSE))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+def test_a_head_collapsed_onto_the_shoulders_abstains_rather_than_reporting_zero() -> None:
+    """Zero would mean "head maximally forward", a confident and specific claim about a
+    measurement that does not exist."""
+    metric = metric_of(cva, body=Anthropometry(neck=0.0))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+def test_a_two_dimensional_backend_abstains() -> None:
+    metric = cva(flat_resolver(neck_deg=30.0), DEFAULT_THRESHOLDS)
+    assert metric.value is None
+    assert "world coordinates" in metric.detail

--- a/packages/posture-core/tests/test_trunk.py
+++ b/packages/posture-core/tests/test_trunk.py
@@ -7,13 +7,21 @@ rather than about somebody's reading of a photograph.
 from __future__ import annotations
 
 import pytest
-from builders import metric_of, resolver, unclear, value_of, with_thresholds, without
+from builders import (
+    flat_resolver,
+    metric_of,
+    unclear,
+    value_of,
+    with_thresholds,
+    without,
+)
 
 from posture_core import KeypointName as K
 from posture_core.metrics.trunk import NAME
 from posture_core.metrics.trunk import trunk_inclination_deg as trunk
 from posture_core.status import MetricStatus
 from posture_core.synthetic import Anthropometry, Facing, View
+from posture_core.thresholds import DEFAULT_THRESHOLDS
 
 
 @pytest.mark.parametrize("requested", [-30.0, -12.0, 0.0, 8.0, 25.0, 45.0])
@@ -173,29 +181,9 @@ def test_confidence_is_carried_through_from_the_weakest_input() -> None:
 
 
 def test_a_two_dimensional_backend_abstains_instead_of_guessing_in_pixels() -> None:
-    """ADR-0005's fallback path is not implemented, and says so rather than quietly computing an
-    angle in a space stretched by the aspect ratio."""
-    from posture_core import Landmark, PoseFrame
-    from posture_core.resolver import KeypointResolver
-    from posture_core.thresholds import DEFAULT_THRESHOLDS
-
-    flat = {
-        name: Landmark(x=landmark.x, y=landmark.y, visibility=0.95, presence=0.98)
-        for name, landmark in resolver(trunk_deg=20.0).frame.landmarks.items()
-    }
-    metric = trunk(
-        KeypointResolver(
-            PoseFrame(
-                landmarks=flat,
-                image_width=640,
-                image_height=480,
-                backend="flat",
-                inference_ms=0.0,
-            ),
-            DEFAULT_THRESHOLDS,
-        ),
-        DEFAULT_THRESHOLDS,
-    )
+    """ADR-0005's image-space fallback is not implemented, and says so rather than quietly
+    computing an angle in a space stretched by the aspect ratio."""
+    metric = trunk(flat_resolver(trunk_deg=20.0), DEFAULT_THRESHOLDS)
     assert metric.value is None
     assert "world coordinates" in metric.detail
 


### PR DESCRIPTION
This pull request introduces a new metrics subsystem for posture analysis, with a focus on clear, robust, and testable measurement of key clinical angles. It adds a modular architecture for metrics, implements two core metrics (`craniovertebral_angle_deg` and `trunk_inclination_deg`), and provides comprehensive test scaffolding and tests to ensure correctness and reliability.

**New Metrics Subsystem**

- Added a new metrics package structure with a unified interface for all metrics, ensuring each metric is isolated in its own module and returns a standardized `Metric` result. (`packages/posture-core/src/posture_core/metrics/__init__.py`)

- Introduced `_support.py` with shared utilities for metric modules, including helpers for abstaining from a measurement, fetching world coordinates, and safely running computations with explicit error handling. (`packages/posture-core/src/posture_core/metrics/_support.py`)

**Implemented Metrics**

- Added `craniovertebral_angle_deg` in `head.py`, measuring forward head posture using a clinically accurate method, with robust handling for missing data and configurable thresholds. (`packages/posture-core/src/posture_core/metrics/head.py`)

- Added `trunk_inclination_deg` in `trunk.py`, measuring trunk lean with improvements over the legacy implementation, including correct sign convention, world-space measurement, and explicit error reporting. (`packages/posture-core/src/posture_core/metrics/trunk.py`)

**Test Infrastructure and Coverage**

- Added `builders.py` to provide test scaffolding for constructing synthetic postures and running metrics in a controlled, analytic environment, enabling precise and meaningful tests. (`packages/posture-core/tests/builders.py`)

- Added comprehensive tests for `craniovertebral_angle_deg`, covering geometric correctness, threshold handling, abstention scenarios, and edge cases. (`packages/posture-core/tests/test_head.py`)