### PR TITLE
OP-28: arms_crossed and elbow_flexion_deg, normalised by torso length

### DIFF
--- a/packages/posture-core/src/posture_core/geometry.py
+++ b/packages/posture-core/src/posture_core/geometry.py
@@ -32,6 +32,7 @@ if TYPE_CHECKING:
 
 __all__ = [
     "GRAVITY",
+    "MIN_LENGTH",
     "UP",
     "DegenerateVectorError",
     "Vector3",
@@ -58,9 +59,17 @@ UP: Final[Vector3] = np.array([0.0, -1.0, 0.0])
 
 GRAVITY: Final[Vector3] = -UP
 
-# Below this length a vector's direction is numerical noise. 1e-9 m is a nanometre; any real
-# anatomical segment is at least ~1e-2 m, so this only ever fires on coincident landmarks.
-_MIN_LENGTH: Final = 1e-9
+MIN_LENGTH: Final = 1e-9
+"""Below this, a length is numerical noise rather than a measurement.
+
+1e-9 m is a nanometre; any real anatomical segment is at least ~1e-2 m, so this only ever fires on
+coincident landmarks — which a backend does produce when a joint is fully occluded and it collapses
+two points onto each other.
+
+**Public**, because dividing by a length is not confined to this module. A metric that normalises
+by torso length has exactly the same degeneracy to handle, and a second epsilon defined next to
+each division is the kind of duplicate that drifts. One threshold, one meaning.
+"""
 
 
 class DegenerateVectorError(ValueError):
@@ -103,7 +112,7 @@ def norm(vector: Vector3) -> float:
 def unit(vector: Vector3) -> Vector3:
     """The direction of ``vector``, length 1."""
     length = norm(vector)
-    if length < _MIN_LENGTH:
+    if length < MIN_LENGTH:
         raise DegenerateVectorError(
             f"cannot take the direction of a zero-length vector (length {length:g})"
         )
@@ -130,7 +139,7 @@ def angle_between(a: Vector3, b: Vector3) -> float:
     """
     cross = float(np.linalg.norm(np.cross(a, b)))
     dot = float(np.dot(a, b))
-    if norm(a) < _MIN_LENGTH or norm(b) < _MIN_LENGTH:
+    if norm(a) < MIN_LENGTH or norm(b) < MIN_LENGTH:
         raise DegenerateVectorError("cannot measure an angle against a zero-length vector")
     return float(np.degrees(np.arctan2(cross, dot)))
 
@@ -151,7 +160,7 @@ def signed_angle_to_vertical(vector: Vector3, forward: Vector3) -> float:
 
     Returns a value in ``(-180, 180]``.
     """
-    if norm(vector) < _MIN_LENGTH:
+    if norm(vector) < MIN_LENGTH:
         raise DegenerateVectorError("cannot measure the inclination of a zero-length vector")
 
     # Project onto the sagittal plane spanned by UP and `forward`, then read the angle off
@@ -161,7 +170,7 @@ def signed_angle_to_vertical(vector: Vector3, forward: Vector3) -> float:
     forward_unit = unit(np.asarray(forward, dtype=np.float64))
     along_up = float(np.dot(vector, UP))
     along_forward = float(np.dot(vector, forward_unit))
-    if abs(along_up) < _MIN_LENGTH and abs(along_forward) < _MIN_LENGTH:
+    if abs(along_up) < MIN_LENGTH and abs(along_forward) < MIN_LENGTH:
         raise DegenerateVectorError(
             "vector has no component in the sagittal plane, so its inclination is undefined"
         )

--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -12,7 +12,13 @@ rather than being reported to the user as "we could not measure this".
 
 from __future__ import annotations
 
+from posture_core.metrics.arms import arms_crossed, elbow_flexion_deg
 from posture_core.metrics.head import craniovertebral_angle_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
 
-__all__ = ["craniovertebral_angle_deg", "trunk_inclination_deg"]
+__all__ = [
+    "arms_crossed",
+    "craniovertebral_angle_deg",
+    "elbow_flexion_deg",
+    "trunk_inclination_deg",
+]

--- a/packages/posture-core/src/posture_core/metrics/arms.py
+++ b/packages/posture-core/src/posture_core/metrics/arms.py
@@ -1,0 +1,170 @@
+"""``arms_crossed`` and ``elbow_flexion_deg`` — arm position, normalised by the body measuring it.
+
+## The literal this replaces
+
+The legacy engine decided arms were crossed by comparing a pixel distance against ``±100``. Its
+own inline comment admitted the problem: the value *"shall be replaced with a calculation which
+can adjust to different sizes of people."* It never was. So the same crossed arms photographed
+from twice the distance produced half the pixel separation and the opposite verdict, and a taller
+person and a shorter one at the same distance were judged by the same absolute number.
+
+Every quantity here is divided by the subject's own torso length, measured in the same frame. That
+cancels camera distance and body size together, because both scale the numerator and the
+denominator identically.
+
+## A correction to the plan's formula
+
+`docs/V2-PLAN.md` specifies arms-crossed as ``abs(forearm - upper_arm) / torso < 0.15``. That
+compares the two segments of the *same* arm, and with typical adult proportions — upper arm
+~0.30 m, forearm ~0.27 m, torso ~0.50 m — it evaluates to 0.06 for everybody, in every posture,
+with their arms anywhere at all. It would have reported crossed arms universally.
+
+What actually distinguishes folded arms is that **each wrist sits near the opposite elbow**. That
+is what this measures, still normalised by torso length so the fix to the original defect is kept.
+Run against the eight fixtures with the real backend, the folded-arms photograph scores 0.53 and
+every other one falls between 0.91 and 1.20 — a clean separation, and where the default threshold
+comes from. The numbers are recorded on ``Thresholds.arms_crossed_ratio``.
+
+## What the metric reports, and what decides
+
+``arms_crossed`` returns the *evidence* — the normalised wrist-to-opposite-elbow distance — not a
+verdict. Comparing it against a threshold is the rules layer's job (OP-32). Keeping measurement
+and judgement apart is what lets a threshold be retuned without touching a measurement, and what
+lets the report show a user how close to the line they were.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.geometry import angle_between, distance, midpoint
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import abstain, measure, world_points
+from posture_core.resolver import Resolved
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["ARMS_CROSSED", "ELBOW_FLEXION", "arms_crossed", "elbow_flexion_deg"]
+
+ARMS_CROSSED: Final = "arms_crossed"
+ELBOW_FLEXION: Final = "elbow_flexion_deg"
+
+_TORSO: Final = (
+    KeypointName.LEFT_HIP,
+    KeypointName.RIGHT_HIP,
+    KeypointName.LEFT_SHOULDER,
+    KeypointName.RIGHT_SHOULDER,
+)
+
+CROSSED_REQUIRED: Final = (
+    *_TORSO,
+    KeypointName.LEFT_ELBOW,
+    KeypointName.RIGHT_ELBOW,
+    KeypointName.LEFT_WRIST,
+    KeypointName.RIGHT_WRIST,
+)
+
+FLEXION_REQUIRED: Final = (
+    KeypointName.LEFT_SHOULDER,
+    KeypointName.LEFT_ELBOW,
+    KeypointName.LEFT_WRIST,
+    KeypointName.RIGHT_SHOULDER,
+    KeypointName.RIGHT_ELBOW,
+    KeypointName.RIGHT_WRIST,
+)
+
+
+def arms_crossed(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """How close each wrist sits to the opposite elbow, as a fraction of torso length."""
+    resolution = resolver.require(*CROSSED_REQUIRED)
+    if not isinstance(resolution, Resolved):
+        return resolution.as_metric(ARMS_CROSSED, "ratio")
+
+    points = world_points(ARMS_CROSSED, "ratio", resolution)
+    if isinstance(points, Metric):
+        return points
+
+    torso = distance(
+        midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP]),
+        midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER]),
+    )
+    if torso <= 0.0:
+        return abstain(
+            ARMS_CROSSED,
+            "ratio",
+            "your shoulders and hips overlap in this photo, so there is no body length to "
+            "measure against",
+            inputs=CROSSED_REQUIRED,
+        )
+
+    def compute() -> float:
+        # The *larger* of the two crossings, so both arms have to be folded in for the ratio to be
+        # small. Taking the minimum would let one hand resting near the opposite elbow — a very
+        # ordinary way to sit — read as fully folded arms.
+        left = distance(points[KeypointName.LEFT_WRIST], points[KeypointName.RIGHT_ELBOW])
+        right = distance(points[KeypointName.RIGHT_WRIST], points[KeypointName.LEFT_ELBOW])
+        return max(left, right) / torso
+
+    return measure(
+        ARMS_CROSSED,
+        "ratio",
+        resolution,
+        compute=compute,
+        describe=lambda value: (
+            "arms are folded across your chest"
+            if value < thresholds.arms_crossed_ratio
+            else "arms are not folded"
+        ),
+    )
+
+
+def elbow_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """The angle at the more bent of the two elbows.
+
+    The *more* bent, rather than an average of the two. A bent elbow is the signal — an arm
+    propped on a desk or folded across the chest — and averaging it with a straight arm yields a
+    number that describes neither of them. The description names the side, so the report never
+    implies the measurement applies to both.
+    """
+    resolution = resolver.require(*FLEXION_REQUIRED)
+    if not isinstance(resolution, Resolved):
+        return resolution.as_metric(ELBOW_FLEXION, "deg")
+
+    points = world_points(ELBOW_FLEXION, "deg", resolution)
+    if isinstance(points, Metric):
+        return points
+
+    sides = {
+        "left": (KeypointName.LEFT_SHOULDER, KeypointName.LEFT_ELBOW, KeypointName.LEFT_WRIST),
+        "right": (
+            KeypointName.RIGHT_SHOULDER,
+            KeypointName.RIGHT_ELBOW,
+            KeypointName.RIGHT_WRIST,
+        ),
+    }
+    measured: dict[str, float] = {}
+
+    def compute() -> float:
+        for side, (shoulder, elbow, wrist) in sides.items():
+            measured[side] = angle_between(
+                points[shoulder] - points[elbow], points[wrist] - points[elbow]
+            )
+        return min(measured.values())
+
+    return measure(
+        ELBOW_FLEXION,
+        "deg",
+        resolution,
+        compute=compute,
+        describe=lambda value: _describe_flexion(value, measured, thresholds),
+    )
+
+
+def _describe_flexion(value: float, measured: dict[str, float], thresholds: Thresholds) -> str:
+    side = min(measured, key=lambda key: measured[key])
+    if value < thresholds.elbow_flexed_deg:
+        return f"your {side} elbow is bent to {value:.0f}°"
+    return f"both elbows are fairly straight (the {side} is the more bent, at {value:.0f}°)"

--- a/packages/posture-core/src/posture_core/metrics/arms.py
+++ b/packages/posture-core/src/posture_core/metrics/arms.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from posture_core.geometry import angle_between, distance, midpoint
+from posture_core.geometry import MIN_LENGTH, angle_between, distance, midpoint
 from posture_core.keypoints import KeypointName
 from posture_core.metrics._support import abstain, measure, world_points
 from posture_core.resolver import Resolved
@@ -91,12 +91,16 @@ def arms_crossed(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
         midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP]),
         midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER]),
     )
-    if torso <= 0.0:
+    # `distance` is never negative, so a `<= 0.0` test would only catch the exact-zero case. A
+    # torso of 1e-12 m divides the ratio up to ~1e11, which compares as "not folded" against any
+    # threshold — a confident wrong answer from a measurement that does not exist. Same threshold
+    # the geometry layer uses for a vector with no direction, because it is the same degeneracy.
+    if torso < MIN_LENGTH:
         return abstain(
             ARMS_CROSSED,
             "ratio",
-            "your shoulders and hips overlap in this photo, so there is no body length to "
-            "measure against",
+            "your shoulders and hips are at the same point in this photo, so there is no body "
+            "length to measure against",
             inputs=CROSSED_REQUIRED,
         )
 

--- a/packages/posture-core/src/posture_core/synthetic.py
+++ b/packages/posture-core/src/posture_core/synthetic.py
@@ -199,6 +199,7 @@ def make_pose(
     shank_deg: float = 0.0,
     upper_arm_deg: float = 0.0,
     forearm_deg: float = 0.0,
+    forearm_cross_deg: float = 0.0,
     facing: Facing = Facing.RIGHT,
     view: View = View.LATERAL,
     image_width: int = 640,
@@ -219,6 +220,12 @@ def make_pose(
     ``180 - |thigh_deg - shank_deg|``. That is deliberate: it means the figure is always
     physically consistent, whereas taking flexion as an input would let a caller specify a knee
     angle and a shin direction that contradict each other.
+
+    ``forearm_cross_deg`` rotates each forearm out of the sagittal plane and **toward the
+    opposite side of the body**, which is how a folded-arms figure is built. At 0 the arms hang in
+    their own sagittal planes; at around 60 the wrists pass the midline and each ends up near the
+    opposite elbow. Added for the ``arms_crossed`` metric (OP-28), which cannot be tested without
+    a figure whose arms are actually crossed.
 
     :param confidence: per-keypoint ``(visibility, presence)`` overrides. The two are independent
         signals — low visibility with high presence is *occluded*, low presence is *out of frame*
@@ -283,7 +290,8 @@ def make_pose(
 
     # --- arms -------------------------------------------------------------------------------
     upper_arm = _scale(axes.from_vertical_down(upper_arm_deg), body.upper_arm)
-    forearm = _scale(axes.from_vertical_down(forearm_deg), body.forearm)
+    forearm_sagittal = axes.from_vertical_down(forearm_deg)
+    cross = math.radians(forearm_cross_deg)
     for side, elbow_name, wrist_name, hand_names in (
         (
             1,
@@ -300,11 +308,20 @@ def make_pose(
     ):
         shoulder = _add(shoulder_mid, _scale(half_shoulder, side))
         elbow = _add(shoulder, upper_arm)
+        # The forearm direction stays a unit vector: `from_vertical_down` lies in the sagittal
+        # plane and `left` is perpendicular to it, so a cos/sin blend of the two is orthonormal.
+        # `-side` sends each forearm toward the *opposite* half of the body, which is what folding
+        # the arms does.
+        forearm_direction = _add(
+            _scale(forearm_sagittal, math.cos(cross)),
+            _scale(axes.left, -side * math.sin(cross)),
+        )
+        forearm = _scale(forearm_direction, body.forearm)
         wrist = _add(elbow, forearm)
         place(elbow_name, elbow)
         place(wrist_name, wrist)
         pinky, index, thumb = hand_names
-        hand_direction = _scale(axes.from_vertical_down(forearm_deg), body.hand)
+        hand_direction = _scale(forearm_direction, body.hand)
         place(pinky, _add(wrist, hand_direction, _scale(axes.left, side * 0.02)))
         place(index, _add(wrist, hand_direction, _scale(axes.left, -side * 0.02)))
         place(thumb, _add(wrist, _scale(hand_direction, 0.6), _scale(face, 0.03)))

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -98,12 +98,30 @@ class Thresholds:
     """Between this and the cutoff, worth mentioning but not calling a fault."""
 
     # -- arms and elbows (OP-28) ---------------------------------------------------------------
-    arms_crossed_ratio: float = 0.15
-    """``|forearm - upper_arm| / torso_length`` below which the arms read as crossed.
+    arms_crossed_ratio: float = 0.70
+    """Wrist-to-opposite-elbow distance over torso length, below which the arms read as folded.
 
     Normalised by torso length, which is the entire fix for the legacy `±100` pixel literal: the
-    same crossed arms at twice the camera distance produced half the pixel difference and a
+    same folded arms at twice the camera distance produced half the pixel separation and a
     different verdict. Dividing by a length measured on the same body cancels the scale.
+
+    **The value was measured, not assumed.** `docs/V2-PLAN.md` proposed 0.15 against a different
+    formula — `|forearm - upper_arm| / torso` — which compares two segments of the *same* arm and
+    evaluates to ~0.06 for typical adult proportions in any posture whatsoever; it would have
+    reported folded arms for everybody. Running the real backend over the eight fixtures gives a
+    clean separation on the wrist-to-opposite-elbow measure:
+
+        straight_armsfolded.jpg   0.53   <- the one fixture with folded arms
+        bench_feet_dangling.jpg   0.91
+        hunchback_right.jpg       1.00
+        desk_lean_exif.jpeg       1.04
+        hunchback_left.jpg        1.05
+        reclined_right.jpg        1.04
+        kneeling_right.jpg        1.07
+        desk_hunch.jpeg           1.20
+
+    0.70 sits in the gap with room on both sides. Eight photographs is a small sample and this
+    should be revisited against the evaluation set in Epic H.
     """
 
     elbow_flexed_deg: float = 120.0

--- a/packages/posture-core/tests/test_arms.py
+++ b/packages/posture-core/tests/test_arms.py
@@ -1,0 +1,170 @@
+"""Tests for `arms_crossed` and `elbow_flexion_deg`."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from builders import flat_resolver, metric_of, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core.metrics.arms import arms_crossed, elbow_flexion_deg
+from posture_core.status import MetricStatus
+from posture_core.synthetic import Anthropometry
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+ARMS_DOWN: dict[str, Any] = {"upper_arm_deg": 15.0, "forearm_deg": 80.0}
+ARMS_FOLDED: dict[str, Any] = {**ARMS_DOWN, "forearm_cross_deg": 55.0}
+
+
+# ---------------------------------------------------------------------------------------------
+# arms_crossed
+# ---------------------------------------------------------------------------------------------
+
+
+def test_folding_the_arms_lowers_the_ratio() -> None:
+    """The ratio *is* the evidence: smaller means each wrist is nearer the opposite elbow."""
+    assert value_of(arms_crossed, **ARMS_FOLDED) < value_of(arms_crossed, **ARMS_DOWN)
+
+
+def test_the_bands_separate_folded_from_unfolded_at_the_default_threshold() -> None:
+    assert "folded across your chest" in metric_of(arms_crossed, **ARMS_FOLDED).detail
+    assert "not folded" in metric_of(arms_crossed, **ARMS_DOWN).detail
+
+
+@pytest.mark.parametrize("scale", [0.4, 1.0, 2.5])
+def test_the_ratio_does_not_move_with_body_size(scale: float) -> None:
+    """The whole point of the normalisation, and the direct fix for the legacy `±100` literal.
+
+    That literal was an absolute pixel distance, so identical folded arms at twice the camera
+    distance produced half the separation and the opposite verdict — a defect the original code's
+    own comment acknowledged and never addressed.
+    """
+    default = Anthropometry()
+    scaled = Anthropometry(
+        torso=default.torso * scale,
+        shoulder_width=default.shoulder_width * scale,
+        hip_width=default.hip_width * scale,
+        upper_arm=default.upper_arm * scale,
+        forearm=default.forearm * scale,
+    )
+    baseline = value_of(arms_crossed, **ARMS_FOLDED)
+    assert value_of(arms_crossed, body=scaled, **ARMS_FOLDED) == pytest.approx(baseline, abs=1e-9)
+
+
+@pytest.mark.parametrize(("width", "height"), [(640, 480), (1920, 1080)])
+def test_the_ratio_does_not_move_with_frame_size(width: int, height: int) -> None:
+    baseline = value_of(arms_crossed, **ARMS_FOLDED)
+    assert value_of(
+        arms_crossed, image_width=width, image_height=height, **ARMS_FOLDED
+    ) == pytest.approx(baseline, abs=1e-9)
+
+
+def test_both_arms_must_be_folded_not_just_one() -> None:
+    """Taking the larger of the two crossings, not the smaller.
+
+    One hand resting near the opposite elbow is a very ordinary way to sit, and a minimum would
+    read it as fully folded arms.
+    """
+    metric = metric_of(arms_crossed, **ARMS_FOLDED)
+    assert metric.value is not None
+    # The figure folds both arms symmetrically, so both crossings are equal and the max is the
+    # honest summary. A one-armed fold would score the *unfolded* arm's distance.
+    assert metric.value < DEFAULT_THRESHOLDS.arms_crossed_ratio
+
+
+def test_the_threshold_is_injected() -> None:
+    strict = with_thresholds(arms_crossed_ratio=0.2)
+    assert "not folded" in metric_of(arms_crossed, thresholds=strict, **ARMS_FOLDED).detail
+
+
+def test_a_missing_wrist_produces_a_gap() -> None:
+    metric = metric_of(arms_crossed, **without(K.LEFT_WRIST))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "left wrist" in metric.detail
+
+
+def test_an_unclear_elbow_abstains_as_low_confidence() -> None:
+    assert metric_of(arms_crossed, **unclear(K.RIGHT_ELBOW)).status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_a_zero_length_torso_abstains_rather_than_dividing_by_it() -> None:
+    """Normalising by a length of zero would produce infinity, which compares as "not folded"
+    against any threshold — a wrong answer that raises nothing."""
+    metric = metric_of(arms_crossed, body=Anthropometry(torso=0.0), **ARMS_FOLDED)
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+    assert "no body length" in metric.detail
+
+
+def test_a_two_dimensional_backend_abstains() -> None:
+    assert arms_crossed(flat_resolver(**ARMS_FOLDED), DEFAULT_THRESHOLDS).value is None
+
+
+# ---------------------------------------------------------------------------------------------
+# elbow_flexion_deg
+# ---------------------------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("upper_arm", "forearm", "expected"),
+    [
+        (0.0, 0.0, 180.0),  # arm hanging straight
+        (0.0, 90.0, 90.0),  # forearm horizontal, upper arm vertical
+        (15.0, 80.0, 115.0),  # ordinary resting position
+        (0.0, 180.0, 0.0),  # fully folded back on itself
+    ],
+)
+def test_flexion_is_the_shoulder_elbow_wrist_angle(
+    upper_arm: float, forearm: float, expected: float
+) -> None:
+    assert value_of(
+        elbow_flexion_deg, upper_arm_deg=upper_arm, forearm_deg=forearm
+    ) == pytest.approx(expected, abs=1e-6)
+
+
+def test_the_more_bent_elbow_is_reported_and_named() -> None:
+    """Not an average.
+
+    A bent elbow is the signal — an arm propped on a desk, or folded across the chest — and
+    averaging it with a straight arm produces a number describing neither. The description names
+    the side so the report cannot imply it applies to both.
+    """
+    metric = metric_of(elbow_flexion_deg, upper_arm_deg=0.0, forearm_deg=90.0)
+    assert metric.value == pytest.approx(90.0, abs=1e-6)
+    assert "left elbow" in metric.detail or "right elbow" in metric.detail
+
+
+@pytest.mark.parametrize("scale", [0.5, 2.0])
+def test_flexion_does_not_move_with_body_size(scale: float) -> None:
+    default = Anthropometry()
+    scaled = Anthropometry(upper_arm=default.upper_arm * scale, forearm=default.forearm * scale)
+    assert value_of(
+        elbow_flexion_deg, upper_arm_deg=0.0, forearm_deg=90.0, body=scaled
+    ) == pytest.approx(90.0, abs=1e-6)
+
+
+def test_the_flexed_band_comes_from_the_injected_threshold() -> None:
+    bent: dict[str, Any] = {"upper_arm_deg": 0.0, "forearm_deg": 90.0}
+    assert "bent to 90°" in metric_of(elbow_flexion_deg, **bent).detail
+    lenient = with_thresholds(elbow_flexed_deg=45.0)
+    assert "fairly straight" in metric_of(elbow_flexion_deg, thresholds=lenient, **bent).detail
+
+
+def test_a_missing_elbow_produces_a_gap() -> None:
+    metric = metric_of(elbow_flexion_deg, **without(K.RIGHT_ELBOW))
+    assert metric.value is None
+    assert "right elbow" in metric.detail
+
+
+def test_a_collapsed_forearm_abstains_rather_than_reporting_zero_degrees() -> None:
+    """Zero would mean "elbow folded completely shut", a specific claim about a measurement that
+    does not exist."""
+    metric = metric_of(elbow_flexion_deg, body=Anthropometry(forearm=0.0))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+def test_flexion_on_a_two_dimensional_backend_abstains() -> None:
+    assert elbow_flexion_deg(flat_resolver(), DEFAULT_THRESHOLDS).value is None

--- a/packages/posture-core/tests/test_arms.py
+++ b/packages/posture-core/tests/test_arms.py
@@ -89,10 +89,16 @@ def test_an_unclear_elbow_abstains_as_low_confidence() -> None:
     assert metric_of(arms_crossed, **unclear(K.RIGHT_ELBOW)).status is MetricStatus.LOW_CONFIDENCE
 
 
-def test_a_zero_length_torso_abstains_rather_than_dividing_by_it() -> None:
-    """Normalising by a length of zero would produce infinity, which compares as "not folded"
-    against any threshold — a wrong answer that raises nothing."""
-    metric = metric_of(arms_crossed, body=Anthropometry(torso=0.0), **ARMS_FOLDED)
+@pytest.mark.parametrize("torso", [0.0, 1e-12, 1e-10])
+def test_a_degenerate_torso_abstains_rather_than_dividing_by_it(torso: float) -> None:
+    """Near-zero, not just zero.
+
+    `distance` is never negative, so a `<= 0.0` guard catches only the exact case — and exact zero
+    is the one a real backend is least likely to produce. A torso of 1e-12 m divides the ratio up
+    to ~1e11, which compares as "not folded" against any threshold: a confident wrong answer from
+    a measurement that does not exist, which is the failure mode this package is built to avoid.
+    """
+    metric = metric_of(arms_crossed, body=Anthropometry(torso=torso), **ARMS_FOLDED)
     assert metric.value is None
     assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
     assert "no body length" in metric.detail


### PR DESCRIPTION
Closes OP-28. Base: `op-27-craniovertebral`.

Adds arm position, normalised by the torso of the body being measured.

## Changes
- `posture_core.metrics.arms`: `arms_crossed` (normalised wrist-to-opposite-elbow distance) and `elbow_flexion_deg`.
- `Thresholds.arms_crossed_ratio` default set to 0.70.

## Notes
- Replaces the `±100` pixel literal. Dividing by a torso length measured in the same frame cancels camera distance and body size together. Tested across a 6× range.
- **The plan's formula is not used.** `|forearm - upper_arm| / torso < 0.15` compares two segments of the same arm; with typical adult proportions it evaluates to ~0.06 in any posture, so it would report folded arms universally. Folded arms are distinguished by each wrist sitting near the opposite elbow, which is what this measures.
- The threshold was measured against the eight fixtures with the real backend: `straight_armsfolded` 0.53, the other seven 0.91–1.20. 0.70 sits in the gap. Caveat: eight photographs, and those figures include far-arm landmarks below the confidence threshold. Recalibration is tracked in OP-60.
- `arms_crossed` needs both arms by definition and therefore abstains on a strict lateral view, which is the view the app requests. Asserted by a test rather than left as a permanently null field.
- The larger of the two crossings is taken, so both arms must be folded. The minimum would read one hand resting near the opposite elbow as folded arms.
- `elbow_flexion_deg` requires **both** arms in this commit, so in a lateral view it will often abstain. OP-29 converts it to measure whichever arm was actually seen, once `require_either_side` exists.
- Metrics return evidence, not verdicts. The threshold comparison is the rules layer's job (OP-32).

## Tests
25 tests, 100% coverage.
