### PR TITLE
OP-29: knee_flexion_deg — hip-knee-ankle angle in world space

### DIFF
--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -14,11 +14,13 @@ from __future__ import annotations
 
 from posture_core.metrics.arms import arms_crossed, elbow_flexion_deg
 from posture_core.metrics.head import craniovertebral_angle_deg
+from posture_core.metrics.knees import knee_flexion_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
 
 __all__ = [
     "arms_crossed",
     "craniovertebral_angle_deg",
     "elbow_flexion_deg",
+    "knee_flexion_deg",
     "trunk_inclination_deg",
 ]

--- a/packages/posture-core/src/posture_core/metrics/_support.py
+++ b/packages/posture-core/src/posture_core/metrics/_support.py
@@ -14,15 +14,16 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from posture_core.geometry import DegenerateVectorError, Vector3, world_vec
-from posture_core.status import Metric, MetricStatus
+from posture_core.resolver import Resolved, Unresolved
+from posture_core.status import KeypointStatus, Metric, MetricStatus
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
 
     from posture_core.keypoints import KeypointName
-    from posture_core.resolver import Resolved
+    from posture_core.resolver import KeypointResolver
 
-__all__ = ["abstain", "measure", "world_points"]
+__all__ = ["abstain", "measure", "require_either_side", "world_points"]
 
 
 def abstain(
@@ -97,4 +98,47 @@ def measure(
         detail=describe(value),
         inputs=tuple(resolution.landmarks),
         confidence=resolution.confidence,
+    )
+
+
+def require_either_side(
+    resolver: KeypointResolver, sides: Mapping[str, tuple[KeypointName, ...]]
+) -> tuple[str, Resolved] | Unresolved:
+    """Resolve whichever side of the body the camera actually saw.
+
+    **Measured, not assumed.** Requiring both knees, both elbows or both feet was the first
+    implementation, and running it over the eight fixtures with the real backend made every single
+    one abstain: in a lateral view — the view this application asks users for — the far limb is
+    behind the torso and MediaPipe reports it below the visibility threshold, correctly. An engine
+    that abstains on every photograph it was designed for is honest and useless.
+
+    So a bilateral metric needs one *usable* side, and reports which. The side with the higher
+    confidence wins, so the near leg is chosen over the inferred far one rather than by an
+    arbitrary left-first rule.
+
+    When neither side resolves, the problems from both are merged into a single refusal, and a
+    structurally missing landmark outranks a merely unclear one — the same precedence the resolver
+    itself uses, for the same reason: reframing the shot subsumes lighting it better.
+    """
+    best: tuple[str, Resolved] | None = None
+    problems: dict[KeypointName, KeypointStatus] = {}
+
+    for side, keypoints in sides.items():
+        resolution = resolver.require(*keypoints)
+        if isinstance(resolution, Resolved):
+            if best is None or resolution.confidence > best[1].confidence:
+                best = (side, resolution)
+        else:
+            problems.update(resolution.problems)
+
+    if best is not None:
+        return best
+
+    structural = any(
+        status in (KeypointStatus.NOT_DETECTED, KeypointStatus.OUT_OF_FRAME)
+        for status in problems.values()
+    )
+    return Unresolved(
+        status=(MetricStatus.INSUFFICIENT_KEYPOINTS if structural else MetricStatus.LOW_CONFIDENCE),
+        problems=problems,
     )

--- a/packages/posture-core/src/posture_core/metrics/arms.py
+++ b/packages/posture-core/src/posture_core/metrics/arms.py
@@ -39,7 +39,7 @@ from typing import TYPE_CHECKING, Final
 
 from posture_core.geometry import angle_between, distance, midpoint
 from posture_core.keypoints import KeypointName
-from posture_core.metrics._support import abstain, measure, world_points
+from posture_core.metrics._support import abstain, measure, require_either_side, world_points
 from posture_core.resolver import Resolved
 from posture_core.status import Metric
 
@@ -67,14 +67,10 @@ CROSSED_REQUIRED: Final = (
     KeypointName.RIGHT_WRIST,
 )
 
-FLEXION_REQUIRED: Final = (
-    KeypointName.LEFT_SHOULDER,
-    KeypointName.LEFT_ELBOW,
-    KeypointName.LEFT_WRIST,
-    KeypointName.RIGHT_SHOULDER,
-    KeypointName.RIGHT_ELBOW,
-    KeypointName.RIGHT_WRIST,
-)
+_ARM_SIDES: Final = {
+    "left": (KeypointName.LEFT_SHOULDER, KeypointName.LEFT_ELBOW, KeypointName.LEFT_WRIST),
+    "right": (KeypointName.RIGHT_SHOULDER, KeypointName.RIGHT_ELBOW, KeypointName.RIGHT_WRIST),
+}
 
 
 def arms_crossed(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
@@ -122,49 +118,37 @@ def arms_crossed(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
 
 
 def elbow_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
-    """The angle at the more bent of the two elbows.
+    """The shoulder-elbow-wrist angle on whichever arm the camera actually saw.
 
-    The *more* bent, rather than an average of the two. A bent elbow is the signal — an arm
-    propped on a desk or folded across the chest — and averaging it with a straight arm yields a
-    number that describes neither of them. The description names the side, so the report never
-    implies the measurement applies to both.
+    One arm, not both, and for the same reason the leg metrics take one leg: in a lateral view the
+    far arm is behind the torso and is reported below the visibility threshold. Requiring both made
+    every fixture abstain. See :func:`~posture_core.metrics._support.require_either_side`.
+
+    The description names the side, so a report can never imply the measurement covers both arms.
     """
-    resolution = resolver.require(*FLEXION_REQUIRED)
-    if not isinstance(resolution, Resolved):
-        return resolution.as_metric(ELBOW_FLEXION, "deg")
+    resolved = require_either_side(resolver, _ARM_SIDES)
+    if not isinstance(resolved, tuple):
+        return resolved.as_metric(ELBOW_FLEXION, "deg")
+    side, resolution = resolved
 
     points = world_points(ELBOW_FLEXION, "deg", resolution)
     if isinstance(points, Metric):
         return points
 
-    sides = {
-        "left": (KeypointName.LEFT_SHOULDER, KeypointName.LEFT_ELBOW, KeypointName.LEFT_WRIST),
-        "right": (
-            KeypointName.RIGHT_SHOULDER,
-            KeypointName.RIGHT_ELBOW,
-            KeypointName.RIGHT_WRIST,
-        ),
-    }
-    measured: dict[str, float] = {}
-
-    def compute() -> float:
-        for side, (shoulder, elbow, wrist) in sides.items():
-            measured[side] = angle_between(
-                points[shoulder] - points[elbow], points[wrist] - points[elbow]
-            )
-        return min(measured.values())
+    shoulder, elbow, wrist = _ARM_SIDES[side]
 
     return measure(
         ELBOW_FLEXION,
         "deg",
         resolution,
-        compute=compute,
-        describe=lambda value: _describe_flexion(value, measured, thresholds),
+        compute=lambda: angle_between(
+            points[shoulder] - points[elbow], points[wrist] - points[elbow]
+        ),
+        describe=lambda value: _describe_flexion(value, side, thresholds),
     )
 
 
-def _describe_flexion(value: float, measured: dict[str, float], thresholds: Thresholds) -> str:
-    side = min(measured, key=lambda key: measured[key])
+def _describe_flexion(value: float, side: str, thresholds: Thresholds) -> str:
     if value < thresholds.elbow_flexed_deg:
         return f"your {side} elbow is bent to {value:.0f}°"
-    return f"both elbows are fairly straight (the {side} is the more bent, at {value:.0f}°)"
+    return f"your {side} elbow is fairly straight, at {value:.0f}°"

--- a/packages/posture-core/src/posture_core/metrics/knees.py
+++ b/packages/posture-core/src/posture_core/metrics/knees.py
@@ -56,10 +56,18 @@ def knee_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metr
 
 
 def _describe(value: float, side: str, thresholds: Thresholds) -> str:
+    """Every band names the side, and none of them says "legs" or "knees".
+
+    Only one leg was measured. A description that implies both is not a wording nit — it is the
+    metric claiming coverage it does not have. The band ordering here is what
+    :meth:`~posture_core.thresholds.Thresholds.__post_init__` validates: kneeling is tested first,
+    so a ``knee_kneeling_max_deg`` at or above ``knee_seated_min_deg`` would make the tucked-back
+    band unreachable.
+    """
     if value <= thresholds.knee_kneeling_max_deg:
         return f"your {side} knee is folded to {value:.0f}° — you appear to be kneeling"
     if value < thresholds.knee_seated_min_deg:
         return f"your {side} knee is tucked back sharply, at {value:.0f}°"
     if value <= thresholds.knee_seated_max_deg:
         return f"your {side} knee is at a comfortable seated angle ({value:.0f}°)"
-    return f"legs are extended, with the {side} knee at {value:.0f}°"
+    return f"your {side} leg is extended, with the knee at {value:.0f}°"

--- a/packages/posture-core/src/posture_core/metrics/knees.py
+++ b/packages/posture-core/src/posture_core/metrics/knees.py
@@ -1,0 +1,65 @@
+"""``knee_flexion_deg`` — the hip-knee-ankle angle, in world space.
+
+Replaces ``checkKneeling``, which raised ``UnboundLocalError`` on a path where its result variable
+was never assigned. The function could not even fail cleanly, let alone report kneeling.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.geometry import angle_between
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import measure, require_either_side, world_points
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["KNEE_FLEXION", "knee_flexion_deg"]
+
+KNEE_FLEXION: Final = "knee_flexion_deg"
+
+SIDES: Final = {
+    "left": (KeypointName.LEFT_HIP, KeypointName.LEFT_KNEE, KeypointName.LEFT_ANKLE),
+    "right": (KeypointName.RIGHT_HIP, KeypointName.RIGHT_KNEE, KeypointName.RIGHT_ANKLE),
+}
+
+
+def knee_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """The hip-knee-ankle angle on whichever leg the camera actually saw.
+
+    One leg, not both. In the lateral view this application asks users for, the far leg sits behind
+    the torso and is reported below the visibility threshold — correctly. Requiring both made every
+    one of the eight fixtures abstain. See
+    :func:`~posture_core.metrics._support.require_either_side`.
+    """
+    resolved = require_either_side(resolver, SIDES)
+    if not isinstance(resolved, tuple):
+        return resolved.as_metric(KNEE_FLEXION, "deg")
+    side, resolution = resolved
+
+    points = world_points(KNEE_FLEXION, "deg", resolution)
+    if isinstance(points, Metric):
+        return points
+
+    hip, knee, ankle = SIDES[side]
+
+    return measure(
+        KNEE_FLEXION,
+        "deg",
+        resolution,
+        compute=lambda: angle_between(points[hip] - points[knee], points[ankle] - points[knee]),
+        describe=lambda value: _describe(value, side, thresholds),
+    )
+
+
+def _describe(value: float, side: str, thresholds: Thresholds) -> str:
+    if value <= thresholds.knee_kneeling_max_deg:
+        return f"your {side} knee is folded to {value:.0f}° — you appear to be kneeling"
+    if value < thresholds.knee_seated_min_deg:
+        return f"your {side} knee is tucked back sharply, at {value:.0f}°"
+    if value <= thresholds.knee_seated_max_deg:
+        return f"knees are at a comfortable seated angle ({value:.0f}°)"
+    return f"legs are extended, with the {side} knee at {value:.0f}°"

--- a/packages/posture-core/src/posture_core/metrics/knees.py
+++ b/packages/posture-core/src/posture_core/metrics/knees.py
@@ -61,5 +61,5 @@ def _describe(value: float, side: str, thresholds: Thresholds) -> str:
     if value < thresholds.knee_seated_min_deg:
         return f"your {side} knee is tucked back sharply, at {value:.0f}°"
     if value <= thresholds.knee_seated_max_deg:
-        return f"knees are at a comfortable seated angle ({value:.0f}°)"
+        return f"your {side} knee is at a comfortable seated angle ({value:.0f}°)"
     return f"legs are extended, with the {side} knee at {value:.0f}°"

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -191,6 +191,14 @@ class Thresholds:
             )
         if self.knee_seated_min_deg >= self.knee_seated_max_deg:
             raise ValueError("knee_seated_min_deg must be below knee_seated_max_deg")
+        if self.knee_kneeling_max_deg >= self.knee_seated_min_deg:
+            raise ValueError(
+                f"knee_kneeling_max_deg ({self.knee_kneeling_max_deg}) must be strictly below "
+                f"knee_seated_min_deg ({self.knee_seated_min_deg}). The knee bands are tested "
+                "in ascending order and kneeling is tested first, so an overlap does not produce "
+                "a wrong answer — it silently swallows the tucked-back band, and every kneeling "
+                "angle above the overlap reports as seated"
+            )
         if self.lateral_view_max_ratio >= self.frontal_view_min_ratio:
             raise ValueError(
                 "lateral_view_max_ratio must be below frontal_view_min_ratio; the gap between "

--- a/packages/posture-core/tests/test_arms.py
+++ b/packages/posture-core/tests/test_arms.py
@@ -102,6 +102,20 @@ def test_a_two_dimensional_backend_abstains() -> None:
     assert arms_crossed(flat_resolver(**ARMS_FOLDED), DEFAULT_THRESHOLDS).value is None
 
 
+def test_arms_crossed_needs_both_arms_and_says_so_when_one_is_hidden() -> None:
+    """The honest limitation, asserted so it cannot be forgotten.
+
+    Unlike every other bilateral metric here, this one genuinely cannot fall back to a single side:
+    "each wrist near the opposite elbow" is a statement about both arms at once. In a strict
+    lateral view the far arm is occluded, so the metric abstains — which is correct, and means
+    folded arms are not assessable from the very view the app asks users for. Recorded here rather
+    than discovered later by someone wondering why the field is always null.
+    """
+    metric = metric_of(arms_crossed, **unclear(K.RIGHT_WRIST, K.RIGHT_ELBOW), **ARMS_FOLDED)
+    assert metric.value is None
+    assert metric.status is MetricStatus.LOW_CONFIDENCE
+
+
 # ---------------------------------------------------------------------------------------------
 # elbow_flexion_deg
 # ---------------------------------------------------------------------------------------------
@@ -124,16 +138,27 @@ def test_flexion_is_the_shoulder_elbow_wrist_angle(
     ) == pytest.approx(expected, abs=1e-6)
 
 
-def test_the_more_bent_elbow_is_reported_and_named() -> None:
-    """Not an average.
+def test_the_measured_arm_is_named_in_the_description() -> None:
+    """One arm, not both, and the report says which.
 
-    A bent elbow is the signal — an arm propped on a desk, or folded across the chest — and
-    averaging it with a straight arm produces a number describing neither. The description names
-    the side so the report cannot imply it applies to both.
+    In a lateral view the far arm is behind the torso and reported below the visibility threshold,
+    so requiring both made every fixture abstain. Since only one arm is measured, the description
+    must never imply otherwise.
     """
     metric = metric_of(elbow_flexion_deg, upper_arm_deg=0.0, forearm_deg=90.0)
     assert metric.value == pytest.approx(90.0, abs=1e-6)
     assert "left elbow" in metric.detail or "right elbow" in metric.detail
+
+
+def test_the_visible_arm_is_used_when_the_far_one_is_occluded() -> None:
+    metric = metric_of(
+        elbow_flexion_deg,
+        upper_arm_deg=0.0,
+        forearm_deg=90.0,
+        **unclear(K.RIGHT_SHOULDER, K.RIGHT_ELBOW, K.RIGHT_WRIST),
+    )
+    assert metric.value == pytest.approx(90.0, abs=1e-6)
+    assert "left elbow" in metric.detail
 
 
 @pytest.mark.parametrize("scale", [0.5, 2.0])
@@ -152,10 +177,11 @@ def test_the_flexed_band_comes_from_the_injected_threshold() -> None:
     assert "fairly straight" in metric_of(elbow_flexion_deg, thresholds=lenient, **bent).detail
 
 
-def test_a_missing_elbow_produces_a_gap() -> None:
-    metric = metric_of(elbow_flexion_deg, **without(K.RIGHT_ELBOW))
+def test_both_elbows_missing_produces_a_gap() -> None:
+    metric = metric_of(elbow_flexion_deg, **without(K.LEFT_ELBOW, K.RIGHT_ELBOW))
     assert metric.value is None
     assert "right elbow" in metric.detail
+    assert "left elbow" in metric.detail
 
 
 def test_a_collapsed_forearm_abstains_rather_than_reporting_zero_degrees() -> None:

--- a/packages/posture-core/tests/test_knees.py
+++ b/packages/posture-core/tests/test_knees.py
@@ -57,7 +57,7 @@ def test_the_angle_does_not_move_with_leg_length(scale: float) -> None:
         (15.0, 165.0, "kneeling"),
         (120.0, 5.0, "tucked back sharply"),
         (85.0, 5.0, "comfortable seated angle"),
-        (0.0, 0.0, "legs are extended"),
+        (0.0, 0.0, "leg is extended"),
     ],
 )
 def test_the_description_reflects_the_configured_bands(
@@ -70,15 +70,35 @@ def test_the_description_reflects_the_configured_bands(
 def test_every_description_names_the_side_it_measured(thigh: float, shank: float) -> None:
     """Only one leg is measured, so the report must never imply otherwise.
 
-    Every band has to say which. The seated band did not, which is easy to miss precisely because
-    it is the band most photographs land in.
+    Every band has to say which. The seated band did not, and the extended band said "legs" in the
+    plural — both easy to miss, and the seated one is the band most photographs land in.
     """
     detail = metric_of(knee, thigh_deg=thigh, shank_deg=shank).detail
     assert "left" in detail or "right" in detail
 
 
+@pytest.mark.parametrize(("thigh", "shank"), [(15.0, 165.0), (120.0, 5.0), (85.0, 5.0), (0.0, 0.0)])
+def test_no_description_implies_both_legs_were_measured(thigh: float, shank: float) -> None:
+    """Naming a side is not enough if the sentence around it is still plural.
+
+    "legs are extended, with the left knee at 180°" names a side and still claims both legs were
+    assessed. Only one was.
+    """
+    detail = metric_of(knee, thigh_deg=thigh, shank_deg=shank).detail
+    assert "legs" not in detail
+    assert "knees" not in detail
+
+
 def test_the_bands_are_injected() -> None:
-    strict = with_thresholds(knee_kneeling_max_deg=110.0)
+    """The seated floor moves with the kneeling ceiling, because the two are validated together.
+
+    Overriding `knee_kneeling_max_deg` alone up to 110 would now be rejected at construction: it
+    would reach past the 70° seated floor and delete the tucked-back band. That rejection is the
+    point of the check, so the test configures a coherent set instead of a contradictory one.
+    """
+    strict = with_thresholds(
+        knee_kneeling_max_deg=110.0, knee_seated_min_deg=115.0, knee_seated_max_deg=140.0
+    )
     assert "kneeling" in metric_of(knee, thigh_deg=85.0, shank_deg=5.0, thresholds=strict).detail
 
 

--- a/packages/posture-core/tests/test_knees.py
+++ b/packages/posture-core/tests/test_knees.py
@@ -1,0 +1,114 @@
+"""Tests for `knee_flexion_deg`."""
+
+from __future__ import annotations
+
+import pytest
+from builders import flat_resolver, metric_of, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core.metrics.knees import knee_flexion_deg as knee
+from posture_core.status import MetricStatus
+from posture_core.synthetic import Anthropometry
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+
+@pytest.mark.parametrize(
+    ("thigh", "shank", "expected"),
+    [
+        (0.0, 0.0, 180.0),  # standing, leg straight
+        (85.0, 5.0, 100.0),  # sitting on a chair
+        (90.0, 0.0, 90.0),  # a right angle
+        (15.0, 165.0, 30.0),  # kneeling, shin folded back
+    ],
+)
+def test_flexion_is_the_hip_knee_ankle_angle(thigh: float, shank: float, expected: float) -> None:
+    """Constructed at known segment angles, so the expected value is arithmetic.
+
+    The relationship is `180 - |thigh - shank|`, which the builder guarantees by making flexion
+    emergent rather than an input — a figure cannot be asked for a knee angle that contradicts the
+    direction of its own shin.
+    """
+    assert value_of(knee, thigh_deg=thigh, shank_deg=shank) == pytest.approx(expected, abs=1e-6)
+
+
+def test_the_legacy_unbound_local_path_now_returns_a_value() -> None:
+    """`checkKneeling` raised UnboundLocalError on a path where its result was never assigned.
+
+    It could not even fail cleanly. Any input that produces a number here is an improvement on
+    that, which is why this reads as a trivially simple test.
+    """
+    metric = metric_of(knee, thigh_deg=15.0, shank_deg=165.0)
+    assert metric.value is not None
+    assert "kneeling" in metric.detail
+
+
+@pytest.mark.parametrize("scale", [0.5, 2.0])
+def test_the_angle_does_not_move_with_leg_length(scale: float) -> None:
+    default = Anthropometry()
+    scaled = Anthropometry(thigh=default.thigh * scale, shank=default.shank * scale)
+    assert value_of(knee, thigh_deg=85.0, shank_deg=5.0, body=scaled) == pytest.approx(
+        100.0, abs=1e-6
+    )
+
+
+@pytest.mark.parametrize(
+    ("thigh", "shank", "expected"),
+    [
+        (15.0, 165.0, "kneeling"),
+        (120.0, 5.0, "tucked back sharply"),
+        (85.0, 5.0, "comfortable seated angle"),
+        (0.0, 0.0, "legs are extended"),
+    ],
+)
+def test_the_description_reflects_the_configured_bands(
+    thigh: float, shank: float, expected: str
+) -> None:
+    assert expected in metric_of(knee, thigh_deg=thigh, shank_deg=shank).detail
+
+
+def test_the_bands_are_injected() -> None:
+    strict = with_thresholds(knee_kneeling_max_deg=110.0)
+    assert "kneeling" in metric_of(knee, thigh_deg=85.0, shank_deg=5.0, thresholds=strict).detail
+
+
+def test_the_visible_leg_is_used_when_the_far_one_is_occluded() -> None:
+    """The design change the real fixtures forced.
+
+    Requiring both legs made every one of the eight fixtures abstain — in a lateral view the far
+    leg is behind the torso and MediaPipe reports it below the visibility threshold, correctly. An
+    engine that abstains on every photograph it was designed for is honest and useless.
+    """
+    metric = metric_of(knee, **unclear(K.RIGHT_KNEE, K.RIGHT_ANKLE, K.RIGHT_HIP))
+    assert metric.value is not None
+    assert "left knee" in metric.detail or "seated angle" in metric.detail
+
+
+def test_the_more_confident_side_wins_rather_than_the_first_one() -> None:
+    """So the near leg is chosen because it was seen better, not because of alphabetical order."""
+    metric = metric_of(knee, **unclear(K.LEFT_KNEE, visibility=0.55))
+    assert metric.value is not None
+    assert metric.confidence is not None
+    assert metric.confidence > 0.55
+
+
+def test_both_legs_missing_produces_a_gap_naming_them() -> None:
+    metric = metric_of(knee, **without(K.LEFT_KNEE, K.RIGHT_KNEE))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "left knee" in metric.detail
+    assert "right knee" in metric.detail
+
+
+def test_both_legs_unclear_abstains_as_low_confidence() -> None:
+    metric = metric_of(knee, **unclear(K.LEFT_KNEE, K.RIGHT_KNEE))
+    assert metric.status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_a_collapsed_shank_abstains_rather_than_reporting_zero() -> None:
+    metric = metric_of(knee, body=Anthropometry(shank=0.0))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+def test_a_two_dimensional_backend_abstains() -> None:
+    assert knee(flat_resolver(), DEFAULT_THRESHOLDS).value is None

--- a/packages/posture-core/tests/test_knees.py
+++ b/packages/posture-core/tests/test_knees.py
@@ -66,6 +66,17 @@ def test_the_description_reflects_the_configured_bands(
     assert expected in metric_of(knee, thigh_deg=thigh, shank_deg=shank).detail
 
 
+@pytest.mark.parametrize(("thigh", "shank"), [(15.0, 165.0), (120.0, 5.0), (85.0, 5.0), (0.0, 0.0)])
+def test_every_description_names_the_side_it_measured(thigh: float, shank: float) -> None:
+    """Only one leg is measured, so the report must never imply otherwise.
+
+    Every band has to say which. The seated band did not, which is easy to miss precisely because
+    it is the band most photographs land in.
+    """
+    detail = metric_of(knee, thigh_deg=thigh, shank_deg=shank).detail
+    assert "left" in detail or "right" in detail
+
+
 def test_the_bands_are_injected() -> None:
     strict = with_thresholds(knee_kneeling_max_deg=110.0)
     assert "kneeling" in metric_of(knee, thigh_deg=85.0, shank_deg=5.0, thresholds=strict).detail
@@ -80,7 +91,10 @@ def test_the_visible_leg_is_used_when_the_far_one_is_occluded() -> None:
     """
     metric = metric_of(knee, **unclear(K.RIGHT_KNEE, K.RIGHT_ANKLE, K.RIGHT_HIP))
     assert metric.value is not None
-    assert "left knee" in metric.detail or "seated angle" in metric.detail
+    # The side, specifically. The looser `or "seated angle"` this used to allow would have passed
+    # against a description that identified no side at all, which is exactly the regression the
+    # test exists to catch.
+    assert "left knee" in metric.detail
 
 
 def test_the_more_confident_side_wins_rather_than_the_first_one() -> None:

--- a/packages/posture-core/tests/test_thresholds.py
+++ b/packages/posture-core/tests/test_thresholds.py
@@ -94,6 +94,18 @@ def test_an_inverted_knee_band_is_rejected() -> None:
         Thresholds(knee_seated_min_deg=130.0, knee_seated_max_deg=120.0)
 
 
+def test_a_kneeling_ceiling_that_reaches_into_the_seated_band_is_rejected() -> None:
+    """The ordering check the seated-band one did not cover.
+
+    `_describe` tests kneeling first, so raising `knee_kneeling_max_deg` to or above
+    `knee_seated_min_deg` does not produce a wrong number — it deletes the tucked-back band
+    entirely and relabels part of the seated range as kneeling. Same class of silent dead rule as
+    the trunk and craniovertebral checks above.
+    """
+    with pytest.raises(ValueError, match="knee_kneeling_max_deg"):
+        Thresholds(knee_kneeling_max_deg=70.0, knee_seated_min_deg=70.0)
+
+
 def test_the_view_bands_must_leave_a_non_negative_ambiguous_gap() -> None:
     with pytest.raises(ValueError, match="ambiguous-view band"):
         Thresholds(lateral_view_max_ratio=0.6, frontal_view_min_ratio=0.5)

--- a/scripts/sync-stack.sh
+++ b/scripts/sync-stack.sh
@@ -35,8 +35,19 @@ trap cleanup EXIT
 git fetch origin --prune --quiet
 
 # A dirty tree turns a clean merge into a confusing one, so refuse rather than guess.
+#
+# Untracked files count. `git diff-index` does not see them, but `git checkout` does: it aborts
+# with "would be overwritten by checkout" the moment an untracked path collides with a file on the
+# branch being visited. Halfway through a loop that walks every open branch, that leaves the stack
+# partly synced and the tree parked somewhere unexpected.
 if ! git diff-index --quiet HEAD -- 2>/dev/null; then
   echo "error: working tree has uncommitted changes. Commit or stash them first." >&2
+  exit 1
+fi
+
+if [[ -n "$(git ls-files --others --exclude-standard)" ]]; then
+  echo "error: working tree has untracked files. Commit, stash (git stash -u) or remove them:" >&2
+  git ls-files --others --exclude-standard | sed 's/^/  /' >&2
   exit 1
 fi
 
@@ -72,8 +83,11 @@ while read -r number branch; do
     continue
   fi
 
-  git checkout -q "$branch"
-  git reset -q --hard "origin/$branch"
+  # `-B` rather than a plain checkout followed by a reset: it creates the local branch when it is
+  # absent and repoints it when it is not, in one step. A plain `git checkout "$branch"` fails on
+  # a fresh clone, or after the branch was pruned locally, and `set -e` would abort the whole
+  # sweep on the first such branch — leaving every branch after it unsynced.
+  git checkout -q -B "$branch" "origin/$branch"
   if git merge --no-edit origin/main >/dev/null 2>&1; then
     git push -q origin "$branch"
     printf '  #%-4s %-30s merged and pushed\n' "$number" "$branch"

--- a/scripts/sync-stack.sh
+++ b/scripts/sync-stack.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Merge the current `main` into every open stacked pull-request branch.
+#
+# Run this after each merge. Two things go stale otherwise:
+#
+#   1. GitHub's Files tab keeps the changeset it computed when the pull request was last pushed
+#      to, so a branch whose base has moved shows its own changes *plus* everything merged since.
+#      That is only a display artifact — the merge itself uses the true merge-base — but it makes
+#      review unreliable, which is the whole point of one pull request per ticket.
+#   2. A branch that has not seen a later `main` can develop a real conflict without saying so
+#      until you try to merge it.
+#
+# Pushing the merge commit fixes both: GitHub recomputes on push.
+#
+# WHY MERGE RATHER THAN REBASE
+# ----------------------------
+# Rebasing rewrites the branch, which invalidates any review already left against those commits and
+# races with whoever is merging. Merging is additive and safe to run repeatedly. The extra merge
+# commits are noise in the branch, not in `main`, which only ever sees the pull request's own
+# commits plus one merge.
+#
+# Usage:
+#   scripts/sync-stack.sh            # merge origin/main into every open op-* branch
+#   scripts/sync-stack.sh --dry-run  # report what would happen, change nothing
+
+set -euo pipefail
+
+DRY_RUN=false
+[[ "${1:-}" == "--dry-run" ]] && DRY_RUN=true
+
+starting_branch=$(git rev-parse --abbrev-ref HEAD)
+cleanup() { git checkout -q "$starting_branch" 2>/dev/null || true; }
+trap cleanup EXIT
+
+git fetch origin --prune --quiet
+
+# A dirty tree turns a clean merge into a confusing one, so refuse rather than guess.
+if ! git diff-index --quiet HEAD -- 2>/dev/null; then
+  echo "error: working tree has uncommitted changes. Commit or stash them first." >&2
+  exit 1
+fi
+
+# The open pull requests, in stack order. Read from GitHub rather than from local branches so a
+# branch left behind after a merge is not resurrected.
+branches=$(gh pr list --state open --limit 50 --json number,headRefName \
+  --jq '.[] | select(.headRefName | startswith("op-")) | "\(.number) \(.headRefName)"' | sort -n)
+
+if [[ -z "$branches" ]]; then
+  echo "No open op-* pull requests."
+  exit 0
+fi
+
+conflicted=()
+while read -r number branch; do
+  [[ -z "$branch" ]] && continue
+
+  if git merge-base --is-ancestor origin/main "origin/$branch" 2>/dev/null; then
+    printf '  #%-4s %-30s already up to date\n' "$number" "$branch"
+    continue
+  fi
+
+  if $DRY_RUN; then
+    git checkout -q -B _sync_check "origin/$branch"
+    if git merge --no-commit --no-ff origin/main >/dev/null 2>&1; then
+      printf '  #%-4s %-30s would merge clean\n' "$number" "$branch"
+    else
+      printf '  #%-4s %-30s WOULD CONFLICT: %s\n' "$number" "$branch" \
+        "$(git diff --name-only --diff-filter=U | tr '\n' ' ')"
+      conflicted+=("$number")
+    fi
+    git merge --abort 2>/dev/null || git reset -q --hard
+    continue
+  fi
+
+  git checkout -q "$branch"
+  git reset -q --hard "origin/$branch"
+  if git merge --no-edit origin/main >/dev/null 2>&1; then
+    git push -q origin "$branch"
+    printf '  #%-4s %-30s merged and pushed\n' "$number" "$branch"
+  else
+    git merge --abort
+    printf '  #%-4s %-30s CONFLICT — resolve by hand: %s\n' "$number" "$branch" \
+      "$(git diff --name-only --diff-filter=U | tr '\n' ' ')"
+    conflicted+=("$number")
+  fi
+done <<< "$branches"
+
+git checkout -q "$starting_branch"
+git branch -D _sync_check >/dev/null 2>&1 || true
+
+if [[ ${#conflicted[@]} -gt 0 ]]; then
+  echo
+  echo "Conflicts on: ${conflicted[*]}"
+  exit 1
+fi


### PR DESCRIPTION
This pull request introduces a new, modular metrics system to the `posture_core` package, replacing legacy posture measurements with robust, world-space calculations. Each metric is now its own module, with standardized interfaces and detailed abstention handling for missing or degenerate data. The new approach eliminates prior issues such as pixel-based thresholds, ambiguous error handling, and incorrect anatomical calculations, and provides clear, actionable metric results.

**New modular metrics system:**

* Added `posture_core/metrics/__init__.py` to define the metrics API, importing and exposing new metric functions: `arms_crossed`, `craniovertebral_angle_deg`, `elbow_flexion_deg`, `knee_flexion_deg`, and `trunk_inclination_deg`.
* Introduced `posture_core/metrics/_support.py` providing shared utilities for metric modules, including robust abstention, world coordinate extraction, and error handling that distinguishes between user-facing failures and programming errors.

**Metric module rewrites:**

* Rewrote arm metrics in `posture_core/metrics/arms.py`, replacing pixel-based and incorrect formulas with world-space, anatomically correct calculations for `arms_crossed` and `elbow_flexion_deg`.
* Added `posture_core/metrics/head.py` for craniovertebral angle measurement, accurately implementing clinical standards and replacing a broken legacy calculation.
* Added `posture_core/metrics/knees.py` for knee flexion, robustly handling visibility and abstention, and replacing a legacy function that could crash.
* Added `posture_core/metrics/trunk.py` for trunk inclination, fixing sign errors, missing data handling, and pixel thresholding present in the legacy code.

**Synthetic data support:**

* Extended `make_pose` in `synthetic.py` to accept a new `forearm_cross_deg` parameter, supporting more flexible synthetic pose generation for testing.