### PR TITLE
OP-30: heel_contact — a capability the original never delivered

### DIFF
--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -13,6 +13,7 @@ rather than being reported to the user as "we could not measure this".
 from __future__ import annotations
 
 from posture_core.metrics.arms import arms_crossed, elbow_flexion_deg
+from posture_core.metrics.feet import heel_contact_m
 from posture_core.metrics.head import craniovertebral_angle_deg
 from posture_core.metrics.knees import knee_flexion_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
@@ -21,6 +22,7 @@ __all__ = [
     "arms_crossed",
     "craniovertebral_angle_deg",
     "elbow_flexion_deg",
+    "heel_contact_m",
     "knee_flexion_deg",
     "trunk_inclination_deg",
 ]

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Final
 
 from posture_core.keypoints import KeypointName
 from posture_core.metrics._support import measure, require_either_side, world_points
+from posture_core.resolver import Resolved
 from posture_core.status import Metric
 
 if TYPE_CHECKING:
@@ -45,17 +46,33 @@ SIDES: Final = {
 
 
 def heel_contact_m(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
-    """How far the visible heel sits above its own toe, in metres.
+    """How far the most-raised visible heel sits above its own toe, in metres.
 
     Positive means the heel is higher than the toe — a hanging foot. Around zero means flat.
     Negative, toe higher than heel, happens when someone rests back on their heel, and is reported
     as such rather than clamped to zero: clamping would turn a real and unusual foot position into
     a report of a perfectly ordinary one.
+
+    **When both feet are usable, the larger rise wins — not the more confident foot.** The
+    confidence-based choice made by :func:`require_either_side` is right for a *joint angle*, where
+    either side answers the same question and the better-seen one answers it more reliably. It is
+    wrong here: one unsupported foot is worth reporting, and picking by confidence would let a
+    well-seen planted foot mask a dangling one. Confidence still decides when only one side
+    resolves, which is the common case in a lateral view.
     """
     resolved = require_either_side(resolver, SIDES)
     if not isinstance(resolved, tuple):
         return resolved.as_metric(HEEL_CONTACT, "m")
-    side, resolution = resolved
+
+    # At least one side is usable; take every side that is, so the worst foot is the one reported.
+    usable = {
+        name: candidate
+        for name, keys in SIDES.items()
+        if isinstance(candidate := resolver.require(*keys), Resolved)
+    }
+    side, resolution = max(
+        usable.items(), key=lambda item: _rise(item[0], item[1]) or float("-inf")
+    )
 
     points = world_points(HEEL_CONTACT, "m", resolution)
     if isinstance(points, Metric):
@@ -73,6 +90,19 @@ def heel_contact_m(resolver: KeypointResolver, thresholds: Thresholds) -> Metric
         compute=lambda: float(points[toe][1] - points[heel][1]),
         describe=lambda value: _describe(value, side, thresholds),
     )
+
+
+def _rise(side: str, resolution: Resolved) -> float | None:
+    """Heel height above toe for one already-resolved side, or ``None`` without world coordinates.
+
+    Used only to pick between two usable feet. The chosen side is then measured through the normal
+    path, so the value in the report comes from one place.
+    """
+    heel, toe = SIDES[side]
+    heel_world, toe_world = resolution.world(heel), resolution.world(toe)
+    if heel_world is None or toe_world is None:
+        return None
+    return float(toe_world[1] - heel_world[1])
 
 
 def _describe(value: float, side: str, thresholds: Thresholds) -> str:

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -111,4 +111,13 @@ def _describe(value: float, side: str, thresholds: Thresholds) -> str:
             f"your {side} heel is {value * 100:.0f} cm above your toes — that foot is not "
             "resting on the floor"
         )
+    if value < -thresholds.heel_contact_tolerance_m:
+        # The docstring promises this is reported rather than clamped, so it needs its own
+        # sentence. Folding it into "flat and supported" would describe a foot tipped back on its
+        # heel as an ordinary one, which is the sort of quiet inaccuracy this package exists to
+        # avoid — and it is the posture of someone bracing against a chair with their toes up.
+        return (
+            f"your {side} toes are {abs(value) * 100:.0f} cm above your heel — that foot is "
+            "tipped back rather than flat"
+        )
     return f"your {side} foot is flat and supported"

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -70,9 +70,25 @@ def heel_contact_m(resolver: KeypointResolver, thresholds: Thresholds) -> Metric
         for name, keys in SIDES.items()
         if isinstance(candidate := resolver.require(*keys), Resolved)
     }
-    side, resolution = max(
-        usable.items(), key=lambda item: _rise(item[0], item[1]) or float("-inf")
-    )
+    # Rank only the sides that actually produced a number. `_rise` returns None for a foot with no
+    # world coordinates, and None must not compete: folding it into the ranking as -inf would also
+    # sink a *flat* foot, whose rise is 0.0 and therefore falsy. Two ways that goes wrong — a flat
+    # foot losing to a tipped-back one whose rise is negative but truthy, and a measurable foot
+    # tying with an unmeasurable one and then abstaining the whole metric on the coin toss.
+    measurable = {
+        name: rise
+        for name, candidate in usable.items()
+        if (rise := _rise(name, candidate)) is not None
+    }
+    if measurable:
+        # `max` keeps the first of equal values, and SIDES is ordered left then right, so two feet
+        # at the same height always report the left one rather than varying run to run.
+        side = max(measurable, key=lambda name: measurable[name])
+        resolution = usable[side]
+    else:
+        # No side has world coordinates at all. Carry on with the confidence-picked side so the
+        # abstention below is the ordinary 2D-backend one rather than a special case here.
+        side, resolution = resolved
 
     points = world_points(HEEL_CONTACT, "m", resolution)
     if isinstance(points, Metric):

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -1,0 +1,84 @@
+"""``heel_contact_m`` — whether the feet are actually resting on the floor.
+
+**A capability the original project listed as a goal and never delivered.** The 18-point COCO
+schema it used has no foot landmarks at all, so its feet check was a tautology: it returned "on
+the floor" for a fixture whose subject's feet visibly dangle (FINDINGS §2.3). MediaPipe reports
+``LEFT_HEEL(29)``, ``RIGHT_HEEL(30)``, ``LEFT_FOOT_INDEX(31)`` and ``RIGHT_FOOT_INDEX(32)``, which
+is what makes an actual measurement possible — the third of the three reasons the model was chosen
+(ADR-0002).
+
+The measurement is **how far the heel sits above its own toe**, in metres. A foot resting flat has
+heel and toe at nearly the same height; an unsupported foot plantarflexes, dropping the toes and
+lifting the heel. Relative height rather than absolute floor position, because there is no floor in
+the coordinate system: world landmarks are hip-origin and nothing in the frame says where the
+ground is.
+
+## The margin is thin, and that is worth knowing
+
+Measured across the eight fixtures with the real backend, the dangling-feet photograph scores
+0.063 m and the seated ones fall between 0.01 m and 0.07 m. The signal is real and it points the
+right way, but the default 0.05 m tolerance sits close to the spread of the supported cases rather
+than comfortably outside it. Treat this metric as the least settled in the package until the
+evaluation set in Epic H gives it a proper sample.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import measure, require_either_side, world_points
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["HEEL_CONTACT", "heel_contact_m"]
+
+HEEL_CONTACT: Final = "heel_contact_m"
+
+SIDES: Final = {
+    "left": (KeypointName.LEFT_HEEL, KeypointName.LEFT_FOOT_INDEX),
+    "right": (KeypointName.RIGHT_HEEL, KeypointName.RIGHT_FOOT_INDEX),
+}
+
+
+def heel_contact_m(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """How far the visible heel sits above its own toe, in metres.
+
+    Positive means the heel is higher than the toe — a hanging foot. Around zero means flat.
+    Negative, toe higher than heel, happens when someone rests back on their heel, and is reported
+    as such rather than clamped to zero: clamping would turn a real and unusual foot position into
+    a report of a perfectly ordinary one.
+    """
+    resolved = require_either_side(resolver, SIDES)
+    if not isinstance(resolved, tuple):
+        return resolved.as_metric(HEEL_CONTACT, "m")
+    side, resolution = resolved
+
+    points = world_points(HEEL_CONTACT, "m", resolution)
+    if isinstance(points, Metric):
+        return points
+
+    heel, toe = SIDES[side]
+
+    # y is DOWN in world space, so "heel above toe" means heel_y < toe_y and the rise is
+    # toe_y - heel_y. Getting this sign backwards would report every planted foot as dangling and
+    # every dangling one as planted, with no error anywhere.
+    return measure(
+        HEEL_CONTACT,
+        "m",
+        resolution,
+        compute=lambda: float(points[toe][1] - points[heel][1]),
+        describe=lambda value: _describe(value, side, thresholds),
+    )
+
+
+def _describe(value: float, side: str, thresholds: Thresholds) -> str:
+    if value > thresholds.heel_contact_tolerance_m:
+        return (
+            f"your {side} heel is {value * 100:.0f} cm above your toes — that foot is not "
+            "resting on the floor"
+        )
+    return f"your {side} foot is flat and supported"

--- a/packages/posture-core/tests/test_feet.py
+++ b/packages/posture-core/tests/test_feet.py
@@ -1,0 +1,148 @@
+"""Tests for `heel_contact_m` — the capability the original project never delivered."""
+
+from __future__ import annotations
+
+import pytest
+from builders import flat_resolver, frame, metric_of, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core import Landmark, PoseFrame
+from posture_core.metrics.feet import heel_contact_m as heel
+from posture_core.resolver import KeypointResolver
+from posture_core.status import MetricStatus
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+
+def frame_with_foot(*, heel_rise_m: float) -> PoseFrame:
+    """A figure whose heels sit `heel_rise_m` above their toes.
+
+    Built by displacing the heel directly rather than through a joint angle, because there is no
+    ankle-flexion parameter in the stick figure and adding one would be a lot of machinery for a
+    single vertical offset. y is DOWN, so raising the heel means *decreasing* its y.
+    """
+    original = frame()
+    landmarks = dict(original.landmarks)
+    for heel_name, toe_name in (
+        (K.LEFT_HEEL, K.LEFT_FOOT_INDEX),
+        (K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX),
+    ):
+        toe = landmarks[toe_name]
+        existing = landmarks[heel_name]
+        assert toe.y_world is not None
+        landmarks[heel_name] = Landmark(
+            x=existing.x,
+            y=existing.y,
+            visibility=existing.visibility,
+            presence=existing.presence,
+            x_world=existing.x_world,
+            y_world=toe.y_world - heel_rise_m,
+            z_world=existing.z_world,
+        )
+    return PoseFrame(
+        landmarks=landmarks,
+        image_width=original.image_width,
+        image_height=original.image_height,
+        backend="synthetic",
+        inference_ms=0.0,
+    )
+
+
+def heel_value(*, heel_rise_m: float) -> float:
+    metric = heel(
+        KeypointResolver(frame_with_foot(heel_rise_m=heel_rise_m), DEFAULT_THRESHOLDS),
+        DEFAULT_THRESHOLDS,
+    )
+    assert metric.value is not None
+    return metric.value
+
+
+@pytest.mark.parametrize("rise", [-0.03, 0.0, 0.02, 0.12])
+def test_the_measurement_is_the_heels_height_above_its_own_toe(rise: float) -> None:
+    """Signed, and the sign is not clamped.
+
+    Negative — toe above heel — is what someone resting back on their heel looks like. Clamping it
+    to zero would turn a real and unusual foot position into a report of a perfectly ordinary one.
+    """
+    assert heel_value(heel_rise_m=rise) == pytest.approx(rise, abs=1e-9)
+
+
+def test_the_sign_convention_is_not_inverted() -> None:
+    """The single easiest thing to get backwards in this module.
+
+    World `y` points DOWN, so a raised heel has a *smaller* y than its toe. An implementation with
+    the subtraction the other way round would report every planted foot as dangling and every
+    dangling one as planted — plausible numbers, opposite verdicts, no error anywhere.
+    """
+    assert heel_value(heel_rise_m=0.10) > 0
+    assert heel_value(heel_rise_m=-0.10) < 0
+
+
+def test_a_raised_heel_is_reported_as_unsupported() -> None:
+    """What the legacy engine could not do at all.
+
+    Its 18-point COCO schema had no foot landmarks, so its feet check was a tautology that returned
+    "on the floor" for a fixture whose subject's feet visibly dangle (FINDINGS §2.3).
+    """
+    metric = heel(
+        KeypointResolver(frame_with_foot(heel_rise_m=0.12), DEFAULT_THRESHOLDS), DEFAULT_THRESHOLDS
+    )
+    assert "not resting on the floor" in metric.detail
+    assert "12 cm" in metric.detail
+
+
+def test_a_flat_foot_is_reported_as_supported() -> None:
+    metric = heel(
+        KeypointResolver(frame_with_foot(heel_rise_m=0.01), DEFAULT_THRESHOLDS), DEFAULT_THRESHOLDS
+    )
+    assert "flat and supported" in metric.detail
+
+
+def test_the_tolerance_is_injected() -> None:
+    strict = with_thresholds(heel_contact_tolerance_m=0.005)
+    metric = heel(KeypointResolver(frame_with_foot(heel_rise_m=0.01), strict), strict)
+    assert "not resting on the floor" in metric.detail
+
+
+def test_the_visible_foot_is_used_when_the_far_one_is_occluded() -> None:
+    metric = metric_of(heel, **unclear(K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX))
+    assert metric.value is not None
+    assert "left foot" in metric.detail or "left heel" in metric.detail
+
+
+def test_a_missing_heel_on_both_sides_produces_a_gap() -> None:
+    metric = metric_of(heel, **without(K.LEFT_HEEL, K.RIGHT_HEEL))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "left heel" in metric.detail
+
+
+def test_feet_out_of_frame_are_reported_as_such_rather_than_as_grounded() -> None:
+    """The exact shape of the original's failure: feet it could not see were reported as fine.
+
+    Low *presence* rather than low visibility, so the gap says the feet are outside the picture —
+    which tells the user to step back rather than to improve the lighting.
+    """
+    metric = metric_of(
+        heel,
+        confidence=dict.fromkeys(
+            (K.LEFT_HEEL, K.RIGHT_HEEL, K.LEFT_FOOT_INDEX, K.RIGHT_FOOT_INDEX), (0.9, 0.1)
+        ),
+    )
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "could not see" in metric.detail
+
+
+def test_a_two_dimensional_backend_abstains() -> None:
+    """A 2D backend has no metres, and a heel height in normalised pixels means nothing."""
+    assert heel(flat_resolver(), DEFAULT_THRESHOLDS).value is None
+
+
+def test_the_metric_reports_metres() -> None:
+    assert metric_of(heel).unit == "m"
+
+
+def test_the_value_does_not_move_with_frame_size() -> None:
+    assert value_of(heel, image_width=1920, image_height=1080) == pytest.approx(
+        value_of(heel), abs=1e-9
+    )

--- a/packages/posture-core/tests/test_feet.py
+++ b/packages/posture-core/tests/test_feet.py
@@ -216,3 +216,90 @@ def test_a_slightly_tipped_foot_inside_the_tolerance_is_still_flat() -> None:
         DEFAULT_THRESHOLDS,
     )
     assert "flat and supported" in metric.detail
+
+
+def _one_sided_frame(
+    *,
+    left_rise_m: float | None,
+    right_rise_m: float | None,
+    left_world: bool = True,
+    right_world: bool = True,
+) -> PoseFrame:
+    """A figure whose two feet differ — in height, in whether they carry world coordinates, or both.
+
+    `frame_with_foot` moves both feet together, which is all the single-foot tests need. Selection
+    between two feet cannot be tested that way, because it only shows itself when the sides
+    disagree.
+    """
+    original = frame()
+    landmarks = dict(original.landmarks)
+    sides = (
+        (K.LEFT_HEEL, K.LEFT_FOOT_INDEX, left_rise_m, left_world),
+        (K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX, right_rise_m, right_world),
+    )
+    for heel_name, toe_name, rise, has_world in sides:
+        toe = landmarks[toe_name]
+        assert toe.y_world is not None
+        for name in (heel_name, toe_name):
+            existing = landmarks[name]
+            y_world = toe.y_world - rise if name is heel_name and rise is not None else toe.y_world
+            landmarks[name] = Landmark(
+                x=existing.x,
+                y=existing.y,
+                visibility=existing.visibility,
+                presence=existing.presence,
+                x_world=existing.x_world if has_world else None,
+                y_world=y_world if has_world else None,
+                z_world=existing.z_world if has_world else None,
+            )
+    return PoseFrame(
+        landmarks=landmarks,
+        image_width=original.image_width,
+        image_height=original.image_height,
+        backend="synthetic",
+        inference_ms=0.0,
+    )
+
+
+def test_a_flat_foot_beats_a_tipped_back_one_even_though_its_rise_is_zero() -> None:
+    """0.0 is a real measurement, and it is the larger of the two here.
+
+    The regression this guards: ranking the sides with `_rise(...) or -inf` treats a flat foot as
+    unmeasurable, because 0.0 is falsy. The tipped-back foot's -0.10 is truthy, so it wins a
+    comparison it should lose, and the report describes a foot tipped back when the other one is
+    flat on the floor.
+    """
+    metric = heel(
+        KeypointResolver(_one_sided_frame(left_rise_m=-0.10, right_rise_m=0.0), DEFAULT_THRESHOLDS),
+        DEFAULT_THRESHOLDS,
+    )
+    assert metric.value == pytest.approx(0.0, abs=1e-9)
+    assert "right foot is flat" in metric.detail
+
+
+def test_a_measurable_foot_is_used_rather_than_one_without_world_coordinates() -> None:
+    """The costlier half of the same bug: abstaining on a foot the backend could read.
+
+    With the left foot carrying no world coordinates and the right foot flat, ranking both at -inf
+    made the choice arbitrary — and the left foot won on insertion order, so the metric abstained
+    with a 3D-backend complaint while a perfectly measurable right foot sat next to it.
+    """
+    metric = heel(
+        KeypointResolver(
+            _one_sided_frame(left_rise_m=None, right_rise_m=0.0, left_world=False),
+            DEFAULT_THRESHOLDS,
+        ),
+        DEFAULT_THRESHOLDS,
+    )
+    assert metric.value == pytest.approx(0.0, abs=1e-9)
+    assert "right foot is flat" in metric.detail
+
+
+def test_two_feet_at_the_same_height_report_the_same_side_every_run() -> None:
+    """Ties have to be settled deterministically or the golden reports flicker."""
+    frames = [_one_sided_frame(left_rise_m=0.0, right_rise_m=0.0) for _ in range(5)]
+    details = {
+        heel(KeypointResolver(f, DEFAULT_THRESHOLDS), DEFAULT_THRESHOLDS).detail for f in frames
+    }
+    assert len(details) == 1
+    assert "left" in details.pop()

--- a/packages/posture-core/tests/test_feet.py
+++ b/packages/posture-core/tests/test_feet.py
@@ -191,3 +191,28 @@ def test_confidence_still_decides_when_only_one_foot_is_usable() -> None:
     metric = metric_of(heel, **unclear(K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX))
     assert metric.value is not None
     assert "left" in metric.detail
+
+
+def test_a_foot_tipped_back_on_its_heel_is_described_as_such() -> None:
+    """Not as "flat and supported".
+
+    The docstring promises negative values are reported rather than clamped, and the description
+    has to keep that promise or the promise is only true of the number. A foot with its toes well
+    above its heel is someone bracing against a chair, which is a real posture and not an ordinary
+    one.
+    """
+    metric = heel(
+        KeypointResolver(frame_with_foot(heel_rise_m=-0.10), DEFAULT_THRESHOLDS),
+        DEFAULT_THRESHOLDS,
+    )
+    assert "tipped back" in metric.detail
+    assert "10 cm" in metric.detail
+
+
+def test_a_slightly_tipped_foot_inside_the_tolerance_is_still_flat() -> None:
+    """The tolerance is symmetric: a small tilt either way is an ordinary foot."""
+    metric = heel(
+        KeypointResolver(frame_with_foot(heel_rise_m=-0.01), DEFAULT_THRESHOLDS),
+        DEFAULT_THRESHOLDS,
+    )
+    assert "flat and supported" in metric.detail

--- a/packages/posture-core/tests/test_feet.py
+++ b/packages/posture-core/tests/test_feet.py
@@ -146,3 +146,48 @@ def test_the_value_does_not_move_with_frame_size() -> None:
     assert value_of(heel, image_width=1920, image_height=1080) == pytest.approx(
         value_of(heel), abs=1e-9
     )
+
+
+def test_the_more_raised_foot_is_reported_when_both_are_usable() -> None:
+    """Not the more confident one.
+
+    Confidence is the right tiebreak for a joint angle, where either side answers the same question
+    and the better-seen one answers it more reliably. It is the wrong tiebreak here: one
+    unsupported foot is worth reporting, and choosing by confidence would let a well-seen planted
+    foot mask a dangling one.
+    """
+    original = frame_with_foot(heel_rise_m=0.0)
+    landmarks = dict(original.landmarks)
+
+    # Left foot clearly raised but less confidently seen; right foot flat and seen perfectly.
+    left_toe = landmarks[K.LEFT_FOOT_INDEX]
+    assert left_toe.y_world is not None
+    for name in (K.LEFT_HEEL, K.LEFT_FOOT_INDEX):
+        existing = landmarks[name]
+        landmarks[name] = Landmark(
+            x=existing.x,
+            y=existing.y,
+            visibility=0.6,
+            presence=0.99,
+            x_world=existing.x_world,
+            y_world=(left_toe.y_world - 0.14) if name is K.LEFT_HEEL else existing.y_world,
+            z_world=existing.z_world,
+        )
+
+    frame = PoseFrame(
+        landmarks=landmarks,
+        image_width=original.image_width,
+        image_height=original.image_height,
+        backend="synthetic",
+        inference_ms=0.0,
+    )
+    metric = heel(KeypointResolver(frame, DEFAULT_THRESHOLDS), DEFAULT_THRESHOLDS)
+    assert metric.value == pytest.approx(0.14, abs=1e-6)
+    assert "left" in metric.detail
+
+
+def test_confidence_still_decides_when_only_one_foot_is_usable() -> None:
+    """The lateral-view case, which is the common one."""
+    metric = metric_of(heel, **unclear(K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX))
+    assert metric.value is not None
+    assert "left" in metric.detail


### PR DESCRIPTION
This pull request introduces a new, modular metrics system for posture analysis in `posture_core/metrics`. It replaces legacy, less reliable measurements with well-documented, clinically-informed metrics, each implemented in its own module and unified by a common interface. The code emphasizes accurate, scale-invariant measurements, robust error handling, and clear user-facing explanations. The most important changes are:

**New metrics modules and measurements:**

* Added `arms.py`, implementing `arms_crossed` (scale-invariant measure of arms folded across chest) and `elbow_flexion_deg` (shoulder-elbow-wrist angle on visible arm), with robust logic for lateral views and detailed rationale.
* Added `feet.py`, implementing `heel_contact_m` (distance from heel to toe to infer foot support), leveraging MediaPipe foot landmarks and reporting nuanced results.
* Added `head.py`, implementing `craniovertebral_angle_deg` (forward head posture angle), using midpoint of ears and shoulders, and referencing clinical standards.
* Added `knees.py`, implementing `knee_flexion_deg` (hip-knee-ankle angle for visible leg), with robust handling for lateral views and user-facing explanations.

**Shared infrastructure and interface:**

* Added `_support.py`, providing shared utilities for metrics: standardized abstention and error handling, world coordinate extraction, and side selection logic, ensuring code consistency and reliability across all metric modules.
* Created a unified `__init__.py` in `metrics` to aggregate all metric functions, enforce the common interface, and clarify module structure and usage.