### PR TITLE
OP-31: view_confidence — enforce the side-angle requirement

### DIFF
--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -17,6 +17,7 @@ from posture_core.metrics.feet import heel_contact_m
 from posture_core.metrics.head import craniovertebral_angle_deg
 from posture_core.metrics.knees import knee_flexion_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
+from posture_core.metrics.view import view_confidence, view_confidence_factor
 
 __all__ = [
     "arms_crossed",
@@ -25,4 +26,6 @@ __all__ = [
     "heel_contact_m",
     "knee_flexion_deg",
     "trunk_inclination_deg",
+    "view_confidence",
+    "view_confidence_factor",
 ]

--- a/packages/posture-core/src/posture_core/metrics/__init__.py
+++ b/packages/posture-core/src/posture_core/metrics/__init__.py
@@ -17,7 +17,13 @@ from posture_core.metrics.feet import heel_contact_m
 from posture_core.metrics.head import craniovertebral_angle_deg
 from posture_core.metrics.knees import knee_flexion_deg
 from posture_core.metrics.trunk import trunk_inclination_deg
-from posture_core.metrics.view import view_confidence, view_confidence_factor
+from posture_core.metrics.view import view_confidence
+
+# `view_confidence_factor` is deliberately absent. It takes a ratio and returns a float, not
+# `(resolver, thresholds) -> Metric`, so exporting it here would put something in this namespace
+# that the paragraph above says is not in it — and `report.py` enumerates this list. It stays
+# reachable as `posture_core.metrics.view.view_confidence_factor`, which is how the one caller
+# that wants it already imports it.
 
 __all__ = [
     "arms_crossed",
@@ -27,5 +33,4 @@ __all__ = [
     "knee_flexion_deg",
     "trunk_inclination_deg",
     "view_confidence",
-    "view_confidence_factor",
 ]

--- a/packages/posture-core/src/posture_core/metrics/view.py
+++ b/packages/posture-core/src/posture_core/metrics/view.py
@@ -1,0 +1,124 @@
+"""``view_confidence`` — is this photograph actually taken from the side?
+
+The original application *told* users "this image must be taken from a side angle" and then
+assessed whatever arrived. It had no way to check, and no way to express doubt if it had.
+
+## What is measured
+
+Shoulder separation divided by torso length, **in image space**. Face-on, the shoulders span most
+of the subject's width and the ratio approaches their real proportions; side-on, one shoulder is
+directly behind the other and the ratio collapses toward zero. Image space is the right space here
+precisely *because* it is the projection — the question is what the camera could see, not what the
+body is doing.
+
+## Why this downgrades rather than vetoes — a correction to the plan
+
+The plan treats a frontal view as fatal to sagittal metrics, on the reasoning that a slump
+photographed head-on projects to nothing. That reasoning is sound for a 2D engine and wrong for
+this one: world landmarks are metric 3D, so the facing axis comes out along the view direction and
+the full lean *is* recovered. Measured against a synthetic figure built at 30°, the frontal
+projection still reports 30.0°.
+
+What actually degrades is **reliability**, not availability. MediaPipe reconstructs depth far less
+accurately along the camera axis than across it, so a head-on measurement of forward lean rests on
+the model's weakest dimension. So this metric produces a **confidence factor** the report applies
+to sagittal findings, rather than a veto that discards them. A lower-confidence finding is more
+useful to a user than a missing one, and more honest than a confident one.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Final
+
+from posture_core.geometry import distance, image_vec, midpoint
+from posture_core.keypoints import KeypointName
+from posture_core.metrics._support import abstain, measure
+from posture_core.resolver import Resolved
+from posture_core.status import Metric
+
+if TYPE_CHECKING:
+    from posture_core.resolver import KeypointResolver
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["NAME", "view_confidence", "view_confidence_factor"]
+
+NAME: Final = "view_confidence"
+UNIT: Final = "ratio"
+
+REQUIRED: Final = (
+    KeypointName.LEFT_SHOULDER,
+    KeypointName.RIGHT_SHOULDER,
+    KeypointName.LEFT_HIP,
+    KeypointName.RIGHT_HIP,
+)
+
+
+def view_confidence(resolver: KeypointResolver, thresholds: Thresholds) -> Metric:
+    """Shoulder span over torso length, as the camera saw them."""
+    resolution = resolver.require(*REQUIRED)
+    if not isinstance(resolution, Resolved):
+        return resolution.as_metric(NAME, UNIT)
+
+    frame = resolver.frame
+    width, height = frame.image_width, frame.image_height
+    points = {
+        name: image_vec(landmark, width, height) for name, landmark in resolution.landmarks.items()
+    }
+
+    torso = distance(
+        midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP]),
+        midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER]),
+    )
+    if torso <= 0.0:
+        return abstain(
+            NAME,
+            UNIT,
+            "your shoulders and hips are at the same point in this photo, so the camera angle "
+            "cannot be judged",
+            inputs=REQUIRED,
+        )
+
+    return measure(
+        NAME,
+        UNIT,
+        resolution,
+        compute=lambda: (
+            distance(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER])
+            / torso
+        ),
+        describe=lambda value: _describe(value, thresholds),
+    )
+
+
+def _describe(value: float, thresholds: Thresholds) -> str:
+    if value <= thresholds.lateral_view_max_ratio:
+        return "photographed from the side, which is the best angle for this assessment"
+    if value >= thresholds.frontal_view_min_ratio:
+        return (
+            "photographed from the front — forward lean is measurable but less reliable here, "
+            "so a side-on photo would give a firmer answer"
+        )
+    return "photographed at an angle between side-on and front-on"
+
+
+def view_confidence_factor(ratio: float | None, thresholds: Thresholds) -> float:
+    """How much to trust a sagittal measurement taken from this angle, in ``[0.4, 1.0]``.
+
+    A linear ramp between the two configured ratios: full confidence side-on, falling to 0.4
+    face-on. Linear because there is no evidence for any particular curve — inventing one would
+    dress a guess up as a model. The floor is 0.4 rather than 0 because the measurement genuinely
+    still works face-on; it is the depth estimate underneath it that weakens.
+
+    ``None`` — the view could not be assessed at all — yields the floor. Assuming the best angle
+    when we could not check is precisely the optimism this package exists to remove.
+    """
+    floor = 0.4
+    if ratio is None:
+        return floor
+    if ratio <= thresholds.lateral_view_max_ratio:
+        return 1.0
+    if ratio >= thresholds.frontal_view_min_ratio:
+        return floor
+    span = thresholds.frontal_view_min_ratio - thresholds.lateral_view_max_ratio
+    position = (ratio - thresholds.lateral_view_max_ratio) / span
+    return 1.0 - position * (1.0 - floor)

--- a/packages/posture-core/src/posture_core/metrics/view.py
+++ b/packages/posture-core/src/posture_core/metrics/view.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Final
 
-from posture_core.geometry import distance, image_vec, midpoint
+from posture_core.geometry import MIN_LENGTH, distance, image_vec, midpoint
 from posture_core.keypoints import KeypointName
 from posture_core.metrics._support import abstain, measure
 from posture_core.resolver import Resolved
@@ -69,7 +69,13 @@ def view_confidence(resolver: KeypointResolver, thresholds: Thresholds) -> Metri
         midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP]),
         midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER]),
     )
-    if torso <= 0.0:
+    # `distance` is never negative, so a `<= 0.0` test would only catch the exact-zero case — the
+    # one a backend is least likely to produce. A torso a fraction of a pixel long divides the
+    # ratio up to an enormous number, which reads as "photographed from the front" against any
+    # threshold and then drags every sagittal finding down to the confidence floor. Same threshold
+    # `arms_crossed` uses for the same division, and the same one the geometry layer uses for a
+    # vector with no direction, because it is the same degeneracy.
+    if torso < MIN_LENGTH:
         return abstain(
             NAME,
             UNIT,

--- a/packages/posture-core/tests/test_view.py
+++ b/packages/posture-core/tests/test_view.py
@@ -69,10 +69,36 @@ def test_an_unclear_hip_abstains_as_low_confidence() -> None:
     assert metric_of(view, **unclear(K.LEFT_HIP)).status is MetricStatus.LOW_CONFIDENCE
 
 
-def test_a_zero_length_torso_abstains_rather_than_dividing_by_it() -> None:
-    metric = metric_of(view, body=Anthropometry(torso=0.0))
+@pytest.mark.parametrize("angle", [View.LATERAL, View.FRONTAL])
+@pytest.mark.parametrize("torso", [0.0, 1e-13, 1e-12])
+def test_a_degenerate_torso_abstains_rather_than_dividing_by_it(torso: float, angle: View) -> None:
+    """Near-zero, not just zero — the same guard `arms_crossed` needed for the same division.
+
+    `distance` is never negative, so a `<= 0.0` test catches only the exact case, and exact zero is
+    the one a real backend is least likely to produce.
+
+    Both views, because only the frontal one shows the damage. Side-on the shoulders coincide, so
+    the numerator is zero and a tiny torso still yields 0.0 — the right answer by luck. Face-on the
+    numerator is real and the ratio runs to ~3.8e10, which reads as "photographed from the front"
+    against any threshold. That does not stay local: the ratio feeds `view_confidence_factor`, so
+    one degenerate torso pins every sagittal finding in the report to the confidence floor.
+    """
+    metric = metric_of(view, body=Anthropometry(torso=torso), view=angle)
     assert metric.value is None
     assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+def test_the_guard_is_a_divide_by_zero_check_not_a_plausibility_floor() -> None:
+    """Worth stating outright, because the constant is named for metres and used here on pixels.
+
+    `MIN_LENGTH` is 1e-9, and this metric divides in *image* space, so the guard trips at about
+    1e-12 m of world torso rather than at anything a person would call short. A 5e-12 m torso is
+    physically absurd and still measures. That is the shared constant behaving as intended — it
+    exists to stop a division by nothing, not to judge whether a body is a plausible size — and it
+    is preferable to a second, pixel-scaled epsilon here that would drift from the one in
+    `arms_crossed` the first time either was retuned.
+    """
+    assert metric_of(view, body=Anthropometry(torso=5e-12)).status is MetricStatus.OK
 
 
 # ---------------------------------------------------------------------------------------------

--- a/packages/posture-core/tests/test_view.py
+++ b/packages/posture-core/tests/test_view.py
@@ -1,0 +1,131 @@
+"""Tests for `view_confidence` — the check the original app never performed."""
+
+from __future__ import annotations
+
+import pytest
+from builders import metric_of, unclear, value_of, with_thresholds, without
+
+from posture_core import KeypointName as K
+from posture_core.metrics.view import view_confidence as view
+from posture_core.metrics.view import view_confidence_factor as factor
+from posture_core.status import MetricStatus
+from posture_core.synthetic import Anthropometry, View
+from posture_core.thresholds import DEFAULT_THRESHOLDS as T
+
+
+def test_a_side_on_view_collapses_the_shoulder_span_to_nothing() -> None:
+    """One shoulder directly behind the other, so the projected separation is zero."""
+    assert value_of(view, view=View.LATERAL) == pytest.approx(0.0, abs=1e-9)
+
+
+def test_a_frontal_view_shows_the_subjects_real_proportions() -> None:
+    assert value_of(view, view=View.FRONTAL) > T.frontal_view_min_ratio
+
+
+@pytest.mark.parametrize(
+    ("camera", "expected"),
+    [
+        (View.LATERAL, "from the side"),
+        (View.FRONTAL, "from the front"),
+    ],
+)
+def test_the_description_names_the_camera_angle(camera: View, expected: str) -> None:
+    assert expected in metric_of(view, view=camera).detail
+
+
+def test_an_intermediate_angle_is_described_as_such_rather_than_forced_into_a_bucket() -> None:
+    """The gap between the two thresholds is a real state, not an oversight.
+
+    Most real photographs are neither perfectly side-on nor perfectly face-on, and pretending
+    otherwise would make the confidence factor jump discontinuously across a boundary that nothing
+    physical corresponds to.
+    """
+    lenient = with_thresholds(lateral_view_max_ratio=0.05, frontal_view_min_ratio=0.9)
+    assert (
+        "between side-on and front-on"
+        in metric_of(view, view=View.FRONTAL, thresholds=lenient).detail
+    )
+
+
+@pytest.mark.parametrize("scale", [0.5, 2.0])
+def test_the_ratio_does_not_move_with_body_size(scale: float) -> None:
+    default = Anthropometry()
+    scaled = Anthropometry(
+        torso=default.torso * scale,
+        shoulder_width=default.shoulder_width * scale,
+        hip_width=default.hip_width * scale,
+    )
+    baseline = value_of(view, view=View.FRONTAL)
+    assert value_of(view, view=View.FRONTAL, body=scaled) == pytest.approx(baseline, abs=1e-9)
+
+
+def test_a_missing_shoulder_produces_a_gap() -> None:
+    metric = metric_of(view, **without(K.LEFT_SHOULDER))
+    assert metric.value is None
+    assert metric.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+
+
+def test_an_unclear_hip_abstains_as_low_confidence() -> None:
+    assert metric_of(view, **unclear(K.LEFT_HIP)).status is MetricStatus.LOW_CONFIDENCE
+
+
+def test_a_zero_length_torso_abstains_rather_than_dividing_by_it() -> None:
+    metric = metric_of(view, body=Anthropometry(torso=0.0))
+    assert metric.value is None
+    assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
+
+
+# ---------------------------------------------------------------------------------------------
+# The confidence factor
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_side_on_photo_earns_full_confidence() -> None:
+    assert factor(0.0, T) == pytest.approx(1.0)
+    assert factor(T.lateral_view_max_ratio, T) == pytest.approx(1.0)
+
+
+def test_a_face_on_photo_is_downgraded_not_discarded() -> None:
+    """The correction to the plan, stated as a test.
+
+    The plan treats a frontal view as fatal to sagittal metrics, on the reasoning that a slump
+    photographed head-on projects to nothing. That holds for a 2D engine. With metric 3D world
+    landmarks the full lean is recovered — measured at exactly 30.0° for a figure built at 30°.
+
+    What weakens is the *depth* estimate the measurement rests on, so the right response is
+    reduced confidence, not a discarded finding. A quieter answer is more useful than no answer
+    and more honest than a loud one.
+    """
+    downgraded = factor(T.frontal_view_min_ratio, T)
+    assert 0.0 < downgraded < 1.0
+
+
+def test_the_factor_falls_monotonically_as_the_view_turns_toward_the_camera() -> None:
+    ratios = [0.0, 0.2, 0.35, 0.45, 0.55, 0.8]
+    factors = [factor(ratio, T) for ratio in ratios]
+    assert factors == sorted(factors, reverse=True)
+
+
+def test_the_ramp_is_continuous_at_both_thresholds() -> None:
+    """No cliff at a boundary that nothing physical corresponds to.
+
+    A discontinuity would mean two photographs a degree apart could report visibly different
+    confidence, which reads to a user as instability in the product rather than in the camera
+    angle.
+    """
+    epsilon = 1e-6
+    assert factor(T.lateral_view_max_ratio + epsilon, T) == pytest.approx(1.0, abs=1e-5)
+    assert factor(T.frontal_view_min_ratio - epsilon, T) == pytest.approx(
+        factor(T.frontal_view_min_ratio, T), abs=1e-5
+    )
+
+
+def test_an_unassessable_view_gets_the_floor_rather_than_the_benefit_of_the_doubt() -> None:
+    """Assuming the best angle when we could not check is exactly the optimism this package
+    exists to remove."""
+    assert factor(None, T) == pytest.approx(factor(1.0, T))
+
+
+def test_the_factor_never_leaves_its_stated_range() -> None:
+    for ratio in (-1.0, 0.0, 0.3, 0.45, 0.6, 5.0):
+        assert 0.4 <= factor(ratio, T) <= 1.0


### PR DESCRIPTION
This pull request adds a new metric for assessing whether a photograph was taken from the side or the front, and introduces a corresponding confidence factor for interpreting sagittal (side-view) posture measurements. The main additions include the implementation of the `view_confidence` and `view_confidence_factor` functions, their integration into the metrics package, and comprehensive tests to ensure correct behavior.

**New metric for camera angle assessment:**

* Added `view_confidence` function in `view.py` to compute the ratio of shoulder span to torso length in image space, which estimates whether the photo was taken from the side or the front. This provides a way to assess the reliability of posture measurements based on camera angle.
* Added `view_confidence_factor` function in `view.py` to produce a confidence score (between 0.4 and 1.0) for sagittal measurements, scaling with how close the camera angle is to a true side view.
* Updated `__init__.py` to export `view_confidence` and `view_confidence_factor` as part of the public metrics API. [[1]](diffhunk://#diff-d360466325dac39b7472e2e71c26f54bcfccdadc9913f4dde9d5cc786702057fR20) [[2]](diffhunk://#diff-d360466325dac39b7472e2e71c26f54bcfccdadc9913f4dde9d5cc786702057fR29-R30)

**Testing and validation:**

* Added a comprehensive test suite in `test_view.py` to verify the correctness of the new metric and its confidence factor, including handling of edge cases (e.g., missing keypoints, ambiguous geometry, and the full range of camera angles).