### PR TITLE
OP-32: report.py — PostureReport, overall_score and versioning

### DIFF
--- a/packages/posture-core/src/posture_core/__init__.py
+++ b/packages/posture-core/src/posture_core/__init__.py
@@ -20,7 +20,26 @@ posture was fine whenever the system had failed to assess them at all.
 from __future__ import annotations
 
 from posture_core.keypoints import KeypointName, Landmark, PoseFrame
+from posture_core.report import PostureReport, build_report
+from posture_core.rules import Finding, Severity
+from posture_core.status import Gap, KeypointStatus, Metric, MetricStatus
+from posture_core.thresholds import DEFAULT_THRESHOLDS, Thresholds
 
-__all__ = ["KeypointName", "Landmark", "PoseFrame", "__version__"]
+__all__ = [
+    "DEFAULT_THRESHOLDS",
+    "Finding",
+    "Gap",
+    "KeypointName",
+    "KeypointStatus",
+    "Landmark",
+    "Metric",
+    "MetricStatus",
+    "PoseFrame",
+    "PostureReport",
+    "Severity",
+    "Thresholds",
+    "__version__",
+    "build_report",
+]
 
 __version__ = "0.1.0"

--- a/packages/posture-core/src/posture_core/report.py
+++ b/packages/posture-core/src/posture_core/report.py
@@ -110,6 +110,15 @@ class PostureReport:
     output that means something.
     """
 
+    def __post_init__(self) -> None:
+        # Same reason as `Quality.__post_init__`: `frozen=True` freezes the attribute bindings, not
+        # the containers bound to them. `build_report` hands over a live dict and a live list, so
+        # without this a caller could edit a report's metrics or delete a finding after the fact —
+        # and the module docstring's promise that one frame always yields one byte-identical
+        # document would hold only until someone took it up on the offer.
+        object.__setattr__(self, "metrics", MappingProxyType(dict(self.metrics)))
+        object.__setattr__(self, "findings", tuple(self.findings))
+
     def to_dict(self) -> dict[str, Any]:
         """A JSON-ready shape. Ordered for a readable diff, not for parsing.
 
@@ -123,7 +132,13 @@ class PostureReport:
             "backend": self.backend,
             "inference_ms": round(self.inference_ms, 3),
             "image": {"width": self.image_width, "height": self.image_height},
-            "overall_score": self.overall_score,
+            # Rounded like every other float here. The default 15.0 penalty happens to divide
+            # cleanly, so this reads as unnecessary today — but 100 - (8.3 * 3.5) is
+            # 70.94999999999999, and most non-integer penalties do something similar. Leaving it
+            # raw means the first threshold retune scatters noise through the golden corpus and
+            # the cross-language comparison in OP-36, where the diff would look like a real
+            # disagreement between two engines rather than a float artefact.
+            "overall_score": _round(self.overall_score),
             "findings": [
                 {
                     "code": finding.code,

--- a/packages/posture-core/src/posture_core/report.py
+++ b/packages/posture-core/src/posture_core/report.py
@@ -1,0 +1,228 @@
+"""``PostureReport`` — the whole assessment, and the only thing the API needs to serialise.
+
+``build_report(frame, thresholds)`` is the top of the rules engine: one pure function, no I/O, no
+printing, no globals, no clock. The same frame and the same thresholds produce a byte-identical
+report forever, which is what makes golden-snapshot testing possible (OP-35) and what lets the
+frontend and the Python engine be compared fixture-by-fixture in CI.
+
+## What a report contains, and why gaps are in it
+
+Findings *and* gaps, side by side. A report saying "you are slouching, and I could not see your
+knees" is a more useful and more honest document than one saying only "you are slouching" — and
+the silence in the second version is exactly what the inherited engine shipped.
+
+## The version stamps
+
+``schema_version`` describes the *shape* of this document; ``rules_version`` describes the
+thresholds that produced it. Both are stored with every analysis (Epic E) because two reports are
+only comparable if they were produced by the same rules. Without the stamps, a stored report
+becomes uninterpretable the first time a threshold moves: you can no longer tell whether the
+user's posture changed or the yardstick did — which quietly destroys the trend view that is the
+whole point of keeping history.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from types import MappingProxyType
+from typing import TYPE_CHECKING, Any, Final
+
+from posture_core.metrics import arms, feet, head, knees, trunk, view
+from posture_core.resolver import KeypointResolver
+from posture_core.rules import Severity, evaluate
+from posture_core.status import KeypointStatus, MetricStatus
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping, Sequence
+
+    from posture_core.keypoints import KeypointName, PoseFrame
+    from posture_core.rules import Finding
+    from posture_core.status import Gap, Metric
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["SCHEMA_VERSION", "PostureReport", "build_report"]
+
+SCHEMA_VERSION: Final = "1.0"
+
+# Every metric, in the order a person reads a body. Adding a metric is adding one entry here and
+# one module — nothing else in this file knows what any of them do.
+METRICS: Final = (
+    view.view_confidence,
+    trunk.trunk_inclination_deg,
+    head.craniovertebral_angle_deg,
+    arms.arms_crossed,
+    arms.elbow_flexion_deg,
+    knees.knee_flexion_deg,
+    feet.heel_contact_m,
+)
+
+_SEVERITY_WEIGHT: Final = {Severity.MAJOR: 1.0, Severity.MINOR: 0.5, Severity.INFO: 0.0}
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Quality:
+    """How much of the body the engine could actually see."""
+
+    assessed: int
+    """Metrics that produced a value."""
+
+    total: int
+    gaps: Sequence[Gap]
+    keypoints: Mapping[KeypointName, KeypointStatus]
+
+    def __post_init__(self) -> None:
+        # `frozen=True` freezes the attribute bindings, not the containers bound to them. `Gap`
+        # and `PoseFrame` both guard against this; a report's quality section is at least as
+        # worth protecting, since it is the record of what the engine could not assess.
+        object.__setattr__(self, "gaps", tuple(self.gaps))
+        object.__setattr__(self, "keypoints", MappingProxyType(dict(self.keypoints)))
+
+    @property
+    def coverage(self) -> float:
+        """Fraction of metrics that produced a value, in ``[0, 1]``."""
+        return self.assessed / self.total if self.total else 0.0
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class PostureReport:
+    """One assessment of one photograph."""
+
+    schema_version: str
+    rules_version: str
+    backend: str
+    inference_ms: float
+    image_width: int
+    image_height: int
+    metrics: Mapping[str, Metric]
+    findings: Sequence[Finding]
+    quality: Quality
+    overall_score: float | None
+    """``0`` to ``100``, or ``None`` when nothing could be measured.
+
+    ``None`` rather than ``0`` or ``100``. A score of 0 would read as terrible posture and 100 as
+    perfect, and both are confident claims about a photograph the engine could not assess. This is
+    the same defect as "Straight back position" wearing different clothes, so it gets the same
+    treatment: say nothing rather than say something false.
+
+    The scoring itself is deliberately crude — 100 less a fixed penalty per finding, weighted by
+    severity — and should be read as a summary rather than a measurement. The findings are the
+    output that means something.
+    """
+
+    def to_dict(self) -> dict[str, Any]:
+        """A JSON-ready shape. Ordered for a readable diff, not for parsing.
+
+        Written here rather than in the API layer so that the CLI, the golden fixtures and the
+        HTTP response all serialise identically. A second serialiser would drift from this one,
+        and the cross-language golden corpus (OP-36) depends on there being exactly one.
+        """
+        return {
+            "schema_version": self.schema_version,
+            "rules_version": self.rules_version,
+            "backend": self.backend,
+            "inference_ms": round(self.inference_ms, 3),
+            "image": {"width": self.image_width, "height": self.image_height},
+            "overall_score": self.overall_score,
+            "findings": [
+                {
+                    "code": finding.code,
+                    "severity": finding.severity.value,
+                    "message": finding.message,
+                    "metric": finding.metric,
+                    "value": _round(finding.value),
+                    "confidence": round(finding.confidence, 3),
+                }
+                for finding in self.findings
+            ],
+            "metrics": {
+                name: {
+                    "value": _round(metric.value),
+                    "unit": metric.unit,
+                    "status": metric.status.value,
+                    "detail": metric.detail,
+                    "confidence": _round(metric.confidence),
+                }
+                for name, metric in sorted(self.metrics.items())
+            },
+            "quality": {
+                "assessed": self.quality.assessed,
+                "total": self.quality.total,
+                "coverage": round(self.quality.coverage, 3),
+                "gaps": [
+                    {
+                        "metric": gap.metric,
+                        "status": gap.status.value,
+                        "detail": gap.detail,
+                        "keypoints": {
+                            name.value: status.value
+                            for name, status in sorted(
+                                gap.keypoints.items(), key=lambda item: item[0].value
+                            )
+                        },
+                    }
+                    for gap in self.quality.gaps
+                ],
+                # Only the keypoints with something wrong. Listing all 34 on every report would
+                # quadruple its size to say "fine" thirty times.
+                "keypoints": {
+                    name.value: status.value
+                    for name, status in sorted(
+                        self.quality.keypoints.items(), key=lambda item: item[0].value
+                    )
+                    if status is not KeypointStatus.OK
+                },
+            },
+        }
+
+
+def _round(value: float | None) -> float | None:
+    return None if value is None else round(value, 4)
+
+
+def build_report(frame: PoseFrame, thresholds: Thresholds = DEFAULT_THRESHOLDS) -> PostureReport:
+    """Run every metric, apply every rule, and assemble the result.
+
+    Pure: no I/O, no printing, no globals, no clock. ``inference_ms`` is carried through from the
+    frame rather than measured here, so the same frame always yields the same report.
+    """
+    resolver = KeypointResolver(frame, thresholds)
+    metrics = {
+        metric.name: metric for metric in (compute(resolver, thresholds) for compute in METRICS)
+    }
+
+    gaps = [
+        metric.as_gap({name: resolver.status(name) for name in metric.inputs})
+        for metric in metrics.values()
+        if metric.status is not MetricStatus.OK
+    ]
+    findings = evaluate(metrics, thresholds)
+    assessed = sum(1 for metric in metrics.values() if metric.is_ok)
+
+    return PostureReport(
+        schema_version=SCHEMA_VERSION,
+        rules_version=thresholds.version,
+        backend=frame.backend,
+        inference_ms=frame.inference_ms,
+        image_width=frame.image_width,
+        image_height=frame.image_height,
+        metrics=metrics,
+        findings=findings,
+        quality=Quality(
+            assessed=assessed,
+            total=len(metrics),
+            gaps=gaps,
+            keypoints=resolver.statuses,
+        ),
+        overall_score=_score(findings, assessed, thresholds),
+    )
+
+
+def _score(findings: Sequence[Finding], assessed: int, thresholds: Thresholds) -> float | None:
+    if assessed == 0:
+        return None
+    penalty = sum(
+        thresholds.score_penalty_per_finding * _SEVERITY_WEIGHT[finding.severity]
+        for finding in findings
+    )
+    return max(0.0, min(100.0, 100.0 - penalty))

--- a/packages/posture-core/src/posture_core/rules.py
+++ b/packages/posture-core/src/posture_core/rules.py
@@ -1,0 +1,307 @@
+"""Turning measurements into findings — the layer that decides, separately from the layer that
+measures.
+
+A metric answers "how far forward is this torso leaning?". A rule answers "is that worth telling
+the user about?". Keeping them apart is what lets a threshold move without touching a
+measurement, and it is why the report can show a user *how close to the line* they were rather
+than only which side of it they landed on.
+
+## Findings and gaps are both outputs
+
+A metric that abstained produces a :class:`~posture_core.status.Gap`, never a
+:class:`Finding` — and never silence. The report carries both. That is the whole correction to
+the inherited engine, which had exactly one output channel and used it to say "Straight back
+position" whenever it had failed (FINDINGS §2.5).
+
+## Confidence travels with the finding
+
+Every finding carries the confidence of the weakest landmark it rests on, multiplied by the view
+factor (OP-31) when the measurement is a sagittal one. A finding is therefore always
+*qualified* — the API and the frontend can present a 0.42-confidence slouch differently from a
+0.95-confidence one, instead of presenting both as fact.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+from posture_core.metrics import arms, feet, head, knees, trunk, view
+
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from posture_core.status import Metric
+    from posture_core.thresholds import Thresholds
+
+__all__ = ["Finding", "Severity", "evaluate"]
+
+
+class Severity(StrEnum):
+    """How much a finding matters.
+
+    Three levels, not a numeric score. A number would imply a precision the underlying evidence
+    does not support, and would invite arithmetic on values that are really categories.
+    """
+
+    INFO = "info"
+    """Context worth showing, not a fault. Kneeling; arms folded; a sub-optimal camera angle."""
+
+    MINOR = "minor"
+    MAJOR = "major"
+
+
+@dataclasses.dataclass(frozen=True, slots=True)
+class Finding:
+    """One thing worth telling the user, with the evidence attached."""
+
+    code: str
+    """Stable machine-readable identifier. The UI keys off this; ``message`` may be reworded."""
+
+    severity: Severity
+    message: str
+    metric: str
+    """Which measurement produced this, so a reader can check the working."""
+
+    value: float | None
+    confidence: float
+    """``[0, 1]``. The weakest input's confidence, further reduced by the camera angle.
+
+    Carried on the finding rather than left in the metric because this is what the user's
+    interface needs in order to hedge. A finding with no confidence attached is a claim; a finding
+    with 0.42 attached is an observation.
+    """
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence <= 1.0:
+            raise ValueError(f"finding {self.code!r} has confidence {self.confidence}")
+
+
+def evaluate(metrics: Mapping[str, Metric], thresholds: Thresholds) -> list[Finding]:
+    """Every finding the measurements support, most severe first.
+
+    Metrics that abstained are skipped silently *here* — their gaps are assembled by
+    :mod:`posture_core.report`, which is the module that owns the report's completeness. A rule
+    that tried to emit both would duplicate every abstention.
+    """
+    view_factor = view.view_confidence_factor(_value(metrics, view.NAME), thresholds)
+
+    findings: list[Finding] = []
+    for rule in _RULES:
+        findings.extend(rule(metrics, thresholds, view_factor))
+
+    # Most severe first, then by descending confidence: the user's eye goes to the top of the
+    # list, so the top of the list should be the thing most worth acting on and least likely to
+    # be wrong.
+    order = {Severity.MAJOR: 0, Severity.MINOR: 1, Severity.INFO: 2}
+    findings.sort(key=lambda finding: (order[finding.severity], -finding.confidence))
+    return findings
+
+
+def _value(metrics: Mapping[str, Metric], name: str) -> float | None:
+    metric = metrics.get(name)
+    return metric.value if metric is not None and metric.is_ok else None
+
+
+def _confidence(metrics: Mapping[str, Metric], name: str, factor: float = 1.0) -> float:
+    metric = metrics.get(name)
+    base = 1.0 if metric is None or metric.confidence is None else metric.confidence
+    return max(0.0, min(1.0, base * factor))
+
+
+def _trunk(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    value = _value(metrics, trunk.NAME)
+    if value is None:
+        return []
+    # Sagittal: the camera angle affects how much the depth estimate can be trusted, so the view
+    # factor applies.
+    confidence = _confidence(metrics, trunk.NAME, view_factor)
+
+    if value >= thresholds.trunk_slouch_deg:
+        return [
+            Finding(
+                code="trunk_slouch",
+                severity=Severity.MAJOR,
+                message=(
+                    f"Your torso is leaning {value:.0f}° forward. Try bringing your hips back "
+                    "into the chair so your back is supported."
+                ),
+                metric=trunk.NAME,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    if value > thresholds.trunk_upright_deg:
+        return [
+            Finding(
+                code="trunk_forward_lean",
+                severity=Severity.MINOR,
+                message=f"Your torso is leaning {value:.0f}° forward — slightly more than neutral.",
+                metric=trunk.NAME,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    if value <= thresholds.trunk_recline_deg:
+        return [
+            Finding(
+                code="trunk_recline",
+                severity=Severity.MINOR,
+                message=(
+                    f"You are leaning {abs(value):.0f}° back. That is fine if the chair supports "
+                    "your back, and not if you are perched on the edge of the seat."
+                ),
+                metric=trunk.NAME,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    return []
+
+
+def _head(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    value = _value(metrics, head.NAME)
+    if value is None:
+        return []
+    confidence = _confidence(metrics, head.NAME, view_factor)
+
+    # Smaller is worse — the opposite of every other threshold in the package.
+    if value < thresholds.cva_forward_head_deg:
+        return [
+            Finding(
+                code="forward_head",
+                severity=Severity.MAJOR,
+                message=(
+                    f"Your head sits well forward of your shoulders (craniovertebral angle "
+                    f"{value:.0f}°, below the {thresholds.cva_forward_head_deg:.0f}° mark). "
+                    "Drawing your chin back over your shoulders takes the load off your neck."
+                ),
+                metric=head.NAME,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    if value < thresholds.cva_borderline_deg:
+        return [
+            Finding(
+                code="forward_head_borderline",
+                severity=Severity.MINOR,
+                message=f"Your head is a little forward of your shoulders ({value:.0f}°).",
+                metric=head.NAME,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    return []
+
+
+def _knees(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    del view_factor  # A joint angle in the sagittal plane, but measured across it, not into it.
+    value = _value(metrics, knees.KNEE_FLEXION)
+    if value is None:
+        return []
+    confidence = _confidence(metrics, knees.KNEE_FLEXION)
+
+    if value <= thresholds.knee_kneeling_max_deg:
+        return [
+            Finding(
+                code="kneeling",
+                severity=Severity.INFO,
+                message=f"You appear to be kneeling — your knee is folded to {value:.0f}°.",
+                metric=knees.KNEE_FLEXION,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    if value < thresholds.knee_seated_min_deg:
+        return [
+            Finding(
+                code="knee_tucked",
+                severity=Severity.MINOR,
+                message=(
+                    f"Your knee is tucked back to {value:.0f}°, which is tighter than a "
+                    "comfortable seated angle. Try moving your feet forward."
+                ),
+                metric=knees.KNEE_FLEXION,
+                value=value,
+                confidence=confidence,
+            )
+        ]
+    return []
+
+
+def _feet(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    del view_factor
+    value = _value(metrics, feet.HEEL_CONTACT)
+    if value is None or value <= thresholds.heel_contact_tolerance_m:
+        return []
+    return [
+        Finding(
+            code="feet_unsupported",
+            severity=Severity.MINOR,
+            message=(
+                f"Your heel is about {value * 100:.0f} cm above your toes, which suggests that "
+                "foot is not resting on the floor. A footrest or a lower seat would help."
+            ),
+            metric=feet.HEEL_CONTACT,
+            value=value,
+            confidence=_confidence(metrics, feet.HEEL_CONTACT),
+        )
+    ]
+
+
+def _arms(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    del view_factor
+    value = _value(metrics, arms.ARMS_CROSSED)
+    if value is None or value >= thresholds.arms_crossed_ratio:
+        return []
+    return [
+        Finding(
+            code="arms_folded",
+            severity=Severity.INFO,
+            message=(
+                "Your arms are folded across your chest. That is not a fault in itself, but it "
+                "often accompanies a rounded upper back."
+            ),
+            metric=arms.ARMS_CROSSED,
+            value=value,
+            confidence=_confidence(metrics, arms.ARMS_CROSSED),
+        )
+    ]
+
+
+def _view(
+    metrics: Mapping[str, Metric], thresholds: Thresholds, view_factor: float
+) -> list[Finding]:
+    del view_factor
+    value = _value(metrics, view.NAME)
+    if value is None or value < thresholds.frontal_view_min_ratio:
+        return []
+    return [
+        Finding(
+            code="frontal_view",
+            severity=Severity.INFO,
+            message=(
+                "This photo looks like it was taken from the front. The measurements below still "
+                "work, but they rest on a depth estimate that is weakest along the camera's own "
+                "axis — a side-on photo would give a firmer answer."
+            ),
+            metric=view.NAME,
+            value=value,
+            confidence=_confidence(metrics, view.NAME),
+        )
+    ]
+
+
+_RULES: Final = (_trunk, _head, _knees, _feet, _arms, _view)

--- a/packages/posture-core/tests/test_report.py
+++ b/packages/posture-core/tests/test_report.py
@@ -1,0 +1,340 @@
+"""Tests for the rules layer and the assembled report.
+
+This is the layer a user actually meets, so these tests are mostly about what the report *says* —
+including what it says about the parts of the body it could not see.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+import pytest
+from builders import SEATED, frame, unclear, with_thresholds, without
+
+from posture_core import Finding, Severity, build_report
+from posture_core import KeypointName as K
+from posture_core.report import SCHEMA_VERSION, PostureReport
+from posture_core.status import MetricStatus
+from posture_core.synthetic import View
+from posture_core.thresholds import DEFAULT_THRESHOLDS, RULES_VERSION
+
+SLOUCHED: dict[str, Any] = {"trunk_deg": 35.0, "neck_deg": 30.0}
+UPRIGHT: dict[str, Any] = {"trunk_deg": 3.0, "neck_deg": 3.0}
+
+
+def report(**pose_kwargs: Any) -> PostureReport:
+    thresholds = pose_kwargs.pop("thresholds", DEFAULT_THRESHOLDS)
+    return build_report(frame(**pose_kwargs), thresholds)
+
+
+def codes(**pose_kwargs: Any) -> list[str]:
+    return [finding.code for finding in report(**pose_kwargs).findings]
+
+
+# ---------------------------------------------------------------------------------------------
+# Findings
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_slouched_figure_produces_the_findings_it_should() -> None:
+    found = codes(**SLOUCHED)
+    assert "trunk_slouch" in found
+    assert "forward_head" in found
+
+
+def test_an_upright_figure_produces_no_faults() -> None:
+    """The only case where saying nothing is correct — and it must be reached by measuring, not
+    by failing to measure. `test_a_frame_the_engine_cannot_read_says_so` is the other half."""
+    assert [
+        finding for finding in report(**UPRIGHT).findings if finding.severity is not Severity.INFO
+    ] == []
+
+
+def test_reclining_is_reported_differently_from_slouching() -> None:
+    """Opposite postures with different advice. An unsigned metric could not separate them."""
+    assert "trunk_recline" in codes(trunk_deg=-30.0)
+    assert "trunk_slouch" in codes(trunk_deg=30.0)
+
+
+def test_findings_are_ordered_most_severe_first() -> None:
+    """The user's eye goes to the top of the list, so the top should be worth acting on."""
+    severities = [finding.severity for finding in report(**SLOUCHED).findings]
+    order = {Severity.MAJOR: 0, Severity.MINOR: 1, Severity.INFO: 2}
+    assert [order[severity] for severity in severities] == sorted(
+        order[severity] for severity in severities
+    )
+
+
+def test_every_finding_names_the_metric_it_came_from() -> None:
+    """So a reader can check the working rather than take the verdict on faith."""
+    result = report(**SLOUCHED)
+    for finding in result.findings:
+        assert finding.metric in result.metrics
+
+
+def test_findings_carry_confidence_rather_than_asserting_facts() -> None:
+    for finding in report(**SLOUCHED).findings:
+        assert 0.0 <= finding.confidence <= 1.0
+
+
+def test_an_unclear_landmark_lowers_the_confidence_of_the_finding_that_rests_on_it() -> None:
+    """The weakest input, not the average — a finding cannot be more certain than its evidence."""
+    confident = next(f for f in report(**SLOUCHED).findings if f.code == "trunk_slouch")
+    hedged = next(
+        f
+        for f in report(**SLOUCHED, **unclear(K.LEFT_HIP, visibility=0.55)).findings
+        if f.code == "trunk_slouch"
+    )
+    assert hedged.confidence < confident.confidence
+
+
+def test_a_frontal_photo_lowers_confidence_and_says_why() -> None:
+    """The correction to the plan, visible in the output.
+
+    A head-on photograph does not lose the measurement — world landmarks recover the full lean —
+    but it does rest on the model's weakest dimension. So the finding survives with reduced
+    confidence, and a separate INFO finding tells the user a side-on photo would be firmer.
+    """
+    side_on = next(f for f in report(**SLOUCHED).findings if f.code == "trunk_slouch")
+    head_on_report = report(**SLOUCHED, view=View.FRONTAL)
+    head_on = next(f for f in head_on_report.findings if f.code == "trunk_slouch")
+
+    assert head_on.confidence < side_on.confidence
+    assert "frontal_view" in [finding.code for finding in head_on_report.findings]
+
+
+def test_the_thresholds_that_decide_are_injected() -> None:
+    strict = with_thresholds(trunk_upright_deg=2.0, trunk_slouch_deg=5.0)
+    assert "trunk_slouch" not in codes(trunk_deg=8.0)
+    assert "trunk_slouch" in codes(trunk_deg=8.0, thresholds=strict)
+
+
+# ---------------------------------------------------------------------------------------------
+# Gaps — the half the original never had
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_metric_that_abstained_appears_as_a_gap_not_as_silence() -> None:
+    """The correction to "Straight back position", in its final form.
+
+    A report saying "you are slouching, and I could not see your knees" is more useful and more
+    honest than one saying only "you are slouching". The silence in the second version is what the
+    inherited engine shipped.
+    """
+    result = report(**SLOUCHED, **without(K.LEFT_KNEE, K.RIGHT_KNEE))
+    gap = next(gap for gap in result.quality.gaps if gap.metric == "knee_flexion_deg")
+    assert gap.status is MetricStatus.INSUFFICIENT_KEYPOINTS
+    assert "knee" in gap.detail
+    assert "trunk_slouch" in [finding.code for finding in result.findings]
+
+
+def test_a_gap_names_the_keypoints_responsible_so_the_advice_can_be_specific() -> None:
+    result = report(**without(K.LEFT_HEEL, K.RIGHT_HEEL))
+    gap = next(gap for gap in result.quality.gaps if gap.metric == "heel_contact_m")
+    assert set(gap.keypoints) == {K.LEFT_HEEL, K.RIGHT_HEEL}
+
+
+def test_coverage_reports_how_much_of_the_body_was_assessed() -> None:
+    full = report(**SEATED)
+    partial = report(**without(K.LEFT_KNEE, K.RIGHT_KNEE, K.LEFT_HEEL, K.RIGHT_HEEL))
+    assert partial.quality.coverage < full.quality.coverage
+    assert 0.0 <= partial.quality.coverage <= 1.0
+
+
+def test_the_score_is_none_when_nothing_could_be_measured() -> None:
+    """Not 0, not 100. Both are confident claims about a photograph the engine could not read —
+    the same defect as "Straight back position" wearing different clothes."""
+    empty = build_report(
+        frame(omit=tuple(K)),
+        DEFAULT_THRESHOLDS,
+    )
+    assert empty.overall_score is None
+    assert empty.findings == []
+    assert len(empty.quality.gaps) == empty.quality.total
+
+
+def test_a_frame_the_engine_cannot_read_says_so_rather_than_reporting_good_posture() -> None:
+    result = build_report(frame(omit=tuple(K)), DEFAULT_THRESHOLDS)
+    assert result.quality.assessed == 0
+    assert all(gap.status is not MetricStatus.OK for gap in result.quality.gaps)
+
+
+# ---------------------------------------------------------------------------------------------
+# Score
+# ---------------------------------------------------------------------------------------------
+
+
+def test_worse_posture_scores_lower() -> None:
+    good = report(**UPRIGHT).overall_score
+    bad = report(**SLOUCHED).overall_score
+    assert good is not None and bad is not None
+    assert bad < good
+
+
+def test_an_informational_finding_does_not_cost_points() -> None:
+    """Kneeling and folded arms are context, not faults, and scoring them would tell users to
+    change things that are not problems."""
+    upright = report(**UPRIGHT).overall_score
+    kneeling = report(trunk_deg=3.0, neck_deg=3.0, thigh_deg=15.0, shank_deg=165.0)
+    assert "kneeling" in [finding.code for finding in kneeling.findings]
+    assert kneeling.overall_score == upright
+
+
+def test_the_score_stays_inside_its_stated_range() -> None:
+    terrible = report(trunk_deg=60.0, neck_deg=60.0, thigh_deg=120.0, shank_deg=5.0)
+    assert terrible.overall_score is not None
+    assert 0.0 <= terrible.overall_score <= 100.0
+
+
+# ---------------------------------------------------------------------------------------------
+# Shape, purity, versioning
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_report_is_stamped_with_both_versions() -> None:
+    """A stored report with no stamps becomes uninterpretable the first time a threshold moves:
+    you cannot tell whether the user's posture changed or the yardstick did."""
+    result = report(**SLOUCHED)
+    assert result.schema_version == SCHEMA_VERSION
+    assert result.rules_version == RULES_VERSION
+
+
+def test_the_rules_version_follows_the_thresholds_actually_used() -> None:
+    custom = with_thresholds(version="9.9.9")
+    assert report(**SLOUCHED, thresholds=custom).rules_version == "9.9.9"
+
+
+def test_backend_and_latency_travel_with_the_report() -> None:
+    result = report(**SLOUCHED)
+    assert result.backend == "synthetic"
+    assert result.inference_ms == 0.0
+
+
+def test_building_a_report_twice_gives_the_same_answer() -> None:
+    """Purity, stated as a test. No clock, no randomness, no globals — which is what makes golden
+    snapshots (OP-35) possible at all."""
+    first = build_report(frame(**SLOUCHED), DEFAULT_THRESHOLDS).to_dict()
+    second = build_report(frame(**SLOUCHED), DEFAULT_THRESHOLDS).to_dict()
+    assert json.dumps(first, sort_keys=True) == json.dumps(second, sort_keys=True)
+
+
+def test_the_serialised_report_is_json_and_sorted() -> None:
+    payload = report(**SLOUCHED).to_dict()
+    encoded = json.dumps(payload)
+    assert json.loads(encoded) == payload
+    assert list(payload["metrics"]) == sorted(payload["metrics"])
+
+
+def test_the_serialised_report_lists_only_problem_keypoints() -> None:
+    """All 34 on every report would quadruple its size to say "fine" thirty times."""
+    payload = report(**SLOUCHED, **without(K.LEFT_HEEL)).to_dict()
+    assert set(payload["quality"]["keypoints"]) == {"left_heel"}
+
+
+def test_every_metric_appears_in_the_report_whether_or_not_it_succeeded() -> None:
+    """A metric silently missing from the output is indistinguishable from one that was never
+    written, which is how a capability quietly disappears."""
+    result = report(**without(K.LEFT_KNEE, K.RIGHT_KNEE))
+    assert "knee_flexion_deg" in result.metrics
+    assert result.metrics["knee_flexion_deg"].value is None
+
+
+def test_a_report_is_immutable() -> None:
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        report(**SLOUCHED).overall_score = 100.0  # type: ignore[misc]
+
+
+def test_a_finding_cannot_carry_an_impossible_confidence() -> None:
+    """Confidence is a probability. A value outside [0, 1] would render as a nonsense percentage
+    in the UI rather than failing anywhere the cause could be found."""
+    with pytest.raises(ValueError, match="confidence"):
+        Finding(
+            code="x",
+            severity=Severity.MINOR,
+            message="",
+            metric="trunk_inclination_deg",
+            value=1.0,
+            confidence=1.5,
+        )
+
+
+def test_a_borderline_forward_head_is_reported_as_minor() -> None:
+    """The middle band exists so the report can mention something without calling it a fault."""
+    assert "forward_head_borderline" in codes(trunk_deg=0.0, neck_deg=37.0)
+
+
+def test_a_tucked_knee_is_reported() -> None:
+    assert "knee_tucked" in codes(thigh_deg=120.0, shank_deg=5.0)
+
+
+def test_folded_arms_are_reported_as_context_not_as_a_fault() -> None:
+    result = report(upper_arm_deg=15.0, forearm_deg=80.0, forearm_cross_deg=55.0)
+    folded = next(f for f in result.findings if f.code == "arms_folded")
+    assert folded.severity is Severity.INFO
+
+
+def test_a_metric_with_no_confidence_recorded_does_not_break_the_finding() -> None:
+    """`Metric.confidence` is optional, and a rule must not assume it was populated."""
+    for finding in report(**SLOUCHED).findings:
+        assert finding.confidence > 0.0
+
+
+def test_a_mild_forward_lean_is_reported_as_minor_rather_than_ignored() -> None:
+    """The band between "upright" and "slouching" exists so the report can nudge without alarming.
+
+    Collapsing it would force every posture into either silence or a major finding, and most real
+    sitting falls between the two.
+    """
+    findings = [f for f in report(trunk_deg=15.0).findings if f.code == "trunk_forward_lean"]
+    assert len(findings) == 1
+    assert findings[0].severity is Severity.MINOR
+
+
+def test_an_unsupported_foot_is_reported_with_a_practical_suggestion() -> None:
+    """The capability the original listed as a goal and never delivered, surfaced to the user."""
+    from posture_core import Landmark, PoseFrame
+
+    original = frame()
+    landmarks = dict(original.landmarks)
+    for heel, toe in ((K.LEFT_HEEL, K.LEFT_FOOT_INDEX), (K.RIGHT_HEEL, K.RIGHT_FOOT_INDEX)):
+        existing, toe_landmark = landmarks[heel], landmarks[toe]
+        assert toe_landmark.y_world is not None
+        landmarks[heel] = Landmark(
+            x=existing.x,
+            y=existing.y,
+            visibility=existing.visibility,
+            presence=existing.presence,
+            x_world=existing.x_world,
+            y_world=toe_landmark.y_world - 0.12,
+            z_world=existing.z_world,
+        )
+
+    result = build_report(
+        PoseFrame(
+            landmarks=landmarks,
+            image_width=original.image_width,
+            image_height=original.image_height,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        DEFAULT_THRESHOLDS,
+    )
+    finding = next(f for f in result.findings if f.code == "feet_unsupported")
+    assert finding.severity is Severity.MINOR
+    assert "footrest" in finding.message
+
+
+def test_a_reports_quality_section_cannot_be_edited_after_the_fact() -> None:
+    """Same guard as `Gap` and `PoseFrame`, for the same reason.
+
+    `frozen=True` freezes the attribute bindings, not the containers bound to them. The quality
+    section is the record of what the engine could not assess, which is precisely the part of a
+    report that should not be quietly revisable.
+    """
+    quality = report(**SLOUCHED, **without(K.LEFT_KNEE)).quality
+    with pytest.raises(TypeError):
+        quality.keypoints[K.NOSE] = "ok"  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        quality.gaps.append(None)  # type: ignore[attr-defined]

--- a/packages/posture-core/tests/test_report.py
+++ b/packages/posture-core/tests/test_report.py
@@ -151,7 +151,9 @@ def test_the_score_is_none_when_nothing_could_be_measured() -> None:
         DEFAULT_THRESHOLDS,
     )
     assert empty.overall_score is None
-    assert empty.findings == []
+    # A tuple, not a list: `__post_init__` copies the findings into one so a frozen report is
+    # frozen all the way down rather than only at its attribute bindings.
+    assert empty.findings == ()
     assert len(empty.quality.gaps) == empty.quality.total
 
 
@@ -338,3 +340,42 @@ def test_a_reports_quality_section_cannot_be_edited_after_the_fact() -> None:
         quality.keypoints[K.NOSE] = "ok"  # type: ignore[index]
     with pytest.raises(AttributeError):
         quality.gaps.append(None)  # type: ignore[attr-defined]
+
+
+def test_a_reports_metrics_and_findings_cannot_be_edited_after_the_fact() -> None:
+    """The same guard the quality section already had, applied to the two containers that matter
+    most.
+
+    `frozen=True` stopped `report.overall_score = 100.0` and nothing else: `build_report` handed
+    over a live dict and a live list, so deleting an inconvenient finding or rewriting a metric's
+    value was an ordinary mutation. The module docstring promises one frame yields one
+    byte-identical document forever, and that promise was only good until someone took it up.
+    """
+    result = report(**SLOUCHED)
+    assert result.findings, "the fixture needs at least one finding for this to mean anything"
+
+    with pytest.raises(TypeError):
+        result.metrics["trunk_inclination_deg"] = None  # type: ignore[index]
+    with pytest.raises(AttributeError):
+        result.findings.append(None)  # type: ignore[attr-defined]
+    with pytest.raises(AttributeError):
+        result.findings.clear()  # type: ignore[attr-defined]
+
+
+def test_the_score_is_rounded_like_every_other_float_in_the_document() -> None:
+    """Invisible at the default 15.0 penalty, which divides cleanly — which is exactly the risk.
+
+    This fixture produces two major findings, so the score is `100 - 2p`. At `p = 32.2` that is
+    `35.599999999999994`. Fifty-six of the first four hundred tenths do something similar here, so
+    the default being clean is luck, not design. An unrounded score would scatter that noise
+    through the golden corpus on the first threshold retune, and through the cross-language
+    comparison in OP-36, where it would read as two engines disagreeing rather than as an artefact
+    of binary floating point.
+    """
+    tuned = with_thresholds(score_penalty_per_finding=32.2)
+    raw = build_report(frame(**SLOUCHED), tuned).overall_score
+    assert raw is not None
+    assert raw != round(raw, 4), "premise: this penalty must produce a non-representable score"
+
+    serialised = build_report(frame(**SLOUCHED), tuned).to_dict()["overall_score"]
+    assert serialised == round(raw, 4)


### PR DESCRIPTION
This pull request introduces the core reporting and rules logic for the posture assessment engine. It adds the `PostureReport` data structure and the `build_report` function, which together define how an assessment is generated, serialized, and scored. It also introduces the rules engine that turns metric measurements into user-facing findings, separating measurement from interpretation for clarity and maintainability. The `__init__.py` file is updated to re-export all new public API symbols, making them available for consumers.

**Reporting and API surface:**

* Adds `PostureReport`, `build_report`, and supporting types to the public API in `posture_core/__init__.py`, ensuring all key reporting and rules types are available for import.
* Implements the `PostureReport` dataclass and the pure function `build_report` in `report.py`, which assembles the assessment, computes overall score, and serializes the result in a stable, testable way.

**Rules engine:**

* Introduces the `rules.py` module, which defines the `Finding` and `Severity` types and the `evaluate` function. This separates measurement from decision logic, allowing thresholds to change without affecting measurement code.
* Implements a set of rules for posture findings (e.g., trunk slouch, forward head, kneeling, unsupported feet, arms folded, frontal view), each with clear messages, severities, and confidence calculations.

**Design and testability improvements:**

* Ensures reports always include both findings and measurement gaps, and version-stamps both schema and rules for robust history and golden-snapshot testing.
* All reporting and rules logic is pure and deterministic, with no I/O or global state, supporting reliable CI and cross-language fixture testing. [[1]](diffhunk://#diff-8ba56844937b94c272754b63f6a9ba152a926a7da110432a4c22226a02007d19R1-R228) [[2]](diffhunk://#diff-7243e976f23e09f28be8387cdb01ffe9246a24dcee4d559fd91450e8b47b93efR1-R307)