### PR TITLE
OP-34: Hypothesis property tests — scale and translation invariance

### DIFF
--- a/packages/posture-core/tests/test_properties.py
+++ b/packages/posture-core/tests/test_properties.py
@@ -1,0 +1,314 @@
+"""Property-based tests. **This file is the proof that the redesign fixed the original defect.**
+
+The inherited engine compared raw pixel distances against literal thresholds (FINDINGS §2.6), so
+identical posture photographed at twice the distance, or on a person of a different size, produced
+a different verdict. Every example-based test in this package agrees the new engine does not do
+that — but examples only ever show that the cases someone thought of happen to work.
+
+Hypothesis generates the cases nobody thought of. For *any* posture, *any* body size in a 10x
+range, and *any* position in the frame, every angular metric must agree to within 1e-6 degrees.
+That is a statement about the whole input space, and it is the one that would fail catastrophically
+against `posture_image.py`.
+
+The second property here is quieter and just as important: **nothing raises**. For any pose with
+any subset of its landmarks removed, `build_report` returns a report. Not a plausible one
+necessarily — a report full of gaps is the correct answer to a photograph of an empty chair — but
+a report, never a traceback and never a `None` the caller has to interpret.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from hypothesis import HealthCheck, given, settings
+from hypothesis import strategies as st
+
+from posture_core import KeypointName as K
+from posture_core import Landmark, PoseFrame, build_report
+from posture_core.metrics import (
+    craniovertebral_angle_deg,
+    elbow_flexion_deg,
+    knee_flexion_deg,
+    trunk_inclination_deg,
+    view_confidence,
+)
+from posture_core.resolver import KeypointResolver
+from posture_core.synthetic import Anthropometry, Facing, View, make_pose
+from posture_core.thresholds import DEFAULT_THRESHOLDS as T
+
+# Angular metrics only. `heel_contact_m` is a *length* in metres and is supposed to scale with the
+# body — asserting it invariant would be asserting the wrong thing. `arms_crossed` is a ratio and
+# gets its own check below.
+ANGULAR = (
+    trunk_inclination_deg,
+    craniovertebral_angle_deg,
+    elbow_flexion_deg,
+    knee_flexion_deg,
+)
+
+# Physically plausible joint angles. Bounded rather than unbounded because a figure with a 400°
+# knee is not a posture the engine will ever see, and testing it would only pin down the behaviour
+# of arithmetic on nonsense.
+poses = st.fixed_dictionaries(
+    {
+        "trunk_deg": st.floats(-60, 70),
+        "neck_deg": st.floats(-30, 60),
+        "thigh_deg": st.floats(0, 110),
+        "shank_deg": st.floats(-20, 180),
+        "upper_arm_deg": st.floats(-40, 100),
+        "forearm_deg": st.floats(-20, 170),
+        "forearm_cross_deg": st.floats(0, 80),
+        "facing": st.sampled_from(list(Facing)),
+        "view": st.sampled_from(list(View)),
+    }
+)
+
+# 0.3x to 3.0x: a small child through to a very large adult, which is a wider range than the
+# application will meet and therefore a stronger claim than it needs.
+scales = st.floats(0.3, 3.0)
+
+frame_sizes = st.tuples(st.integers(240, 4000), st.integers(240, 4000))
+
+SETTINGS = settings(
+    max_examples=200,
+    deadline=None,
+    suppress_health_check=[HealthCheck.function_scoped_fixture],
+)
+
+
+def scaled_body(scale: float) -> Anthropometry:
+    default = Anthropometry()
+    return Anthropometry(
+        **{
+            field: getattr(default, field) * scale
+            for field in (
+                "torso",
+                "neck",
+                "shoulder_width",
+                "hip_width",
+                "head_width",
+                "upper_arm",
+                "forearm",
+                "hand",
+                "thigh",
+                "shank",
+                "foot",
+                "heel_drop",
+            )
+        }
+    )
+
+
+def resolver_for(
+    landmarks: dict[K, Landmark], width: int = 640, height: int = 480
+) -> KeypointResolver:
+    return KeypointResolver(
+        PoseFrame(
+            landmarks=landmarks,
+            image_width=width,
+            image_height=height,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        T,
+    )
+
+
+def angular_values(landmarks: dict[K, Landmark], **frame_kwargs: int) -> dict[str, float | None]:
+    resolver = resolver_for(landmarks, **frame_kwargs)
+    return {metric.__name__: metric(resolver, T).value for metric in ANGULAR}
+
+
+# ---------------------------------------------------------------------------------------------
+# The headline property
+# ---------------------------------------------------------------------------------------------
+
+
+@SETTINGS
+@given(pose=poses, scale=scales)
+def test_every_angular_metric_is_invariant_to_body_size(pose: dict[str, Any], scale: float) -> None:
+    """The defect the whole rebuild exists to fix, stated over the entire input space.
+
+    The legacy engine's thresholds were absolute pixel counts, so this property fails
+    catastrophically against it — a person twice as far from the camera got a different verdict for
+    the same posture. Here the angle is computed in metric world space, where scale never enters.
+
+    1e-6 degrees is not a tolerance for a normalisation that nearly works; it is floating-point
+    noise. The invariance is exact by construction.
+    """
+    baseline = angular_values(make_pose(**pose))
+    scaled = angular_values(make_pose(**pose, body=scaled_body(scale)))
+
+    for name, value in baseline.items():
+        other = scaled[name]
+        assert (value is None) == (other is None), name
+        if value is not None and other is not None:
+            assert other == pytest.approx(value, abs=1e-6), f"{name} moved under {scale}x scaling"
+
+
+@SETTINGS
+@given(pose=poses, size=frame_sizes)
+def test_every_angular_metric_is_invariant_to_frame_size_and_aspect_ratio(
+    pose: dict[str, Any], size: tuple[int, int]
+) -> None:
+    """A 4:3 photo and a 21:9 one of the same posture must agree.
+
+    Worth its own property because the obvious implementation — computing angles straight from
+    normalised coordinates — silently measures in a space stretched by the aspect ratio, and the
+    error it produces is small enough to look like model noise.
+    """
+    width, height = size
+    baseline = angular_values(make_pose(**pose))
+    resized = angular_values(
+        make_pose(**pose, image_width=width, image_height=height), width=width, height=height
+    )
+
+    for name, value in baseline.items():
+        other = resized[name]
+        assert (value is None) == (other is None), name
+        if value is not None and other is not None:
+            assert other == pytest.approx(value, abs=1e-6), f"{name} moved at {width}x{height}"
+
+
+@SETTINGS
+@given(pose=poses, offset=st.tuples(st.floats(-2.0, 2.0), st.floats(-2.0, 2.0)))
+def test_every_angular_metric_is_invariant_to_where_the_subject_stands(
+    pose: dict[str, Any], offset: tuple[float, float]
+) -> None:
+    """Translation invariance, applied in world space where the metrics actually work.
+
+    MediaPipe's world landmarks are hip-origin, so a real translation is invisible to them by
+    construction — which is exactly why this must be checked rather than assumed. Shifting every
+    world coordinate by a constant simulates a backend that did *not* re-origin, and the angles
+    must not care.
+    """
+    dx, dy = offset
+    original = make_pose(**pose)
+    shifted = {
+        name: Landmark(
+            x=landmark.x,
+            y=landmark.y,
+            visibility=landmark.visibility,
+            presence=landmark.presence,
+            x_world=None if landmark.x_world is None else landmark.x_world + dx,
+            y_world=None if landmark.y_world is None else landmark.y_world + dy,
+            z_world=landmark.z_world,
+        )
+        for name, landmark in original.items()
+    }
+
+    baseline = angular_values(original)
+    moved = angular_values(shifted)
+    for name, value in baseline.items():
+        other = moved[name]
+        if value is not None and other is not None:
+            assert other == pytest.approx(value, abs=1e-6), f"{name} moved under translation"
+
+
+@SETTINGS
+@given(pose=poses, scale=scales)
+def test_the_view_ratio_is_invariant_to_body_size(pose: dict[str, Any], scale: float) -> None:
+    """A ratio of two image-space lengths, so the projection cancels.
+
+    Separated from the angular metrics because it is measured in image space on purpose — the
+    question it answers is what the *camera* could see.
+    """
+    baseline = view_confidence(resolver_for(make_pose(**pose)), T).value
+    scaled = view_confidence(resolver_for(make_pose(**pose, body=scaled_body(scale))), T).value
+    if baseline is not None and scaled is not None:
+        assert scaled == pytest.approx(baseline, abs=1e-6)
+
+
+# ---------------------------------------------------------------------------------------------
+# Nothing raises, ever
+# ---------------------------------------------------------------------------------------------
+
+
+@SETTINGS
+@given(pose=poses, dropped=st.sets(st.sampled_from(list(K)), max_size=34))
+def test_a_report_can_always_be_built_however_much_is_missing(
+    pose: dict[str, Any], dropped: set[K]
+) -> None:
+    """Degradation must be quiet at the boundary and loud in the report, never an exception.
+
+    The legacy engine's answer to missing data was a swallowed exception and a `None` that its
+    caller rendered as good posture. The answer here is a report full of gaps — which is the
+    correct assessment of a photograph of an empty chair, and is not a crash.
+    """
+    landmarks = make_pose(**pose, omit=tuple(dropped))
+    report = build_report(
+        PoseFrame(
+            landmarks=landmarks,
+            image_width=640,
+            image_height=480,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        T,
+    )
+
+    assert report.quality.assessed + len(report.quality.gaps) == report.quality.total
+    # A metric never claims a value it could not compute, whatever was thrown away.
+    for metric in report.metrics.values():
+        assert metric.is_ok == (metric.value is not None)
+
+
+@SETTINGS
+@given(
+    pose=poses,
+    visibilities=st.lists(st.floats(0.0, 1.0), min_size=34, max_size=34),
+)
+def test_a_report_can_always_be_built_however_unconfident_the_landmarks(
+    pose: dict[str, Any], visibilities: list[float]
+) -> None:
+    """The other half of degradation: everything present, nothing trustworthy."""
+    confidence = {
+        name: (visibility, 0.9)
+        for name, visibility in zip(sorted(K, key=str), visibilities, strict=True)
+    }
+    report = build_report(
+        PoseFrame(
+            landmarks=make_pose(**pose, confidence=confidence),
+            image_width=640,
+            image_height=480,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        T,
+    )
+    for finding in report.findings:
+        assert 0.0 <= finding.confidence <= 1.0
+    assert report.overall_score is None or 0.0 <= report.overall_score <= 100.0
+
+
+@SETTINGS
+@given(pose=poses)
+def test_the_same_pose_always_produces_the_same_report(pose: dict[str, Any]) -> None:
+    """Determinism over the whole input space, not just the examples someone chose.
+
+    Everything downstream that compares two reports — the history trend, the golden corpus, the
+    cross-language check against the TypeScript mirror — is meaningless without this.
+    """
+    landmarks = make_pose(**pose)
+    first = build_report(
+        PoseFrame(
+            landmarks=landmarks,
+            image_width=640,
+            image_height=480,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        T,
+    ).to_dict()
+    second = build_report(
+        PoseFrame(
+            landmarks=landmarks,
+            image_width=640,
+            image_height=480,
+            backend="synthetic",
+            inference_ms=0.0,
+        ),
+        T,
+    ).to_dict()
+    assert first == second

--- a/packages/posture-core/tests/test_properties.py
+++ b/packages/posture-core/tests/test_properties.py
@@ -18,7 +18,7 @@ a report, never a traceback and never a `None` the caller has to interpret.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Final
 
 import pytest
 from hypothesis import HealthCheck, given, settings
@@ -69,6 +69,12 @@ poses = st.fixed_dictionaries(
 scales = st.floats(0.3, 3.0)
 
 frame_sizes = st.tuples(st.integers(240, 4000), st.integers(240, 4000))
+
+# Derived, not written down. `KeypointName` is the source of truth for how many landmarks exist,
+# and a literal here would silently stop covering the new one the day a keypoint is added — the
+# visibility strategy below zips against every name with `strict=True`, so it would fail loudly,
+# but the drop strategy would just quietly stop being able to drop everything.
+KEYPOINT_COUNT: Final = len(K)
 
 SETTINGS = settings(
     max_examples=200,
@@ -172,9 +178,22 @@ def test_every_angular_metric_is_invariant_to_frame_size_and_aspect_ratio(
 
 
 @SETTINGS
-@given(pose=poses, offset=st.tuples(st.floats(-2.0, 2.0), st.floats(-2.0, 2.0)))
+@given(
+    pose=poses,
+    offset=st.tuples(
+        st.floats(-2.0, 2.0),
+        st.floats(-2.0, 2.0),
+        # Depth too, not just the image plane. Checked rather than assumed: perturbing `z_world`
+        # alone moves `craniovertebral_angle_deg` (50.0° to 66.3°) and `knee_flexion_deg` (100.0°
+        # to 96.4°), so an x/y-only offset was exercising two axes out of three on metrics that
+        # genuinely read the third. `trunk_inclination_deg` is the exception and correctly so —
+        # depth is its *lateral* axis once the facing direction is resolved, so a sideways shift
+        # should not change a forward lean.
+        st.floats(-2.0, 2.0),
+    ),
+)
 def test_every_angular_metric_is_invariant_to_where_the_subject_stands(
-    pose: dict[str, Any], offset: tuple[float, float]
+    pose: dict[str, Any], offset: tuple[float, float, float]
 ) -> None:
     """Translation invariance, applied in world space where the metrics actually work.
 
@@ -183,7 +202,7 @@ def test_every_angular_metric_is_invariant_to_where_the_subject_stands(
     world coordinate by a constant simulates a backend that did *not* re-origin, and the angles
     must not care.
     """
-    dx, dy = offset
+    dx, dy, dz = offset
     original = make_pose(**pose)
     shifted = {
         name: Landmark(
@@ -193,7 +212,7 @@ def test_every_angular_metric_is_invariant_to_where_the_subject_stands(
             presence=landmark.presence,
             x_world=None if landmark.x_world is None else landmark.x_world + dx,
             y_world=None if landmark.y_world is None else landmark.y_world + dy,
-            z_world=landmark.z_world,
+            z_world=None if landmark.z_world is None else landmark.z_world + dz,
         )
         for name, landmark in original.items()
     }
@@ -202,6 +221,11 @@ def test_every_angular_metric_is_invariant_to_where_the_subject_stands(
     moved = angular_values(shifted)
     for name, value in baseline.items():
         other = moved[name]
+        # Availability first, as the scale and frame-size properties already do. Comparing only
+        # when both sides produced a number would pass a translation that changed whether a metric
+        # can be computed at all — a bigger regression than one that changes its value, and the
+        # one this loop was silently exempting.
+        assert (value is None) == (other is None), f"{name} changed availability under translation"
         if value is not None and other is not None:
             assert other == pytest.approx(value, abs=1e-6), f"{name} moved under translation"
 
@@ -216,6 +240,7 @@ def test_the_view_ratio_is_invariant_to_body_size(pose: dict[str, Any], scale: f
     """
     baseline = view_confidence(resolver_for(make_pose(**pose)), T).value
     scaled = view_confidence(resolver_for(make_pose(**pose, body=scaled_body(scale))), T).value
+    assert (baseline is None) == (scaled is None), "resizing the body changed availability"
     if baseline is not None and scaled is not None:
         assert scaled == pytest.approx(baseline, abs=1e-6)
 
@@ -226,7 +251,7 @@ def test_the_view_ratio_is_invariant_to_body_size(pose: dict[str, Any], scale: f
 
 
 @SETTINGS
-@given(pose=poses, dropped=st.sets(st.sampled_from(list(K)), max_size=34))
+@given(pose=poses, dropped=st.sets(st.sampled_from(list(K)), max_size=KEYPOINT_COUNT))
 def test_a_report_can_always_be_built_however_much_is_missing(
     pose: dict[str, Any], dropped: set[K]
 ) -> None:
@@ -257,7 +282,7 @@ def test_a_report_can_always_be_built_however_much_is_missing(
 @SETTINGS
 @given(
     pose=poses,
-    visibilities=st.lists(st.floats(0.0, 1.0), min_size=34, max_size=34),
+    visibilities=st.lists(st.floats(0.0, 1.0), min_size=KEYPOINT_COUNT, max_size=KEYPOINT_COUNT),
 )
 def test_a_report_can_always_be_built_however_unconfident_the_landmarks(
     pose: dict[str, Any], visibilities: list[float]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,10 @@ pose-backends = { workspace = true }
 # Installed into the workspace environment for local development and CI.
 [dependency-groups]
 dev = [
+    # Property-based testing (OP-34). The scale-invariance property is the proof that the redesign
+    # fixed the original engine's central defect, and a handful of hand-picked examples would not
+    # be proof of anything.
+    "hypothesis>=6.100",
     "mypy>=1.14",
     "pytest>=8.3",
     "pytest-asyncio>=0.25",

--- a/uv.lock
+++ b/uv.lock
@@ -425,6 +425,71 @@ wheels = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.161.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "sortedcontainers" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2c/2a/f082741a0aa60e2729c8afed2f0c8717aa74648b1ca15ff553516548d262/hypothesis-6.161.6.tar.gz", hash = "sha256:e276f5705cb929ff059785db8fd3a5074c9081529944833a0a4b4f6b9b9303dd", size = 487491, upload-time = "2026-07-27T05:33:24.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6a/59/0b6670cdeea0de95d9b80a22877e8ac9fdc78d48f92fc4bd774f14528017/hypothesis-6.161.6-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a7933cf957fa95ed311be348beb6ebab9a80e4fbcd665bdfdfc82d28703967d8", size = 767824, upload-time = "2026-07-27T05:32:09.953Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/ed/b74f9035406917eebf0bbac4fd075478457fd63e9a610cda7ac5c41ae24f/hypothesis-6.161.6-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:39564c86891a731872d5a2fffa76788ee24cf57dc713d8d140382487f4afc4f4", size = 763367, upload-time = "2026-07-27T05:32:07.164Z" },
+    { url = "https://files.pythonhosted.org/packages/94/76/9b406c3c0fc4596ce46d87e5f7e9dc0751550af3425287472e1decff024b/hypothesis-6.161.6-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:428951eb9e755d5d061fe110313cd6c625184cb8b1cbe2cd781b117aaf02d3a7", size = 1092657, upload-time = "2026-07-27T05:32:04.657Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/96/d10f48cc40b9a6091d460c9a7597f6e2e28a7eab1e794feffdd5d5ee5df1/hypothesis-6.161.6-cp310-abi3-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c0eee4d6609b0245fb6343c600794387d780d41f298b2120869930adb10b22bf", size = 1121225, upload-time = "2026-07-27T05:32:39.111Z" },
+    { url = "https://files.pythonhosted.org/packages/d6/6f/d79b488b8e5f25f01a66ae91d3bb7d50df988eddb5a9cfd34656f946888f/hypothesis-6.161.6-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bedf9019cac5272b0c08542e56a124841121368d084cb6f840d0d97fd2dd73c0", size = 1142152, upload-time = "2026-07-27T05:32:24.288Z" },
+    { url = "https://files.pythonhosted.org/packages/50/ed/fe23766d0f884582e8b4e55cfd58ac5560f4df11ca8b8daaa2ac271060e8/hypothesis-6.161.6-cp310-abi3-manylinux_2_31_riscv64.whl", hash = "sha256:f94c1189c8b4e42a3fa28e89df4fa5b5dfe9289e7aa50381443e459ac003d8ea", size = 1097466, upload-time = "2026-07-27T05:32:15.201Z" },
+    { url = "https://files.pythonhosted.org/packages/72/6a/f05dc0b558a05cc5da691a54a75870232425e16b57ec7e7f095387af9668/hypothesis-6.161.6-cp310-abi3-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:3ce10197c57f7efd7bf49509d24a4154f2a0e01a9758b57cef1523e289c4858d", size = 1134196, upload-time = "2026-07-27T05:32:44.109Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/b0/f43c5f503b5c73776428a37e90c90b5b0a607f275a18b2822ce52618ffdf/hypothesis-6.161.6-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c40f0aed8e8037a5ea4fa9486ea98c0ec3a007419bd7b3dbe14712a3632e028b", size = 1266502, upload-time = "2026-07-27T05:32:42.527Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/2a/bb563f9718ac5bf98ef6dbb566fb1d5fae9fd23829ed320fc4c84c4b5985/hypothesis-6.161.6-cp310-abi3-musllinux_1_2_armv7l.whl", hash = "sha256:fc96ba21133e95a01ab56486b91f83f1e5609ffe55f17618d732cbb29dcb8863", size = 1394242, upload-time = "2026-07-27T05:32:13.435Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/26/6dd5a85e9d3556074ebb3988f5bddb3bf52532b2a2bd10ea2a8421a0f852/hypothesis-6.161.6-cp310-abi3-musllinux_1_2_riscv64.whl", hash = "sha256:4fad1cb8f49b453890dd5768e14c79e9f6cc8079f1f474e3b9027956985ab2c9", size = 1267017, upload-time = "2026-07-27T05:32:11.746Z" },
+    { url = "https://files.pythonhosted.org/packages/26/34/a6cde6774c815bcc98648a17f1ed461345212bcee4492d8c6b0ee72282cf/hypothesis-6.161.6-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7478ba09770f49c160ffbd22b4bbf7d886ac309653fa7116b5edd65e53536b8d", size = 1309114, upload-time = "2026-07-27T05:32:25.889Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/b2/4178fe71ee42c383ab669f345e1841a7b880a8fe84e498e78cffdaac87d3/hypothesis-6.161.6-cp310-abi3-win32.whl", hash = "sha256:7e4cc1073644a1b468f46252cc4f135eb51c59d79dbc08acfcd6b4ac290a9ffc", size = 653673, upload-time = "2026-07-27T05:32:01.864Z" },
+    { url = "https://files.pythonhosted.org/packages/48/fe/2d91b2e7e06e9737450d7e3fcf09d7efa0c66e57767babc0016ed56cd174/hypothesis-6.161.6-cp310-abi3-win_amd64.whl", hash = "sha256:4a40098bc9c863c2013efb7f9b02f22721e971f795305f24934874a3135e77ef", size = 659826, upload-time = "2026-07-27T05:32:16.609Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/78/78d6743e3a4c425412986e1c2595a1fb6f3024cfa61afdd77385d357ee12/hypothesis-6.161.6-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:959a0db6f42fe01faf393646876ce43f736fb3c0162dbfafd4f4de21bd4aa6c8", size = 768298, upload-time = "2026-07-27T05:32:59.534Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/b6/5f05dbc91523f4e6f8b0da75960318faf8287b38298af2b62f1bc5772fcb/hypothesis-6.161.6-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:081a740171bf5bb3cacf2ee2f895803a3d0e6a9709722e0681ed919c724aaf6c", size = 764079, upload-time = "2026-07-27T05:32:22.777Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/43/c9027d8029162069afec7fbdef240b6770f7ed7e086a771ba2b8a5c103d6/hypothesis-6.161.6-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:359eb0d8bd7c6d2a63ac765fc0b6e0d73bfad9a06aef98ad0f7b2619c17ee8fe", size = 1092970, upload-time = "2026-07-27T05:32:29.116Z" },
+    { url = "https://files.pythonhosted.org/packages/04/86/67bf5f444896334dae1b3d52203f573864f2cf7c55400a33b5da3b51e589/hypothesis-6.161.6-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6bbd0a83fc79cb317230bc9122755035a64505071d1e0599e9dfd6371e4ebdb3", size = 1142431, upload-time = "2026-07-27T05:32:18.082Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/a8/b86778a6945c69c067a46329d1680aecf3c0eb85e00be82444319e2500bd/hypothesis-6.161.6-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:b76dd9bfca6ac3baed9996b20a12c84058f7c17e5802636939c13ed9b3664f4d", size = 1266744, upload-time = "2026-07-27T05:31:46.283Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/b3/3b8a6eb0e78a52efc902a4927d7207d2f9478b70658ad4e38f861d1441df/hypothesis-6.161.6-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:2af997b980ddad5cb8a6d13bd48fcae35f4211e339ff5bb48abe2754d75918b8", size = 1309396, upload-time = "2026-07-27T05:32:53.204Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/3d/89a5dc081cdbb6966aa14c8320d74bf2fdce6ac52f27a5c62c2645c762dd/hypothesis-6.161.6-cp311-cp311-win_amd64.whl", hash = "sha256:b9321091368ff8e7955f2178b9df3bf2f1e4dd8d360c173a9414c9d27ed697f4", size = 659521, upload-time = "2026-07-27T05:31:55.117Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/f8/bafca1b91c225d7905d6d2d20882f79591925288c5ca0c6aed4c23e0c421/hypothesis-6.161.6-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:96c325113320f3fc50ed889a20114b9e317145a66c19544dbd071ba173328690", size = 769412, upload-time = "2026-07-27T05:32:03.332Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/2f/89c48ddfb0bf79cd47ec94d30673ebed554c946816f407bd3c79321e2397/hypothesis-6.161.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ff4e786eb37ef81dd6f78f0238ec787217dbcdb00ccc565c14eee22c676677ba", size = 760979, upload-time = "2026-07-27T05:32:35.558Z" },
+    { url = "https://files.pythonhosted.org/packages/00/23/f2fee896448d5d480d3de7d94f8aad2c1c8a0961575d054547f7f81d681d/hypothesis-6.161.6-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:36bd6e336f4a0b259311860306674e83175b56650bd1a54aaa6bb1c878accf03", size = 1091422, upload-time = "2026-07-27T05:31:59.292Z" },
+    { url = "https://files.pythonhosted.org/packages/97/92/1f5ac80a195a14837a041ef7232a9760fca52720edea27f543e17a38c9eb/hypothesis-6.161.6-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ce64858eaef339a487c4e7ac1cb8898412a36d06a7872bc44af239a7ab5c2ffd", size = 1141456, upload-time = "2026-07-27T05:33:11.802Z" },
+    { url = "https://files.pythonhosted.org/packages/98/38/6c4025549e071e315ab97175a159b5e261afec1cca7d9d4f9cb1c32ef120/hypothesis-6.161.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:0323be2fca0754dff630fe1d719d5876c93c5e3be9678ae6fe8557bf689b5868", size = 1264180, upload-time = "2026-07-27T05:31:50.92Z" },
+    { url = "https://files.pythonhosted.org/packages/80/37/b31de9ba2fc908529b18a1e386d8167a39883fcab938107b3ee2de02872b/hypothesis-6.161.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:18fff0ca1d5dded13c56f430d377bc6585327bb4b987fcf8e37676633569b48c", size = 1308460, upload-time = "2026-07-27T05:32:45.915Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b3/795860dc3817f4cf0bbbcd4ecfba307a77dcc0e85e2d601765364f4989bb/hypothesis-6.161.6-cp312-cp312-win_amd64.whl", hash = "sha256:16da70ffe8507307bd8cea7f2ecdcb7bda1d1980412213ad55571044ba53300f", size = 656950, upload-time = "2026-07-27T05:32:05.965Z" },
+    { url = "https://files.pythonhosted.org/packages/09/65/143d649a444037afec0b52aac0b85c16ac0ca99c454f6f8bcbe7202180f1/hypothesis-6.161.6-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:53e279433bba79a30ec299d281572ca1533309986ed7e1992f9b1c300cbc9173", size = 769306, upload-time = "2026-07-27T05:31:52.397Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/cf/7ec64020028051d76160d1e23ec4e2d00ca7772bb387c0a85dc399f38b5b/hypothesis-6.161.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:17bec7179accef79e7bfaed5c68e312a8b440aaf8423e9a67289f8804517ec32", size = 760943, upload-time = "2026-07-27T05:32:57.945Z" },
+    { url = "https://files.pythonhosted.org/packages/de/27/2a79199aa9714f786ad9a522dfffb022e8571339fe392f0af5337f40e4f1/hypothesis-6.161.6-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:badae92f9fe82a882d0e33f48079fdab760fb1c16ac0be282234c0eb89de9f18", size = 1091338, upload-time = "2026-07-27T05:33:22.896Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/5db65f078b00472f69df015c4ebefd5c78da70e633b0563a1ccec39443fa/hypothesis-6.161.6-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b54632d679dc00079ee4aa458131ed58776abb98d96ef27919777ac06b363944", size = 1141284, upload-time = "2026-07-27T05:32:30.926Z" },
+    { url = "https://files.pythonhosted.org/packages/78/e6/05f320f26ff4dd3994e2afed775d0399b348999d554b142ccfaa72ff1d60/hypothesis-6.161.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fdad7dfa87d62ffbbeb89197cfd734285275576f8d8106bcd72696446202c0fc", size = 1264201, upload-time = "2026-07-27T05:31:48.378Z" },
+    { url = "https://files.pythonhosted.org/packages/51/9b/7826008f4e0baff43da6f38d897c5a8c6e16dafed4f12cee52ead0e2f936/hypothesis-6.161.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:a06a6d62efec24bd196ff47dc4dd95c0714e23e870b7f9e2ef2f4429525760ee", size = 1308183, upload-time = "2026-07-27T05:32:32.625Z" },
+    { url = "https://files.pythonhosted.org/packages/44/47/0e2a6179a3c2173acf15de897f6b144d0e22657fbbf38e561a7f0f236ce5/hypothesis-6.161.6-cp313-cp313-win_amd64.whl", hash = "sha256:662221ad5961cf746626ca024b1b52474f2debf892bbac2af978aad4f5e2bfbf", size = 656916, upload-time = "2026-07-27T05:32:34.077Z" },
+    { url = "https://files.pythonhosted.org/packages/74/32/1b7c11d7b293928078aba04a363f6d51c530d89b470c146b1040ae2f94aa/hypothesis-6.161.6-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:ecf98cf996b82ca46efa3eebe151c6721c1109df50d34aeb73ad8477d7b85363", size = 769519, upload-time = "2026-07-27T05:32:40.75Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/c4/fcaac023585da73fca407932bd11afeaeb0bfd1da174da8ec4225761c8e5/hypothesis-6.161.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fc11a56f2b4931ecf25ce578c535c9f6448ed60f112dce9eae09fb0b0d655db1", size = 761082, upload-time = "2026-07-27T05:33:17.442Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/41/563549e4f82c360973a38909018bb4b8e46465bb00d4b5b686509df01d8d/hypothesis-6.161.6-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:16c2af82180b08fa843b699db7f2b7d0ba9b62fd1e21fb8dd646bb96a16fd352", size = 1091840, upload-time = "2026-07-27T05:32:47.818Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/2a/46b5f0a3b46959ced231ff78ea941483f2f571473d6f249c6438967510df/hypothesis-6.161.6-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:332e8a7b99fa69a2675a726f5136e68545b9e84e0ff744679b14accf62ed2b5d", size = 1141464, upload-time = "2026-07-27T05:33:10.127Z" },
+    { url = "https://files.pythonhosted.org/packages/33/25/77c3052c0fcedd2a19bffd7b2b44ea93dac73bd62f1d8b03420d3ac55ee2/hypothesis-6.161.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:160f49f1b7e54e50a3ab67e9772b15df5085ec0f8e624e9acaf66dbaf8422f6e", size = 1264629, upload-time = "2026-07-27T05:33:20.984Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/06a54d1be5468089c9688a6f7e3f3e9c65eb24d0046896d9646cfa4ebce9/hypothesis-6.161.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7712075d545604a728007ea085fa10acd785713d6e54c8702dbc0b5bed6d2175", size = 1308485, upload-time = "2026-07-27T05:33:08.227Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/8e/8e4688ee36c16502aa09b3d2d771f7413b9d9124448c3483b996228fa110/hypothesis-6.161.6-cp314-cp314-pyemscripten_2026_0_wasm32.whl", hash = "sha256:8da289ff744e6225feb222f6d8ece08d77324cbabe2357ab7067632c0c06a359", size = 601010, upload-time = "2026-07-27T05:33:13.62Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/2f/1f8451e2f1c18f34a5fad71610887eb81451d09658555c2de1470689ca47/hypothesis-6.161.6-cp314-cp314-win_amd64.whl", hash = "sha256:61ae780388292510ea303f0d79154a4623e8e0c00c49ba981329ec111800bd7c", size = 656829, upload-time = "2026-07-27T05:33:15.325Z" },
+    { url = "https://files.pythonhosted.org/packages/86/ef/9da7f06a693f0fb0c51c51e843c37210492a03c330699f000d007f505452/hypothesis-6.161.6-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:6fc0cd5490f69202a8608aa3c3085078c598117049672c6173c4eb8cdfff8b26", size = 768102, upload-time = "2026-07-27T05:31:53.708Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/80/c26463bbacbe3caa1567a3121be328ee2ae16a91b5cded6f79edbe3e192c/hypothesis-6.161.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e692d51542664b3d431fe835ada7d37630764e7542150bfa987346b03b3b00a1", size = 759547, upload-time = "2026-07-27T05:31:49.746Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/4c926dc8bc4d7c6df7a0321a291dcfcc214665f34a9a073165e9fdbadf75/hypothesis-6.161.6-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:225b51e0ea315cb70eaee0e0d6506bc5452f1b3f08f48c48953dd2afea006491", size = 1090434, upload-time = "2026-07-27T05:33:02.965Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/3c/cc7d2f675b7c44179ba3d343b5fa6b07627365bdc2f0d8c014be5448b85a/hypothesis-6.161.6-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2efac2635c2a690b2afe84e94fceed8c4d3c219fa806340e73fc8f26233dc801", size = 1140375, upload-time = "2026-07-27T05:32:19.866Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/f4/662cb8b5ae2a5f92c12892f3654a2c59ce73c25adbacddc6876336c33876/hypothesis-6.161.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:ac13ee5963380f63f9ffe2de47b7b489a09f8a1e2701e9c816476ff52405ed71", size = 1262843, upload-time = "2026-07-27T05:32:27.546Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/49/ee44c0aec2ae4f2e3024c44893b6fa2761cacd4d3b08a3223ea1a1ba8779/hypothesis-6.161.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:47ff47cff1fc4b704b805c255bc7c3c64e2c3f7eebdc1bc4c4155df8621cbab3", size = 1307243, upload-time = "2026-07-27T05:32:00.696Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4b/725d3eef7be39fb2957eab63ded9c2d338b3ffb52140ec77c449f193fa41/hypothesis-6.161.6-cp314-cp314t-win_amd64.whl", hash = "sha256:981fa76521dd82a05e8749182404f675d3e0ad0b84566c558c8c45d7a8fb70fc", size = 656980, upload-time = "2026-07-27T05:33:01.104Z" },
+    { url = "https://files.pythonhosted.org/packages/79/9d/ab53e1be2074ccf42bea03eb97a8ed7e50da392a7ab841e294d9894877b5/hypothesis-6.161.6-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:3a890919b3c93aab5d7fbc945d25e16100bd3cf58acfba54664f4f7b2023f4c1", size = 769226, upload-time = "2026-07-27T05:32:08.384Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/75/8a08176ef2a44d012490e31315cdad34884c5f157d65e38da9336ca43284/hypothesis-6.161.6-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:f8e3d3c0820b8a71a4804f92e3d2667db2d013c6285e467ac0e098927243e14a", size = 765073, upload-time = "2026-07-27T05:33:19.285Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/19/38c24c5011a3825ee27124e742c681ade72cfdbb4500c0afa1e9e1fc485b/hypothesis-6.161.6-pp311-pypy311_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e5eb2a65d803da165ca5faa01ca07d2c47aa41e0a4de7d14b3c74f478f38241a", size = 1093943, upload-time = "2026-07-27T05:32:51.38Z" },
+    { url = "https://files.pythonhosted.org/packages/25/72/918c964e22d94c78fc0594a06d8077a469e28dcc2f5ede45a703df72f36d/hypothesis-6.161.6-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0b2a58004ed367961bfce1703bee591221d94e28ad8ac15a57f0eecabbe659ac", size = 1143728, upload-time = "2026-07-27T05:32:37.309Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/0c/395637e3bcb374f1b513000d2de2690236acbeb2baf33b4b8446155072a5/hypothesis-6.161.6-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:91bccc94514b865604079a2f5187f02a8e6e855c78ae2127b7fe2e7929a47949", size = 660621, upload-time = "2026-07-27T05:32:54.84Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -877,6 +942,7 @@ source = { virtual = "." }
 
 [package.dev-dependencies]
 dev = [
+    { name = "hypothesis" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -888,6 +954,7 @@ dev = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "hypothesis", specifier = ">=6.100" },
     { name = "mypy", specifier = ">=1.14" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.25" },
@@ -1311,6 +1378,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594, upload-time = "2021-05-16T22:03:42.897Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575, upload-time = "2021-05-16T22:03:41.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
This pull request introduces comprehensive property-based tests to the `posture-core` package to rigorously verify the correctness and robustness of the redesigned posture analysis engine. The new tests use the `hypothesis` library to ensure that the engine's metrics are invariant to body size, image frame size, and subject position, and that the report generation is robust against missing or low-confidence data. Additionally, `hypothesis` is added as a development dependency.

**Testing improvements and verification of invariants:**

* Added `test_properties.py` with property-based tests that prove the engine's angular metrics are invariant to body size, image frame size, and subject translation, using `hypothesis` to generate a wide range of test cases. This directly verifies that the redesign fixed the original scale-dependence defect.
* Added property-based tests to guarantee that the `build_report` function never raises exceptions, even with missing or low-confidence landmarks, and always produces a deterministic report for the same input.

**Dependency updates:**

* Added the `hypothesis` library to the development dependencies in `pyproject.toml` to enable property-based testing.