### PR TITLE
OP-35: Boundary, degradation and golden-snapshot tests

### DIFF
--- a/packages/posture-core/tests/golden/arms_folded.json
+++ b/packages/posture-core/tests/golden/arms_folded.json
@@ -1,0 +1,79 @@
+{
+  "backend": "synthetic",
+  "findings": [
+    {
+      "code": "arms_folded",
+      "confidence": 0.95,
+      "message": "Your arms are folded across your chest. That is not a fault in itself, but it often accompanies a rounded upper back.",
+      "metric": "arms_crossed",
+      "severity": "info",
+      "value": 0.4437
+    }
+  ],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are folded across your chest",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.4437
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is balanced over your shoulders (craniovertebral angle 74°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 74.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 104°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 104.0285
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "knees are at a comfortable seated angle (100°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 100.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "upright, within 8° of vertical",
+      "status": "ok",
+      "unit": "deg",
+      "value": 8.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 100.0,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/arms_folded.json
+++ b/packages/posture-core/tests/golden/arms_folded.json
@@ -46,7 +46,7 @@
     },
     "knee_flexion_deg": {
       "confidence": 0.95,
-      "detail": "knees are at a comfortable seated angle (100°)",
+      "detail": "your left knee is at a comfortable seated angle (100°)",
       "status": "ok",
       "unit": "deg",
       "value": 100.0

--- a/packages/posture-core/tests/golden/frontal_view.json
+++ b/packages/posture-core/tests/golden/frontal_view.json
@@ -1,0 +1,95 @@
+{
+  "backend": "synthetic",
+  "findings": [
+    {
+      "code": "trunk_slouch",
+      "confidence": 0.38,
+      "message": "Your torso is leaning 30° forward. Try bringing your hips back into the chair so your back is supported.",
+      "metric": "trunk_inclination_deg",
+      "severity": "major",
+      "value": 30.0
+    },
+    {
+      "code": "forward_head",
+      "confidence": 0.38,
+      "message": "Your head sits well forward of your shoulders (craniovertebral angle 35°, below the 50° mark). Drawing your chin back over your shoulders takes the load off your neck.",
+      "metric": "craniovertebral_angle_deg",
+      "severity": "major",
+      "value": 35.0
+    },
+    {
+      "code": "frontal_view",
+      "confidence": 0.95,
+      "message": "This photo looks like it was taken from the front. The measurements below still work, but they rest on a depth estimate that is weakest along the camera's own axis — a side-on photo would give a firmer answer.",
+      "metric": "view_confidence",
+      "severity": "info",
+      "value": 0.8776
+    }
+  ],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is well forward of your shoulders (craniovertebral angle 35°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 35.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 115°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 115.0
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "knees are at a comfortable seated angle (100°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 100.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "leaning 30° forward — a pronounced slouch",
+      "status": "ok",
+      "unit": "deg",
+      "value": 30.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the front — forward lean is measurable but less reliable here, so a side-on photo would give a firmer answer",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.8776
+    }
+  },
+  "overall_score": 70.0,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/frontal_view.json
+++ b/packages/posture-core/tests/golden/frontal_view.json
@@ -62,7 +62,7 @@
     },
     "knee_flexion_deg": {
       "confidence": 0.95,
-      "detail": "knees are at a comfortable seated angle (100°)",
+      "detail": "your left knee is at a comfortable seated angle (100°)",
       "status": "ok",
       "unit": "deg",
       "value": 100.0

--- a/packages/posture-core/tests/golden/hunchback.json
+++ b/packages/posture-core/tests/golden/hunchback.json
@@ -54,7 +54,7 @@
     },
     "knee_flexion_deg": {
       "confidence": 0.95,
-      "detail": "knees are at a comfortable seated angle (100°)",
+      "detail": "your left knee is at a comfortable seated angle (100°)",
       "status": "ok",
       "unit": "deg",
       "value": 100.0

--- a/packages/posture-core/tests/golden/hunchback.json
+++ b/packages/posture-core/tests/golden/hunchback.json
@@ -1,0 +1,87 @@
+{
+  "backend": "synthetic",
+  "findings": [
+    {
+      "code": "trunk_slouch",
+      "confidence": 0.95,
+      "message": "Your torso is leaning 32° forward. Try bringing your hips back into the chair so your back is supported.",
+      "metric": "trunk_inclination_deg",
+      "severity": "major",
+      "value": 32.0
+    },
+    {
+      "code": "forward_head",
+      "confidence": 0.95,
+      "message": "Your head sits well forward of your shoulders (craniovertebral angle 28°, below the 50° mark). Drawing your chin back over your shoulders takes the load off your neck.",
+      "metric": "craniovertebral_angle_deg",
+      "severity": "major",
+      "value": 28.0
+    }
+  ],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is well forward of your shoulders (craniovertebral angle 28°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 28.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 115°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 115.0
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "knees are at a comfortable seated angle (100°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 100.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "leaning 32° forward — a pronounced slouch",
+      "status": "ok",
+      "unit": "deg",
+      "value": 32.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 70.0,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/kneeling.json
+++ b/packages/posture-core/tests/golden/kneeling.json
@@ -1,0 +1,79 @@
+{
+  "backend": "synthetic",
+  "findings": [
+    {
+      "code": "kneeling",
+      "confidence": 0.95,
+      "message": "You appear to be kneeling — your knee is folded to 30°.",
+      "metric": "knee_flexion_deg",
+      "severity": "info",
+      "value": 30.0
+    }
+  ],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is balanced over your shoulders (craniovertebral angle 79°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 79.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is fairly straight, at 168°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 168.0
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left knee is folded to 30° — you appear to be kneeling",
+      "status": "ok",
+      "unit": "deg",
+      "value": 30.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "upright, within 5° of vertical",
+      "status": "ok",
+      "unit": "deg",
+      "value": 5.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 100.0,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/partial_occlusion.json
+++ b/packages/posture-core/tests/golden/partial_occlusion.json
@@ -1,0 +1,102 @@
+{
+  "backend": "synthetic",
+  "findings": [],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is balanced over your shoulders (craniovertebral angle 70°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 70.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 114°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 114.0
+    },
+    "heel_contact_m": {
+      "confidence": null,
+      "detail": "could not see left foot index, left heel, right foot index and right heel in the photo",
+      "status": "insufficient_keypoints",
+      "unit": "m",
+      "value": null
+    },
+    "knee_flexion_deg": {
+      "confidence": null,
+      "detail": "could not see left ankle, left knee, right ankle and right knee in the photo",
+      "status": "insufficient_keypoints",
+      "unit": "deg",
+      "value": null
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "upright, within 8° of vertical",
+      "status": "ok",
+      "unit": "deg",
+      "value": 8.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 100.0,
+  "quality": {
+    "assessed": 5,
+    "coverage": 0.714,
+    "gaps": [
+      {
+        "detail": "could not see left ankle, left knee, right ankle and right knee in the photo",
+        "keypoints": {
+          "left_ankle": "not_detected",
+          "left_knee": "not_detected",
+          "right_ankle": "not_detected",
+          "right_knee": "not_detected"
+        },
+        "metric": "knee_flexion_deg",
+        "status": "insufficient_keypoints"
+      },
+      {
+        "detail": "could not see left foot index, left heel, right foot index and right heel in the photo",
+        "keypoints": {
+          "left_foot_index": "not_detected",
+          "left_heel": "not_detected",
+          "right_foot_index": "not_detected",
+          "right_heel": "not_detected"
+        },
+        "metric": "heel_contact_m",
+        "status": "insufficient_keypoints"
+      }
+    ],
+    "keypoints": {
+      "left_ankle": "not_detected",
+      "left_foot_index": "not_detected",
+      "left_heel": "not_detected",
+      "left_knee": "not_detected",
+      "right_ankle": "not_detected",
+      "right_foot_index": "not_detected",
+      "right_heel": "not_detected",
+      "right_knee": "not_detected"
+    },
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/reclined.json
+++ b/packages/posture-core/tests/golden/reclined.json
@@ -46,7 +46,7 @@
     },
     "knee_flexion_deg": {
       "confidence": 0.95,
-      "detail": "knees are at a comfortable seated angle (100°)",
+      "detail": "your left knee is at a comfortable seated angle (100°)",
       "status": "ok",
       "unit": "deg",
       "value": 100.0

--- a/packages/posture-core/tests/golden/reclined.json
+++ b/packages/posture-core/tests/golden/reclined.json
@@ -1,0 +1,79 @@
+{
+  "backend": "synthetic",
+  "findings": [
+    {
+      "code": "trunk_recline",
+      "confidence": 0.95,
+      "message": "You are leaning 25° back. That is fine if the chair supports your back, and not if you are perched on the edge of the seat.",
+      "metric": "trunk_inclination_deg",
+      "severity": "minor",
+      "value": -25.0
+    }
+  ],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is balanced over your shoulders (craniovertebral angle 105°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 105.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 115°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 115.0
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "knees are at a comfortable seated angle (100°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 100.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "leaning 25° back",
+      "status": "ok",
+      "unit": "deg",
+      "value": -25.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 92.5,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/straight.json
+++ b/packages/posture-core/tests/golden/straight.json
@@ -1,0 +1,70 @@
+{
+  "backend": "synthetic",
+  "findings": [],
+  "image": {
+    "height": 480,
+    "width": 640
+  },
+  "inference_ms": 0.0,
+  "metrics": {
+    "arms_crossed": {
+      "confidence": 0.95,
+      "detail": "arms are not folded",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.9323
+    },
+    "craniovertebral_angle_deg": {
+      "confidence": 0.95,
+      "detail": "head is balanced over your shoulders (craniovertebral angle 82°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 82.0
+    },
+    "elbow_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "your left elbow is bent to 115°",
+      "status": "ok",
+      "unit": "deg",
+      "value": 115.0
+    },
+    "heel_contact_m": {
+      "confidence": 0.95,
+      "detail": "your left foot is flat and supported",
+      "status": "ok",
+      "unit": "m",
+      "value": 0.0
+    },
+    "knee_flexion_deg": {
+      "confidence": 0.95,
+      "detail": "knees are at a comfortable seated angle (100°)",
+      "status": "ok",
+      "unit": "deg",
+      "value": 100.0
+    },
+    "trunk_inclination_deg": {
+      "confidence": 0.95,
+      "detail": "upright, within 3° of vertical",
+      "status": "ok",
+      "unit": "deg",
+      "value": 3.0
+    },
+    "view_confidence": {
+      "confidence": 0.95,
+      "detail": "photographed from the side, which is the best angle for this assessment",
+      "status": "ok",
+      "unit": "ratio",
+      "value": 0.0
+    }
+  },
+  "overall_score": 100.0,
+  "quality": {
+    "assessed": 7,
+    "coverage": 1.0,
+    "gaps": [],
+    "keypoints": {},
+    "total": 7
+  },
+  "rules_version": "1.0.0",
+  "schema_version": "1.0"
+}

--- a/packages/posture-core/tests/golden/straight.json
+++ b/packages/posture-core/tests/golden/straight.json
@@ -37,7 +37,7 @@
     },
     "knee_flexion_deg": {
       "confidence": 0.95,
-      "detail": "knees are at a comfortable seated angle (100°)",
+      "detail": "your left knee is at a comfortable seated angle (100°)",
       "status": "ok",
       "unit": "deg",
       "value": 100.0

--- a/packages/posture-core/tests/regenerate_golden.py
+++ b/packages/posture-core/tests/regenerate_golden.py
@@ -20,6 +20,21 @@ sys.path.insert(0, str(Path(__file__).parent))
 from test_golden import CASES, GOLDEN, report_for, serialise
 
 
+def _display(path: Path) -> str:
+    """A short path when the caller is somewhere above it, the full one otherwise.
+
+    `relative_to` raises rather than falling back, so running this from anywhere that is not an
+    ancestor of the repository — `/tmp`, a sibling checkout, an editor's scratch directory — killed
+    the script partway through with a `ValueError` about subpaths. It had already rewritten some of
+    the snapshots by then, which is the worst moment to stop. Cosmetics should not be able to fail
+    the operation they are describing.
+    """
+    try:
+        return str(path.relative_to(Path.cwd()))
+    except ValueError:
+        return str(path)
+
+
 def main() -> int:
     GOLDEN.mkdir(parents=True, exist_ok=True)
     for name in sorted(CASES):
@@ -27,7 +42,7 @@ def main() -> int:
         content = serialise(report_for(name))
         changed = not path.exists() or path.read_text(encoding="utf-8") != content
         path.write_text(content, encoding="utf-8")
-        print(f"{'updated' if changed else 'unchanged'}  {path.relative_to(Path.cwd())}")
+        print(f"{'updated' if changed else 'unchanged'}  {_display(path)}")
     return 0
 
 

--- a/packages/posture-core/tests/regenerate_golden.py
+++ b/packages/posture-core/tests/regenerate_golden.py
@@ -1,0 +1,35 @@
+"""Regenerate the golden snapshots.
+
+    uv run python packages/posture-core/tests/regenerate_golden.py
+
+Run this deliberately, after a change that is *meant* to alter the reports, and read the resulting
+diff. That diff is the review: a retuned threshold should visibly move confidences and verdicts
+across the corpus, and if it moves something you did not expect, that is the finding.
+
+Deliberately not wired to an environment variable checked by the test run. `UPDATE_GOLDEN=1 pytest`
+is one absent-minded shell history entry away from a green suite that asserts nothing.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+
+from test_golden import CASES, GOLDEN, report_for, serialise
+
+
+def main() -> int:
+    GOLDEN.mkdir(parents=True, exist_ok=True)
+    for name in sorted(CASES):
+        path = GOLDEN / f"{name}.json"
+        content = serialise(report_for(name))
+        changed = not path.exists() or path.read_text(encoding="utf-8") != content
+        path.write_text(content, encoding="utf-8")
+        print(f"{'updated' if changed else 'unchanged'}  {path.relative_to(Path.cwd())}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/posture-core/tests/test_boundaries.py
+++ b/packages/posture-core/tests/test_boundaries.py
@@ -1,0 +1,241 @@
+"""Boundary tests: the behaviour at each threshold, from either side, by an epsilon.
+
+Every rule in this package is a comparison, and a comparison has exactly two ways to be wrong that
+no other test catches: the wrong operator (`<` where `<=` belongs) and the wrong side. Both produce
+entirely plausible output everywhere except within a hair's breadth of the line.
+
+The pattern throughout is the same — construct the figure at `threshold ± epsilon`, assert the
+verdict flips exactly there. Because thresholds are injected rather than global, each case sets
+the value it is testing rather than depending on whatever the defaults happen to be, so retuning a
+default cannot silently invalidate a boundary test.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import Any
+
+import pytest
+from builders import frame, with_thresholds
+
+from posture_core import build_report
+from posture_core.metrics.head import craniovertebral_angle_deg
+from posture_core.metrics.knees import knee_flexion_deg
+from posture_core.metrics.trunk import trunk_inclination_deg
+from posture_core.resolver import KeypointResolver
+from posture_core.rules import evaluate
+from posture_core.status import Metric
+from posture_core.status import Metric as MetricValue
+from posture_core.status import MetricStatus as Status
+from posture_core.thresholds import Thresholds
+
+EPSILON = 1e-3
+"""A thousandth of a degree: far inside any real measurement error, far outside float noise."""
+
+UNITS = {"arms_crossed": "ratio", "heel_contact_m": "m", "view_confidence": "ratio"}
+
+
+def codes_for(thresholds: Thresholds, **values: float) -> set[str]:
+    """Rule verdicts for *exact* metric values, bypassing the geometry pipeline.
+
+    Behaviour **at** a threshold has to be asserted on the comparison itself. Routing an exact
+    value through the builder and the trigonometry does not test what it looks like it tests: a
+    figure constructed at 10.000° measures bit-exact 10.0 on arm64 and fractionally above it on
+    x86_64, so a `>` comparison fires on one architecture and not the other. CI found this; the
+    local suite could not.
+
+    The tests below therefore split in two. Exact-threshold cases call this. Cases an epsilon
+    either side of a threshold go through the full pipeline, where a 1e-3 margin is thousands of
+    times larger than the discrepancy.
+    """
+    metrics = {
+        name: MetricValue(
+            name=name,
+            value=value,
+            unit=UNITS.get(name, "deg"),
+            status=Status.OK,
+            detail="",
+            confidence=0.95,
+        )
+        for name, value in values.items()
+    }
+    return {finding.code for finding in evaluate(metrics, thresholds)}
+
+
+def codes_at(thresholds: Thresholds, **pose: Any) -> set[str]:
+    return {finding.code for finding in build_report(frame(**pose), thresholds).findings}
+
+
+def metric_at(
+    compute: Callable[[KeypointResolver, Thresholds], Metric],
+    thresholds: Thresholds,
+    **pose: Any,
+) -> float:
+    metric = compute(KeypointResolver(frame(**pose), thresholds), thresholds)
+    assert metric.value is not None
+    return float(metric.value)
+
+
+# ---------------------------------------------------------------------------------------------
+# Trunk
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_slouch_threshold_is_inclusive_at_exactly_the_configured_angle() -> None:
+    """`>=`, not `>`.
+
+    A threshold documented as "beyond this is a slouch" that excluded the value itself would leave
+    a one-value hole where the verdict silently drops to the weaker finding.
+    """
+    thresholds = with_thresholds(trunk_upright_deg=10.0, trunk_slouch_deg=20.0)
+    assert "trunk_slouch" in codes_for(thresholds, trunk_inclination_deg=20.0)
+    assert "trunk_slouch" in codes_at(thresholds, trunk_deg=20.0 + EPSILON)
+    assert "trunk_slouch" not in codes_at(thresholds, trunk_deg=20.0 - EPSILON)
+
+
+def test_just_under_the_slouch_line_is_still_reported_as_a_forward_lean() -> None:
+    """The bands must abut with no gap. A posture cannot be neither upright nor leaning."""
+    thresholds = with_thresholds(trunk_upright_deg=10.0, trunk_slouch_deg=20.0)
+    assert "trunk_forward_lean" in codes_at(thresholds, trunk_deg=20.0 - EPSILON)
+
+
+def test_the_upright_band_is_exclusive_at_its_upper_edge() -> None:
+    """Exactly at `trunk_upright_deg` is still neutral: the field is documented as "at or below
+    this is neutral", and an off-by-one here would report a fault for textbook posture."""
+    thresholds = with_thresholds(trunk_upright_deg=10.0, trunk_slouch_deg=20.0)
+    assert codes_for(thresholds, trunk_inclination_deg=10.0) == set()
+    assert "trunk_forward_lean" in codes_at(thresholds, trunk_deg=10.0 + EPSILON)
+
+
+def test_the_recline_threshold_fires_at_exactly_its_configured_angle() -> None:
+    thresholds = with_thresholds(trunk_recline_deg=-20.0)
+    assert "trunk_recline" in codes_for(thresholds, trunk_inclination_deg=-20.0)
+    assert "trunk_recline" not in codes_at(thresholds, trunk_deg=-20.0 + EPSILON)
+
+
+def test_upright_and_recline_do_not_overlap() -> None:
+    """A single posture must never produce two contradictory trunk findings."""
+    thresholds = with_thresholds(
+        trunk_upright_deg=10.0, trunk_slouch_deg=20.0, trunk_recline_deg=-20.0
+    )
+    for angle in (-25.0, -20.0, -5.0, 0.0, 5.0, 15.0, 25.0):
+        trunk_codes = {
+            code for code in codes_at(thresholds, trunk_deg=angle) if code.startswith("trunk_")
+        }
+        assert len(trunk_codes) <= 1, f"{angle}° produced {trunk_codes}"
+
+
+# ---------------------------------------------------------------------------------------------
+# Craniovertebral angle — where smaller is worse
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_forward_head_cutoff_is_strict_and_points_the_right_way() -> None:
+    """`<`, not `<=`, and *below* is the fault.
+
+    This is the one threshold in the package that runs the other way, so it is the one most likely
+    to be implemented with the comparison flipped — and a flipped comparison here reports the
+    healthiest posture as the worst while producing believable numbers throughout.
+    """
+    thresholds = with_thresholds(cva_forward_head_deg=50.0, cva_borderline_deg=55.0)
+    assert "forward_head" not in codes_for(thresholds, craniovertebral_angle_deg=50.0)
+    assert "forward_head" in codes_for(thresholds, craniovertebral_angle_deg=50.0 - EPSILON)
+    # The builder's craniovertebral angle is 90 - (trunk + neck), so neck_deg=40 gives 50.
+    assert "forward_head" in codes_at(thresholds, trunk_deg=0.0, neck_deg=40.0 + EPSILON)
+
+
+def test_the_borderline_band_sits_immediately_above_the_cutoff() -> None:
+    thresholds = with_thresholds(cva_forward_head_deg=50.0, cva_borderline_deg=55.0)
+    assert "forward_head_borderline" in codes_for(thresholds, craniovertebral_angle_deg=50.0)
+    assert "forward_head_borderline" not in codes_for(thresholds, craniovertebral_angle_deg=55.0)
+
+
+def test_the_two_head_findings_are_mutually_exclusive() -> None:
+    thresholds = with_thresholds(cva_forward_head_deg=50.0, cva_borderline_deg=55.0)
+    for neck in (0.0, 30.0, 35.0, 40.0, 50.0):
+        head_codes = {
+            code
+            for code in codes_at(thresholds, trunk_deg=0.0, neck_deg=neck)
+            if code.startswith("forward_head")
+        }
+        assert len(head_codes) <= 1, f"neck {neck}° produced {head_codes}"
+
+
+# ---------------------------------------------------------------------------------------------
+# Knees
+# ---------------------------------------------------------------------------------------------
+
+
+def test_the_kneeling_threshold_is_inclusive() -> None:
+    thresholds = with_thresholds(knee_kneeling_max_deg=60.0, knee_seated_min_deg=70.0)
+    assert "kneeling" in codes_for(thresholds, knee_flexion_deg=60.0)
+    assert "kneeling" not in codes_for(thresholds, knee_flexion_deg=60.0 + EPSILON)
+    # 180 - |thigh - shank| = 55 at a 125° separation, comfortably inside the band.
+    assert "kneeling" in codes_at(thresholds, thigh_deg=125.0, shank_deg=5.0)
+
+
+def test_the_comfortable_seated_band_produces_no_finding_at_either_edge() -> None:
+    """Both edges are inclusive, so a knee at exactly 70° or exactly 120° is fine.
+
+    Worth pinning because an exclusive edge would report a fault for a posture the thresholds
+    describe as comfortable, which is the kind of thing users notice and nobody can reproduce.
+    """
+    thresholds = with_thresholds(knee_seated_min_deg=70.0, knee_seated_max_deg=120.0)
+    assert codes_for(thresholds, knee_flexion_deg=70.0) == set()
+    assert codes_for(thresholds, knee_flexion_deg=120.0) == set()
+    assert "knee_tucked" in codes_for(thresholds, knee_flexion_deg=70.0 - EPSILON)
+
+
+def test_the_measured_angle_matches_the_threshold_it_is_compared_against() -> None:
+    """Guards the arithmetic the boundary cases above depend on.
+
+    If the builder and the metric disagreed by even a degree, every boundary test here would be
+    testing a threshold slightly away from the one it names — and would still pass.
+    """
+    thresholds = with_thresholds()
+    assert metric_at(knee_flexion_deg, thresholds, thigh_deg=110.0, shank_deg=0.0) == pytest.approx(
+        70.0, abs=1e-6
+    )
+    assert metric_at(
+        craniovertebral_angle_deg, thresholds, trunk_deg=0.0, neck_deg=40.0
+    ) == pytest.approx(50.0, abs=1e-6)
+    assert metric_at(trunk_inclination_deg, thresholds, trunk_deg=20.0) == pytest.approx(
+        20.0, abs=1e-6
+    )
+
+
+# ---------------------------------------------------------------------------------------------
+# Confidence thresholds
+# ---------------------------------------------------------------------------------------------
+
+
+def test_a_landmark_exactly_at_the_visibility_threshold_is_usable() -> None:
+    """`<` is the rejection, so the threshold value itself passes.
+
+    Documented as "below this, not trusted". An off-by-one would make the configured value mean
+    something one epsilon away from what it says.
+    """
+    from posture_core import KeypointName as K
+    from posture_core.resolver import KeypointResolver as Resolver
+    from posture_core.status import KeypointStatus
+
+    thresholds = with_thresholds(min_visibility=0.5)
+    at = Resolver(frame(confidence={K.LEFT_HIP: (0.5, 0.9)}), thresholds)
+    below = Resolver(frame(confidence={K.LEFT_HIP: (0.5 - EPSILON, 0.9)}), thresholds)
+    assert at.status(K.LEFT_HIP) is KeypointStatus.OK
+    assert below.status(K.LEFT_HIP) is KeypointStatus.LOW_CONFIDENCE
+
+
+def test_presence_is_evaluated_before_visibility_at_the_boundary() -> None:
+    """A landmark that fails both must be reported as out of frame, not merely unclear.
+
+    Out of frame is the stronger and more actionable statement, and it is the one whose remedy —
+    step back — subsumes the other.
+    """
+    from posture_core import KeypointName as K
+    from posture_core.resolver import KeypointResolver as Resolver
+    from posture_core.status import KeypointStatus
+
+    thresholds = with_thresholds(min_visibility=0.5, min_presence=0.5)
+    resolver = Resolver(frame(confidence={K.LEFT_HIP: (0.1, 0.1)}), thresholds)
+    assert resolver.status(K.LEFT_HIP) is KeypointStatus.OUT_OF_FRAME

--- a/packages/posture-core/tests/test_golden.py
+++ b/packages/posture-core/tests/test_golden.py
@@ -1,0 +1,144 @@
+"""Golden snapshots: the whole report, for each named preset, byte for byte.
+
+Every other test in this package asserts one property of one metric. These assert the *entire*
+document — findings, wording, gaps, confidences, score, both version stamps — so a change nobody
+meant to make cannot slip through by being outside the scope of any individual assertion.
+
+## Why they are committed files rather than inline expectations
+
+Three reasons, in order of weight:
+
+1. **The diff is the review.** Retuning a threshold is supposed to change these files. What
+   matters is that the change is *visible* — a reviewer reads "confidence 0.95 -> 0.61 on eleven
+   findings" and asks why, which is not a question that gets asked about a number buried in an
+   assertion.
+2. **The same corpus will be run by the TypeScript mirror** (OP-36). Both engines load these files
+   and CI fails if they disagree on any fixture. That is only possible if the expectation lives in
+   a language-neutral file.
+3. **They are the versioned record of what the engine said.** `docs/archive/legacy-baseline.json`
+   is the old engine's half of the same comparison, captured before its weights and its
+   TensorFlow 2.12 environment were removed and impossible to regenerate. This is the new half.
+
+## Updating them
+
+`python -m tests.regenerate_golden` — or delete a file and run the suite, which writes it and
+fails once with a message saying so. Never edit one by hand: a golden file that was reasoned about
+rather than generated is a golden file that asserts what someone hoped for.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+from builders import frame
+
+from posture_core import build_report
+from posture_core.synthetic import View
+from posture_core.thresholds import DEFAULT_THRESHOLDS
+
+GOLDEN = Path(__file__).parent / "golden"
+
+# The corpus. Named to match `FakePoseBackend`'s presets where they overlap, so a fixture that
+# breaks here and a fake-backed end-to-end test that breaks downstream are visibly the same case.
+CASES: dict[str, dict[str, Any]] = {
+    "straight": {"trunk_deg": 3.0, "neck_deg": 5.0, "upper_arm_deg": 10.0, "forearm_deg": 75.0},
+    "hunchback": {"trunk_deg": 32.0, "neck_deg": 30.0, "upper_arm_deg": 15.0, "forearm_deg": 80.0},
+    "reclined": {"trunk_deg": -25.0, "neck_deg": 10.0, "upper_arm_deg": -5.0, "forearm_deg": 60.0},
+    "kneeling": {
+        "trunk_deg": 5.0,
+        "neck_deg": 6.0,
+        "thigh_deg": 15.0,
+        "shank_deg": 165.0,
+        "upper_arm_deg": 8.0,
+        "forearm_deg": 20.0,
+    },
+    "arms_folded": {
+        "trunk_deg": 8.0,
+        "neck_deg": 8.0,
+        "upper_arm_deg": 15.0,
+        "forearm_deg": 80.0,
+        "forearm_cross_deg": 55.0,
+    },
+    "frontal_view": {
+        "trunk_deg": 30.0,
+        "neck_deg": 25.0,
+        "upper_arm_deg": 10.0,
+        "forearm_deg": 75.0,
+        "view": View.FRONTAL,
+    },
+    # No case may sit on a threshold. `partial_occlusion` was originally built at trunk_deg=10.0,
+    # exactly `trunk_upright_deg`, and CI caught the consequence: the measured angle is bit-exact
+    # 10.0 on arm64 and a hair above it on x86_64, so `value > threshold` fired on one
+    # architecture and not the other. The snapshot then differed by a whole finding and a 7.5
+    # point score while the *displayed* value still read 10.0, which is a genuinely confusing
+    # diff to be handed. Values reaching a comparison have been through a trig pipeline; their
+    # last bits are not portable.
+    "partial_occlusion": {
+        "trunk_deg": 8.0,
+        "neck_deg": 12.0,
+        "upper_arm_deg": 12.0,
+        "forearm_deg": 78.0,
+        "omit": (
+            "left_knee",
+            "right_knee",
+            "left_ankle",
+            "right_ankle",
+            "left_heel",
+            "right_heel",
+            "left_foot_index",
+            "right_foot_index",
+        ),
+    },
+}
+
+
+def report_for(name: str) -> dict[str, Any]:
+    from posture_core import KeypointName
+
+    pose = dict(CASES[name])
+    if "omit" in pose:
+        pose["omit"] = tuple(KeypointName(value) for value in pose["omit"])
+    return build_report(frame(**pose), DEFAULT_THRESHOLDS).to_dict()
+
+
+def serialise(payload: dict[str, Any]) -> str:
+    """Stable formatting, so a diff shows a changed verdict rather than a reordered dictionary."""
+    return json.dumps(payload, indent=2, sort_keys=True, ensure_ascii=False) + "\n"
+
+
+@pytest.mark.parametrize("name", sorted(CASES))
+def test_the_report_matches_its_golden_snapshot(name: str) -> None:
+    path = GOLDEN / f"{name}.json"
+    actual = serialise(report_for(name))
+
+    if not path.exists():
+        # Writing it and failing once, rather than passing silently. A snapshot test that creates
+        # its own expectation on first run and then passes has asserted nothing, and the run where
+        # that happened is the one nobody looks at.
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(actual, encoding="utf-8")
+        pytest.fail(f"golden snapshot {path.name} did not exist and has been written — review it")
+
+    expected = path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"the report for {name!r} changed. If that was intended, regenerate with "
+        f"`uv run python packages/posture-core/tests/regenerate_golden.py` and review the diff."
+    )
+
+
+def test_every_snapshot_on_disk_still_has_a_case() -> None:
+    """An orphaned file would keep passing review as evidence of behaviour nothing produces."""
+    on_disk = {path.stem for path in GOLDEN.glob("*.json")}
+    assert on_disk <= set(CASES), f"golden files with no case: {sorted(on_disk - set(CASES))}"
+
+
+def test_the_snapshots_record_the_versions_that_produced_them() -> None:
+    """Without both stamps a snapshot cannot be interpreted after a threshold moves — you cannot
+    tell whether the engine changed or the yardstick did."""
+    for name in CASES:
+        payload = json.loads((GOLDEN / f"{name}.json").read_text(encoding="utf-8"))
+        assert payload["schema_version"]
+        assert payload["rules_version"]

--- a/packages/posture-core/tests/test_golden.py
+++ b/packages/posture-core/tests/test_golden.py
@@ -21,9 +21,14 @@ Three reasons, in order of weight:
 
 ## Updating them
 
-`python -m tests.regenerate_golden` — or delete a file and run the suite, which writes it and
-fails once with a message saying so. Never edit one by hand: a golden file that was reasoned about
-rather than generated is a golden file that asserts what someone hoped for.
+`uv run python packages/posture-core/tests/regenerate_golden.py`, from the repository root — the
+same command the failure message prints, so there is one instruction rather than two. (`python -m
+tests.regenerate_golden` also works, but only from `packages/posture-core`, and a command that
+silently depends on the working directory is not the one to put in a docstring.)
+
+Or delete a file and run the suite, which writes it and fails once with a message saying so. Never
+edit one by hand: a golden file that was reasoned about rather than generated is a golden file
+that asserts what someone hoped for.
 """
 
 from __future__ import annotations
@@ -137,8 +142,21 @@ def test_every_snapshot_on_disk_still_has_a_case() -> None:
 
 def test_the_snapshots_record_the_versions_that_produced_them() -> None:
     """Without both stamps a snapshot cannot be interpreted after a threshold moves — you cannot
-    tell whether the engine changed or the yardstick did."""
+    tell whether the engine changed or the yardstick did.
+
+    The existence check is not redundant with the test above. That one writes a missing snapshot
+    and fails with an explanation; this one only reads, so on a deleted file — the documented way
+    to regenerate one — it raised `FileNotFoundError` and reported a missing path rather than the
+    thing to do about it. Under a full run the parametrised test happens to write the file first
+    and this never surfaces; run in isolation, or with `-k`, it is the only failure you see.
+    """
     for name in CASES:
-        payload = json.loads((GOLDEN / f"{name}.json").read_text(encoding="utf-8"))
+        path = GOLDEN / f"{name}.json"
+        assert path.exists(), (
+            f"golden snapshot {path.name} is missing. Run the whole file to have it written for "
+            f"review, or regenerate the corpus with "
+            f"`uv run python packages/posture-core/tests/regenerate_golden.py`."
+        )
+        payload = json.loads(path.read_text(encoding="utf-8"))
         assert payload["schema_version"]
         assert payload["rules_version"]


### PR DESCRIPTION
This pull request adds a new set of golden snapshot JSON files and a utility script for regenerating them in the `posture-core` package. These changes support testing and reviewing the posture analysis logic by providing reference outputs for various synthetic test cases.

**Additions to golden test infrastructure:**

* Added new golden snapshot files for various posture scenarios, including `arms_folded`, `frontal_view`, `hunchback`, `kneeling`, `partial_occlusion`, `reclined`, and `straight`. These files contain expected output data for posture assessment, including findings, metrics, and quality assessments. [[1]](diffhunk://#diff-80d74ddea77ab4e597341c111936fa4f8ba8a9992d874763608596aece252c44R1-R79) [[2]](diffhunk://#diff-b0132fb91f3cad8267af40b0b2df3cca3d2027feafb8dd2b06ebdce90f3cd4f1R1-R95) [[3]](diffhunk://#diff-022070232fdd979edf9f9495246298ebba66898851fa13b315dfe29fcfc9ad41R1-R87) [[4]](diffhunk://#diff-3a75a4240f05bf01323c8b161694fbba38eabd960ce70ef9101899288bc05b64R1-R79) [[5]](diffhunk://#diff-024f08d18154b9e51e3a47484635512735be8aceb5becea123ddd3006f016198R1-R102) [[6]](diffhunk://#diff-b4b4452203bd87312bd90da0495b3526ba50de12de613805da5f51d9b3e8ba3eR1-R79) [[7]](diffhunk://#diff-acf815bf5ac7e98c19a3ec201d08babf48d994c05fc5495907a6adb5ab4b84c1R1-R70)

**Test maintenance tooling:**

* Introduced a new script `regenerate_golden.py` to programmatically regenerate all golden snapshot files. This script ensures that changes to the posture analysis logic can be easily captured and reviewed by updating the golden files only when intended.