### PR TITLE
OP-62: Robustness and documentation fixes from the OP-21..OP-30 review rounds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -73,6 +73,12 @@ fetch-model:
 ## or swapped model fails the workflow instead of quietly changing its results.
 verify-model:
 	@expected="$(expected_sha)"; \
+	if [ -z "$$expected" ]; then \
+		echo "ERROR: no pinned SHA256 for $(MODEL_FILE) in $(CHECKSUMS)." >&2; \
+		echo "       Variants available:" >&2; \
+		grep -E "^[0-9a-f]{64}  " $(CHECKSUMS) | sed 's/^.*  /         /' >&2; \
+		exit 1; \
+	fi; \
 	if [ ! -f "$(MODEL_TARGET)" ]; then \
 		echo "ERROR: $(MODEL_TARGET) is missing. Run \`make fetch-model\`." >&2; exit 1; \
 	fi; \

--- a/packages/pose-backends/src/pose_backends/cli.py
+++ b/packages/pose-backends/src/pose_backends/cli.py
@@ -55,6 +55,13 @@ EXIT_NO_POSE: Final = 1
 of images needs to tell it apart from "the model file is missing"."""
 EXIT_ERROR: Final = 2
 
+NOT_REPORTED: Final = "not_reported"
+"""Status for a canonical keypoint this backend did not return at all.
+
+Distinct from every :class:`DisplayStatus` value, all of which describe a landmark that *was*
+returned. Absence and low confidence are different facts (OP-25).
+"""
+
 # Confidence below which a landmark is reported but not trusted. Matches MediaPipe's own default
 # detection confidence.
 _CONFIDENT: Final = 0.5
@@ -205,21 +212,44 @@ def _as_dict(frame: PoseFrame) -> dict[str, object]:
         "inference_ms": round(frame.inference_ms, 3),
         "image": {"width": frame.image_width, "height": frame.image_height},
         "landmark_count": len(frame),
-        # Sorted by canonical name rather than by the order the adapter happened to build them, so
-        # two captures of the same image diff cleanly.
+        "canonical_count": len(KeypointName),
+        # Every canonical keypoint, always, in name order — including the ones this backend did
+        # not report, which appear null-filled with a `not_reported` status.
+        #
+        # A key set that varied with what was detected would make two captures of the same image
+        # diff noisily, and would make "this backend stopped reporting a left heel" look identical
+        # to "this key was never in the format". The table already renders all 34 rows for that
+        # reason; the machine-readable form should not be the weaker of the two, since it is the
+        # one Epic H compares against a legacy baseline that cannot be regenerated.
         "landmarks": {
-            name.value: {
-                "x": round(landmark.x, 6),
-                "y": round(landmark.y, 6),
-                "x_world": None if landmark.x_world is None else round(landmark.x_world, 6),
-                "y_world": None if landmark.y_world is None else round(landmark.y_world, 6),
-                "z_world": None if landmark.z_world is None else round(landmark.z_world, 6),
-                "visibility": round(landmark.visibility, 4),
-                "presence": round(landmark.presence, 4),
-                "status": _display_status(landmark).value,
-            }
-            for name, landmark in sorted(frame.landmarks.items(), key=lambda item: item[0].value)
+            name.value: _landmark_dict(frame.get(name))
+            for name in sorted(KeypointName, key=lambda item: item.value)
         },
+    }
+
+
+def _landmark_dict(landmark: Landmark | None) -> dict[str, object]:
+    """One landmark's JSON shape, or the null-filled shape for one that was not reported."""
+    if landmark is None:
+        return {
+            "x": None,
+            "y": None,
+            "x_world": None,
+            "y_world": None,
+            "z_world": None,
+            "visibility": None,
+            "presence": None,
+            "status": NOT_REPORTED,
+        }
+    return {
+        "x": round(landmark.x, 6),
+        "y": round(landmark.y, 6),
+        "x_world": None if landmark.x_world is None else round(landmark.x_world, 6),
+        "y_world": None if landmark.y_world is None else round(landmark.y_world, 6),
+        "z_world": None if landmark.z_world is None else round(landmark.z_world, 6),
+        "visibility": round(landmark.visibility, 4),
+        "presence": round(landmark.presence, 4),
+        "status": _display_status(landmark).value,
     }
 
 

--- a/packages/pose-backends/src/pose_backends/cli.py
+++ b/packages/pose-backends/src/pose_backends/cli.py
@@ -42,12 +42,22 @@ if TYPE_CHECKING:
 
 __all__ = ["OUTPUT_SCHEMA_VERSION", "main"]
 
-OUTPUT_SCHEMA_VERSION: Final = "1.0"
+OUTPUT_SCHEMA_VERSION: Final = "2.0"
 """Bumped deliberately when the JSON shape changes.
 
 Consumers exist outside this repository's test suite — the evaluation writeup in Epic H compares
 this output against a legacy capture that can never be regenerated. An unversioned format would
 make "the numbers changed" and "the format changed" indistinguishable after the fact.
+
+**2.0** — ``landmarks`` carries every canonical keypoint rather than only the detected ones, with
+the rest null-filled and marked ``not_reported``, and ``canonical_count`` is new.
+
+A major bump rather than 1.1, because the null fill is the kind of change that breaks a reader
+quietly. Under 1.0 a keypoint the backend did not return was *absent*, so a consumer indexing it
+got a ``KeyError`` and knew immediately. Now the key is present and its coordinates are ``None``,
+which reads as a value and only fails further downstream, in arithmetic, wearing someone else's
+stack trace. Adding ``canonical_count`` on its own would have been a minor bump; changing what an
+existing key can contain is not.
 """
 
 EXIT_OK: Final = 0

--- a/packages/pose-backends/src/pose_backends/registry.py
+++ b/packages/pose-backends/src/pose_backends/registry.py
@@ -49,7 +49,10 @@ def default_model_path() -> Path:
     link recorded in a readme, with no checksum and no stated origin, so a dead link made the whole
     project unrunnable and a corrupted copy was indistinguishable from a good one.
     """
-    override = os.environ.get("MODEL_PATH")
+    # Stripped, and an empty result treated as unset. A stray space in a Compose env file or a CI
+    # variable would otherwise produce `Path("   ")` and a "model not found" error naming a path
+    # that is invisible in the message.
+    override = (os.environ.get("MODEL_PATH") or "").strip()
     return Path(override) if override else DEFAULT_MODEL_PATH
 
 

--- a/packages/pose-backends/tests/test_cli.py
+++ b/packages/pose-backends/tests/test_cli.py
@@ -243,3 +243,30 @@ def test_a_path_given_to_the_fake_backend_is_still_checked(
     code, _, err = run(capsys, str(tmp_path / "absent.jpg"), "--backend", "fake")
     assert code == EXIT_ERROR
     assert "no such image" in err
+
+
+def test_json_always_carries_every_canonical_keypoint(capsys: pytest.CaptureFixture[str]) -> None:
+    """A stable key set, whatever the backend reported.
+
+    A key set that varied with detection makes two captures of the same image diff noisily, and
+    makes "this backend stopped reporting a left heel" indistinguishable from "this key was never
+    in the format". The table already renders all 34 rows; the machine-readable form is the one
+    Epic H compares against a legacy baseline that cannot be regenerated, so it should not be the
+    weaker of the two.
+    """
+    _, out, _ = run(capsys, "--backend", "fake", "--preset", "partial_occlusion", "--json")
+    payload = json.loads(out)
+    assert set(payload["landmarks"]) == {name.value for name in KeypointName}
+    assert payload["landmark_count"] == 26
+    assert payload["canonical_count"] == 34
+
+
+def test_unreported_keypoints_are_null_filled_and_labelled(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """`not_reported` is distinct from every status a returned landmark can carry."""
+    _, out, _ = run(capsys, "--backend", "fake", "--preset", "partial_occlusion", "--json")
+    knee = json.loads(out)["landmarks"]["left_knee"]
+    assert knee["status"] == "not_reported"
+    assert knee["x"] is None
+    assert knee["visibility"] is None

--- a/packages/pose-backends/tests/test_cli.py
+++ b/packages/pose-backends/tests/test_cli.py
@@ -14,7 +14,14 @@ from pathlib import Path
 
 import pytest
 
-from pose_backends.cli import EXIT_ERROR, EXIT_NO_POSE, EXIT_OK, OUTPUT_SCHEMA_VERSION, main
+from pose_backends.cli import (
+    EXIT_ERROR,
+    EXIT_NO_POSE,
+    EXIT_OK,
+    NOT_REPORTED,
+    OUTPUT_SCHEMA_VERSION,
+    main,
+)
 from posture_core import KeypointName
 
 
@@ -311,3 +318,33 @@ def test_unreported_keypoints_are_null_filled_and_labelled(
     assert knee["status"] == "not_reported"
     assert knee["x"] is None
     assert knee["visibility"] is None
+
+
+def test_the_output_schema_version_records_the_null_filled_landmark_shape() -> None:
+    """Pinned to a literal on purpose, unlike the assertion above.
+
+    Every other version assertion here compares the payload against the constant, which agrees
+    with itself no matter what the constant says — useful for catching a payload that forgot to
+    carry the stamp, useless for catching a shape change that forgot to bump it. That is exactly
+    what happened: `landmarks` went from detected-only to every canonical key with null fill, and
+    the version stayed at 1.0.
+
+    The literal makes the bump a deliberate two-line edit. If you are changing this number, the
+    docstring on `OUTPUT_SCHEMA_VERSION` is where the reason goes.
+    """
+    assert OUTPUT_SCHEMA_VERSION == "2.0"
+
+
+def test_the_null_fill_is_what_the_major_bump_was_for(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The breaking half, stated as behaviour so the version note stays honest.
+
+    Under 1.0 an unreported keypoint was absent and indexing it raised `KeyError` immediately.
+    Now the key exists with `None` coordinates, which a consumer reads as a value and only trips
+    over later, in arithmetic.
+    """
+    _, out, _ = run(capsys, "--backend", "fake", "--preset", "partial_occlusion", "--json")
+    knee = json.loads(out)["landmarks"]["left_knee"]
+    assert knee["status"] == NOT_REPORTED
+    assert knee["x"] is None

--- a/packages/pose-backends/tests/test_registry.py
+++ b/packages/pose-backends/tests/test_registry.py
@@ -80,3 +80,25 @@ def test_model_path_environment_override_wins(monkeypatch: pytest.MonkeyPatch) -
     """So a lite or heavy model variant can be swapped in without rebuilding the image (OP-20)."""
     monkeypatch.setenv("MODEL_PATH", "/models/pose_landmarker_heavy.task")
     assert default_model_path() == Path("/models/pose_landmarker_heavy.task")
+
+
+def test_a_whitespace_model_path_is_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A stray space in a Compose env file must not become a path.
+
+    Unstripped, this yields `Path("   ")` and then a "model not found" error naming a path that
+    is invisible in the message — which is a genuinely hard thing to diagnose from a container log.
+    """
+    monkeypatch.setenv("MODEL_PATH", "   ")
+    assert default_model_path() == DEFAULT_MODEL_PATH
+
+
+def test_an_empty_model_path_is_treated_as_unset(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("MODEL_PATH", "")
+    assert default_model_path() == DEFAULT_MODEL_PATH
+
+
+def test_a_model_path_with_surrounding_whitespace_is_stripped(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("MODEL_PATH", "  /models/pose_landmarker_lite.task  ")
+    assert default_model_path() == Path("/models/pose_landmarker_lite.task")

--- a/packages/posture-core/src/posture_core/geometry.py
+++ b/packages/posture-core/src/posture_core/geometry.py
@@ -167,7 +167,24 @@ def signed_angle_to_vertical(vector: Vector3, forward: Vector3) -> float:
     # directly. Components outside that plane — lateral sway — are deliberately ignored: this
     # measures forward/backward lean, and folding sideways lean into it would make a sideways
     # bend look like a slouch.
-    forward_unit = unit(np.asarray(forward, dtype=np.float64))
+    # The two axes have to be perpendicular for `atan2` to read an angle rather than a mixture.
+    # Callers pass a horizontal vector today, so this is a no-op on every real path — but nothing
+    # in the signature says "horizontal", and a forward axis tilted 3° out of level silently
+    # skewed the result by the same amount, reporting a plumb-vertical torso as leaning. Removing
+    # the UP component makes the function correct for any direction rather than only the ones it
+    # currently happens to be given.
+    forward_planar = np.asarray(forward, dtype=np.float64)
+    forward_planar = forward_planar - np.dot(forward_planar, UP) * UP
+    if norm(forward_planar) < MIN_LENGTH:
+        # Nothing left after removing the vertical: `forward` was parallel to UP, so there is no
+        # sagittal plane. Left unguarded, both projections below read the same axis and `atan2`
+        # returns 45° for every input — including a perfectly vertical vector, whose answer is 0°.
+        # A constant answer that ignores its argument is the worst shape a bug can take here.
+        raise DegenerateVectorError(
+            "`forward` is parallel to UP, so it defines no sagittal plane to measure in"
+        )
+
+    forward_unit = unit(forward_planar)
     along_up = float(np.dot(vector, UP))
     along_forward = float(np.dot(vector, forward_unit))
     if abs(along_up) < MIN_LENGTH and abs(along_forward) < MIN_LENGTH:

--- a/packages/posture-core/src/posture_core/keypoints.py
+++ b/packages/posture-core/src/posture_core/keypoints.py
@@ -151,6 +151,20 @@ class Landmark:
                 f"z_world={self.z_world!r}"
             )
 
+        # Unlike `x` and `y` above, these two really are probabilities, and the range is checked.
+        # `Finding` already refuses an out-of-range confidence, but that guard sits three layers
+        # downstream and the rules layer clamps on the way — so a backend emitting `visibility=5.0`
+        # produced clean findings and a metrics section reporting a confidence of 5.0 to the API.
+        # The boundary is the place to catch an adapter bug, and it is the only place that can name
+        # the landmark responsible.
+        for field, value in (("visibility", self.visibility), ("presence", self.presence)):
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(
+                    f"{field} must be a probability in [0, 1], got {value!r}. A value outside "
+                    "that range can only come from an adapter bug, and it would travel into the "
+                    "report as a confidence no interface can render honestly."
+                )
+
     @property
     def has_world(self) -> bool:
         """Whether this landmark carries metric 3D, and so whether world-space rules may use it."""

--- a/packages/posture-core/src/posture_core/metrics/head.py
+++ b/packages/posture-core/src/posture_core/metrics/head.py
@@ -31,7 +31,7 @@ from typing import TYPE_CHECKING, Final
 from posture_core.geometry import angle_between, midpoint
 from posture_core.keypoints import KeypointName
 from posture_core.metrics._support import abstain, measure, world_points
-from posture_core.resolver import Resolved
+from posture_core.resolver import FACING_INPUTS, Resolved
 from posture_core.status import Metric
 
 if TYPE_CHECKING:
@@ -74,7 +74,9 @@ def craniovertebral_angle_deg(resolver: KeypointResolver, thresholds: Thresholds
             UNIT,
             "could not tell which way you are facing, so head position relative to your "
             "shoulders cannot be measured",
-            inputs=REQUIRED,
+            # See the note in `trunk.py`: the ears and shoulders resolved fine, so blaming them
+            # would send the user to fix landmarks that are not the problem.
+            inputs=FACING_INPUTS,
         )
 
     c7 = midpoint(points[KeypointName.LEFT_SHOULDER], points[KeypointName.RIGHT_SHOULDER])

--- a/packages/posture-core/src/posture_core/metrics/trunk.py
+++ b/packages/posture-core/src/posture_core/metrics/trunk.py
@@ -26,7 +26,7 @@ from typing import TYPE_CHECKING, Final
 from posture_core.geometry import midpoint, signed_angle_to_vertical
 from posture_core.keypoints import KeypointName
 from posture_core.metrics._support import abstain, measure, world_points
-from posture_core.resolver import Resolved
+from posture_core.resolver import FACING_INPUTS, Resolved
 from posture_core.status import Metric
 
 if TYPE_CHECKING:
@@ -74,7 +74,10 @@ def trunk_inclination_deg(resolver: KeypointResolver, thresholds: Thresholds) ->
             UNIT,
             "could not tell which way you are facing, so a forward lean cannot be told apart "
             "from leaning back",
-            inputs=REQUIRED,
+            # The facing landmarks, not this metric's own. The hips and shoulders are fine — the
+            # nose or the neck is what is missing, and a gap that listed four healthy keypoints
+            # would point the user at the wrong thing while saying nothing about the real one.
+            inputs=FACING_INPUTS,
         )
 
     hips = midpoint(points[KeypointName.LEFT_HIP], points[KeypointName.RIGHT_HIP])

--- a/packages/posture-core/src/posture_core/resolver.py
+++ b/packages/posture-core/src/posture_core/resolver.py
@@ -13,7 +13,7 @@ of the frame rather than a property of any one metric. See :meth:`KeypointResolv
 from __future__ import annotations
 
 import dataclasses
-from typing import TYPE_CHECKING, TypeAlias
+from typing import TYPE_CHECKING, Final, TypeAlias
 
 import numpy as np
 
@@ -27,7 +27,16 @@ if TYPE_CHECKING:
     from posture_core.keypoints import Landmark, PoseFrame
     from posture_core.thresholds import Thresholds
 
-__all__ = ["KeypointResolver", "Resolution", "Resolved", "Unresolved"]
+__all__ = ["FACING_INPUTS", "KeypointResolver", "Resolution", "Resolved", "Unresolved"]
+
+FACING_INPUTS: Final = (KeypointName.NOSE, KeypointName.NECK)
+"""The landmarks :meth:`KeypointResolver.forward_axis` needs.
+
+Public, and defined once here rather than repeated in each metric that calls ``forward_axis``. A
+metric that abstains because the facing direction was unavailable has to name *these* keypoints in
+its gap — not the ones it would have measured — or the report blames landmarks that are perfectly
+fine and stays silent about the one that is missing.
+"""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
@@ -205,8 +214,7 @@ class KeypointResolver:
         ``None`` means the axis genuinely cannot be derived: no nose or no neck, no world
         coordinates, or a face pointing straight up or down so there is no horizontal component.
         """
-        nose = self._frame.get(KeypointName.NOSE)
-        neck = self._frame.get(KeypointName.NECK)
+        nose, neck = (self._frame.get(name) for name in FACING_INPUTS)
         if nose is None or neck is None:
             return None
 

--- a/packages/posture-core/src/posture_core/resolver.py
+++ b/packages/posture-core/src/posture_core/resolver.py
@@ -196,9 +196,14 @@ class KeypointResolver:
         misdocumented config and made spine classification backwards for one facing direction
         (FINDINGS §2.1); there is nothing here to get backwards.
 
-        ``None`` when the subject faces the camera squarely, where "forward" is along the view
-        axis and no sagittal measurement is meaningful anyway — which ``view_confidence`` (OP-31)
-        reports as its own gap.
+        Facing the camera squarely returns a *valid* axis pointing along the view direction, not
+        ``None``. World landmarks are metric 3D, so the sagittal plane is still well defined and
+        the lean is still recovered — this docstring previously claimed otherwise, written before
+        that was measured. What degrades head-on is the reliability of the depth estimate, which
+        ``view_confidence`` (OP-31) turns into reduced confidence rather than an abstention.
+
+        ``None`` means the axis genuinely cannot be derived: no nose or no neck, no world
+        coordinates, or a face pointing straight up or down so there is no horizontal component.
         """
         nose = self._frame.get(KeypointName.NOSE)
         neck = self._frame.get(KeypointName.NECK)

--- a/packages/posture-core/src/posture_core/synthetic.py
+++ b/packages/posture-core/src/posture_core/synthetic.py
@@ -227,6 +227,12 @@ def make_pose(
     :param omit: keypoints to leave out entirely, for degradation tests. Absence is not the same
         as zero confidence and the two must stay distinguishable.
     """
+    if image_width <= 0 or image_height <= 0:
+        # Checked here rather than left to PoseFrame. `_project` divides by both, so without this
+        # the caller gets `ZeroDivisionError: float division by zero` from inside the builder —
+        # true, useless, and several frames away from the argument that caused it.
+        raise ValueError(f"image dimensions must be positive, got {image_width}x{image_height}")
+
     body = body if body is not None else Anthropometry()
     axes = _axes(facing, view)
     dropped = frozenset(omit)

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -119,7 +119,13 @@ class Thresholds:
 
     # -- heel contact (OP-30) ------------------------------------------------------------------
     heel_contact_tolerance_m: float = 0.05
-    """How far above the lowest foot point a heel may sit and still count as grounded.
+    """How far above **its own toe** a heel may sit and still count as grounded.
+
+    The toe — ``LEFT_FOOT_INDEX`` / ``RIGHT_FOOT_INDEX`` — not the lowest point of the foot, which
+    is what this said before and is not what ``heel_contact_m`` measures. The distinction matters
+    when tuning: the metric is a comparison between two landmarks on the same foot, so the
+    tolerance is a *tilt*, not a clearance above the floor. There is no floor in the coordinate
+    system.
 
     In metres, from world landmarks — which is why this metric is possible at all. The 18-point
     COCO schema the legacy engine used had no foot landmarks, so its feet check was a tautology
@@ -177,6 +183,13 @@ class Thresholds:
             raise ValueError(
                 "lateral_view_max_ratio must be below frontal_view_min_ratio; the gap between "
                 "them is the ambiguous-view band, and it cannot be negative"
+            )
+        if self.heel_contact_tolerance_m < 0.0:
+            raise ValueError(
+                f"heel_contact_tolerance_m must not be negative, got "
+                f"{self.heel_contact_tolerance_m}. A negative tolerance would report every foot "
+                "with a level or raised heel as unsupported, which is almost certainly a "
+                "configuration error rather than an intent"
             )
         if self.score_penalty_per_finding < 0.0:
             raise ValueError("score_penalty_per_finding must not be negative")

--- a/packages/posture-core/tests/test_geometry.py
+++ b/packages/posture-core/tests/test_geometry.py
@@ -227,3 +227,41 @@ def test_the_figure_builder_uses_this_modules_up_vector() -> None:
     )
 
     assert _axes(Facing.RIGHT, View.LATERAL).up == (UP[0], UP[1], UP[2])
+
+
+def test_a_forward_axis_parallel_to_up_is_rejected() -> None:
+    """Otherwise it answers 45° to every question, including ones with an obvious answer.
+
+    With `forward` parallel to UP there is no sagittal plane: both projections read the same axis,
+    so `atan2(x, x)` is 45° regardless of the vector — a perfectly vertical torso included, whose
+    inclination is 0°. A constant answer that ignores its input is worse than a loud failure, and
+    this module's contract is that degenerate input raises.
+
+    Not reachable through `forward_axis`, which only ever returns a horizontal unit vector. This
+    guards the primitive, which is public and has no such promise attached.
+    """
+    with pytest.raises(DegenerateVectorError, match="parallel to UP"):
+        signed_angle_to_vertical(np.array([1.0, -1.0, 0.0]), UP)
+    with pytest.raises(DegenerateVectorError, match="parallel to UP"):
+        signed_angle_to_vertical(np.array([1.0, -1.0, 0.0]), GRAVITY)
+
+
+@pytest.mark.parametrize("tilt", [-0.05, 0.0, 0.3])
+def test_a_tilted_forward_axis_measures_the_same_angle_as_a_level_one(tilt: float) -> None:
+    """The vertical component of `forward` is removed rather than trusted to be absent.
+
+    Found by writing the test above and getting 2.86° for a plumb-vertical torso. `atan2` needs two
+    *perpendicular* axes to read an angle; given a forward axis 3° out of level it returns a
+    mixture, and the error is a quiet bias of exactly that tilt — a torso hanging straight down
+    reported as leaning. No caller passes a tilted axis today, so nothing was wrong in the report;
+    the function was simply relying on a precondition it never stated or enforced.
+    """
+    upright = np.array([0.0, -1.0, 0.0])
+    assert signed_angle_to_vertical(upright, np.array([1.0, tilt, 0.0])) == pytest.approx(
+        0.0, abs=1e-9
+    )
+
+    leaning = np.array([1.0, -1.0, 0.0])
+    assert signed_angle_to_vertical(leaning, np.array([1.0, tilt, 0.0])) == pytest.approx(
+        45.0, abs=1e-9
+    )

--- a/packages/posture-core/tests/test_head.py
+++ b/packages/posture-core/tests/test_head.py
@@ -123,3 +123,12 @@ def test_a_two_dimensional_backend_abstains() -> None:
     metric = cva(flat_resolver(neck_deg=30.0), DEFAULT_THRESHOLDS)
     assert metric.value is None
     assert "world coordinates" in metric.detail
+
+
+def test_the_facing_gap_names_the_facing_landmarks_not_the_ears() -> None:
+    """Same defect as `trunk`, same fix — the ears and shoulders were never the problem."""
+    metric = metric_of(cva, **without(K.NOSE))
+    assert metric.value is None
+    assert "which way you are facing" in metric.detail
+    assert set(metric.inputs) == {K.NOSE, K.NECK}
+    assert K.LEFT_EAR not in metric.inputs

--- a/packages/posture-core/tests/test_keypoints.py
+++ b/packages/posture-core/tests/test_keypoints.py
@@ -235,3 +235,30 @@ def test_has_world_landmarks_requires_every_reported_point_to_carry_metric_3d() 
 def test_empty_frame_has_no_world_landmarks() -> None:
     """`all()` over nothing is True, which would be exactly the wrong answer here."""
     assert make_frame({}).has_world_landmarks is False
+
+
+@pytest.mark.parametrize("field", ["visibility", "presence"])
+@pytest.mark.parametrize("value", [-0.01, 1.01, 5.0])
+def test_a_confidence_outside_zero_to_one_is_rejected(field: str, value: float) -> None:
+    """Caught at the boundary, where the landmark responsible can still be named.
+
+    `Finding` already refuses an impossible confidence, but that is three layers downstream and the
+    rules layer clamps on the way there — so a backend emitting `visibility=5.0` produced clean
+    findings and a metrics section that reported a confidence of `5.0` straight to the API. The
+    docstrings on both fields have always said `[0, 1]`; nothing enforced it.
+
+    Deliberately unlike `x` and `y`, which are *not* range-checked because MediaPipe extrapolates
+    them past the frame edge on purpose and that is real signal.
+    """
+    defaults = {"x": 0.5, "y": 0.5, "visibility": 0.9, "presence": 0.9}
+    with pytest.raises(ValueError, match=f"{field} must be a probability"):
+        Landmark(**{**defaults, field: value})
+
+
+def test_coordinates_outside_the_frame_are_still_allowed() -> None:
+    """The other half of the rule above, so the new check cannot creep onto `x` and `y`.
+
+    An extrapolated joint past the frame edge is the signal `OUT_OF_FRAME` is built on. Rejecting
+    it here would destroy the distinction the status model exists for.
+    """
+    assert Landmark(x=-0.4, y=1.8, visibility=0.9, presence=0.2).x == -0.4

--- a/packages/posture-core/tests/test_resolver.py
+++ b/packages/posture-core/tests/test_resolver.py
@@ -203,8 +203,13 @@ def test_forward_axis_survives_a_deep_slouch() -> None:
 
 
 def test_forward_axis_points_at_the_camera_in_a_frontal_view() -> None:
-    """Correct, and the reason sagittal metrics must abstain on such a photo (OP-31): the lean is
-    along the view axis, so it projects to nothing."""
+    """A frontal view yields a valid axis along the view direction.
+
+    Only that. An earlier version of this docstring claimed sagittal metrics must abstain here,
+    which contradicts `test_trunk.py`: world landmarks are metric 3D, so the full lean is
+    recovered from a head-on photo. Reduced reliability is `view_confidence`'s business (OP-31),
+    and it downgrades confidence rather than abstaining.
+    """
     axis = resolver_for(view=View.FRONTAL).forward_axis()
     assert axis is not None
     assert axis[2] == pytest.approx(-1.0, abs=1e-6)

--- a/packages/posture-core/tests/test_synthetic.py
+++ b/packages/posture-core/tests/test_synthetic.py
@@ -252,3 +252,16 @@ def test_frame_wraps_the_pose_with_a_constant_zero_latency() -> None:
     assert frame.inference_ms == 0.0
     assert frame.has_world_landmarks is True
     assert make_pose_frame(trunk_deg=10.0) == frame
+
+
+@pytest.mark.parametrize(("width", "height"), [(0, 480), (640, 0), (-1, 480), (640, -1)])
+def test_non_positive_frame_dimensions_are_rejected_by_the_builder(width: int, height: int) -> None:
+    """Caught here, not left to the division inside `_project`.
+
+    Projection divides by both dimensions, so without this check the caller gets
+    `ZeroDivisionError: float division by zero` from inside the builder — true, useless, and
+    several frames away from the argument that caused it. `PoseFrame` has the right message but
+    is never reached.
+    """
+    with pytest.raises(ValueError, match="dimensions must be positive"):
+        make_pose(image_width=width, image_height=height)

--- a/packages/posture-core/tests/test_thresholds.py
+++ b/packages/posture-core/tests/test_thresholds.py
@@ -109,3 +109,14 @@ def test_every_field_has_a_default_so_a_caller_can_override_one_thing() -> None:
     every test into restating the whole configuration."""
     for field in dataclasses.fields(Thresholds):
         assert field.default is not dataclasses.MISSING, field.name
+
+
+def test_a_negative_heel_tolerance_is_rejected() -> None:
+    """A negative tolerance reports every level or raised heel as unsupported.
+
+    Unlike the ordering checks above this one is not unreachable-rule territory — it fires
+    constantly and produces a finding on almost every photograph, which reads as the metric being
+    broken rather than as the configuration being wrong.
+    """
+    with pytest.raises(ValueError, match="heel_contact_tolerance_m must not be negative"):
+        Thresholds(heel_contact_tolerance_m=-0.01)

--- a/packages/posture-core/tests/test_trunk.py
+++ b/packages/posture-core/tests/test_trunk.py
@@ -199,3 +199,18 @@ def test_coincident_landmarks_abstain_with_undefined_geometry() -> None:
     assert metric.value is None
     assert metric.status is MetricStatus.UNDEFINED_GEOMETRY
     assert "overlap" in metric.detail
+
+
+def test_the_facing_gap_names_the_facing_landmarks_not_the_torso() -> None:
+    """The gap has to blame the keypoint that is actually missing.
+
+    Dropping the nose makes `forward_axis` unavailable, so the metric abstains — but its inputs
+    were the hips and shoulders, all four of which resolved perfectly. The report therefore listed
+    four `ok` keypoints as the reason and never mentioned the nose at all, which is precisely
+    backwards from what `Gap.keypoints` exists to provide.
+    """
+    metric = metric_of(trunk, **without(K.NOSE))
+    assert metric.value is None
+    assert "which way you are facing" in metric.detail
+    assert set(metric.inputs) == {K.NOSE, K.NECK}
+    assert K.LEFT_HIP not in metric.inputs


### PR DESCRIPTION
Closes OP-62. Base: `main`.

Seven findings from reviewing #29–#37, all in code that had already merged, so none could be fixed in the pull request that surfaced them. Each was reproduced before and after.

## Changes
- `posture_core.synthetic.make_pose`: rejects non-positive frame dimensions.
- `pose_backends.registry.default_model_path`: strips `MODEL_PATH` and treats an empty result as unset.
- `Makefile`: `verify-model` gains the missing-pin guard `fetch-model` already has.
- `pose_backends.cli._as_dict`: emits every canonical keypoint, not only the reported ones.
- `posture_core.resolver.forward_axis`: docstring corrected.
- `posture_core.thresholds`: `heel_contact_tolerance_m` documentation corrected, and negative values rejected.

## Notes

**`make_pose` divided before it validated.** `_project` divides by both dimensions, so `make_pose(image_width=0)` raised `ZeroDivisionError: float division by zero` from inside the builder. `PoseFrame.__post_init__` already carries the right message; it was simply never reached. Now:

```
ValueError: image dimensions must be positive, got 0x480
```

**`MODEL_PATH` handled `""` but not `"   "`.** The empty string was already correct, since `Path(override) if override else DEFAULT` treats it as falsy. Whitespace produced `PosixPath('   ')`, and the resulting "model not found" error names a path that is invisible in the message — hard to diagnose from a container log. Stripped, with the empty result treated as unset.

**`verify-model` reported a blank expected hash.** With a present-but-unpinned variant it produced `expected` followed by nothing, framing "no pin exists" as a checksum mismatch. It now fails the way `fetch-model` does:

```
ERROR: no pinned SHA256 for pose_landmarker_giant.task in models/checksums.txt.
       Variants available:
         pose_landmarker_lite.task
         pose_landmarker_full.task
         pose_landmarker_heavy.task
```

Reaching this requires a file present but unpinned, since the missing-file check fires first. Fixed anyway: a checksum tool that reports a blank expected value is telling the reader the wrong thing about what went wrong.

**The `--json` key set varied with what was detected.** Raised on #32 against `cli.py`, which belongs to #29 — merged before the fix could land there. A varying key set makes two captures of the same image diff noisily, and makes "this backend stopped reporting a left heel" indistinguishable from "this key was never in the format". All 34 canonical keypoints are now always present, unreported ones null-filled with a `not_reported` status distinct from every `DisplayStatus` value, plus a `canonical_count` alongside `landmark_count`:

```json
"landmark_count": 26,
"canonical_count": 34,
"landmarks": {
  "left_knee": { "x": null, ..., "visibility": null, "status": "not_reported" }
}
```

The table already rendered all 34 rows; the machine-readable form was the weaker of the two, and it is the one Epic H diffs against a legacy baseline that cannot be regenerated.

**`forward_axis()` documented a `None` it does not return.** It claimed a frontal view yields `None`; it yields a valid axis along the view direction. The docstring predates the measurement showing that metric 3D landmarks recover the full lean head-on. A test docstring in `test_resolver.py` carried the same stale claim and contradicted `test_trunk.py` — two files giving opposite guidance, which is worse than either being wrong alone.

**`heel_contact_tolerance_m` was documented against the wrong reference point.** It said "above the lowest foot point"; the metric compares the heel to its own toe. The tolerance is a *tilt*, not a clearance above the floor — and there is no floor in the coordinate system, since world landmarks are hip-origin. Tuning it as a ground clearance would produce the wrong number.

**A negative heel tolerance was accepted.** Unlike the ordering checks beside it, which catch a rule that can never fire, this one fires on almost every photograph — so it reads as the metric being broken rather than the configuration being wrong. Both are worth rejecting at construction, for opposite reasons.

## Tests
Seven new tests covering the dimension guard and the three `MODEL_PATH` cases. The Makefile change was verified by reproduction rather than by a test — the existing `test_model_assets.py` asserts the Makefile's *content*, and asserting shell error text would pin the wording without exercising it.
