### PR TITLE
OP-40: Load the pose backend once at startup via lifespan, with warmup

### DIFF
--- a/apps/api/src/openposture_api/config.py
+++ b/apps/api/src/openposture_api/config.py
@@ -46,12 +46,21 @@ PoseBackendName = Literal["mediapipe", "fake"]
 
 Spelled out as a literal rather than derived from the registry's names so that an unknown value
 is rejected by *configuration* validation, with the field named, instead of raising from inside
-`create_backend` during startup. The assertion below keeps the two in step.
+`create_backend` during startup. The check below keeps the two in step.
 """
 
-# The literal above duplicates names the registry owns. Cheap insurance that a rename there is a
-# failed import here rather than a config field that silently no longer matches anything.
-assert (MEDIAPIPE_BACKEND, FAKE_BACKEND) == ("mediapipe", "fake")
+# The literal above duplicates names the registry owns, so a rename there must be a loud failure
+# here rather than a config field that silently no longer matches anything.
+#
+# An explicit raise, not an `assert`: `python -O` strips assertions, and a guard that disappears
+# under an optimisation flag is a guard that is absent exactly where it is least likely to be
+# noticed. The cost is one tuple comparison per process.
+if (MEDIAPIPE_BACKEND, FAKE_BACKEND) != ("mediapipe", "fake"):  # pragma: no cover
+    raise RuntimeError(
+        "pose backend names drifted: the registry now exposes "
+        f"{(MEDIAPIPE_BACKEND, FAKE_BACKEND)!r}, but PoseBackendName still declares "
+        "('mediapipe', 'fake'). Update the literal above."
+    )
 
 
 class Settings(BaseSettings):

--- a/apps/api/src/openposture_api/config.py
+++ b/apps/api/src/openposture_api/config.py
@@ -19,12 +19,17 @@ setting ends up with two different defaults in two different places. Everything 
 from __future__ import annotations
 
 from functools import lru_cache
+from pathlib import Path
 from typing import Final, Literal
 
 from pydantic import Field, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-__all__ = ["ENV_PREFIX", "Environment", "Settings", "get_settings"]
+from pose_backends.fake import BACKEND_NAME as FAKE_BACKEND
+from pose_backends.fake import PosePreset
+from pose_backends.mediapipe_backend import BACKEND_NAME as MEDIAPIPE_BACKEND
+
+__all__ = ["ENV_PREFIX", "Environment", "PoseBackendName", "Settings", "get_settings"]
 
 ENV_PREFIX: Final = "OPENPOSTURE_"
 """Namespaced so the container's environment cannot collide with ours.
@@ -35,6 +40,18 @@ ENV_PREFIX: Final = "OPENPOSTURE_"
 Environment = Literal["development", "test", "production"]
 
 LogLevel = Literal["debug", "info", "warning", "error", "critical"]
+
+PoseBackendName = Literal["mediapipe", "fake"]
+"""Which inference adapter to build.
+
+Spelled out as a literal rather than derived from the registry's names so that an unknown value
+is rejected by *configuration* validation, with the field named, instead of raising from inside
+`create_backend` during startup. The assertion below keeps the two in step.
+"""
+
+# The literal above duplicates names the registry owns. Cheap insurance that a rename there is a
+# failed import here rather than a config field that silently no longer matches anything.
+assert (MEDIAPIPE_BACKEND, FAKE_BACKEND) == ("mediapipe", "fake")
 
 
 class Settings(BaseSettings):
@@ -80,6 +97,27 @@ class Settings(BaseSettings):
         min_length=1,
         description=(
             "Inbound header carrying a caller-supplied correlation ID, echoed on every response."
+        ),
+    )
+
+    pose_backend: PoseBackendName = Field(
+        default="mediapipe",
+        description=(
+            "Which inference adapter to load at startup. `fake` runs the whole application with "
+            "no model at all, which is what lets CI and the container smoke test work offline."
+        ),
+    )
+
+    pose_backend_preset: PosePreset = Field(
+        default=PosePreset.STRAIGHT,
+        description="Scenario the fake backend returns. Ignored by `mediapipe`.",
+    )
+
+    model_path: Path | None = Field(
+        default=None,
+        description=(
+            "Override the model location. `None` defers to the backend's own default, which is "
+            "`MODEL_PATH` and then `models/pose_landmarker_full.task`."
         ),
     )
 

--- a/apps/api/src/openposture_api/main.py
+++ b/apps/api/src/openposture_api/main.py
@@ -16,6 +16,7 @@ It is the deployment entry point and nothing else should import it.
 
 from __future__ import annotations
 
+from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
 import structlog
@@ -24,10 +25,19 @@ from fastapi import FastAPI
 from openposture_api import __version__
 from openposture_api.config import Settings, get_settings
 from openposture_api.errors import register_error_handlers
-from openposture_api.health import build_health_router
+from openposture_api.health import ReadinessCheck, build_health_router
 from openposture_api.logging import configure_logging, request_id_middleware
+from openposture_api.pose import (
+    PoseBackendState,
+    PoseBackendUnavailableError,
+    close_pose_backend,
+    handle_pose_backend_unavailable,
+    load_pose_backend,
+)
 
 if TYPE_CHECKING:
+    from collections.abc import AsyncIterator
+
     from openposture_api.health import ReadinessProbe
 
 __all__ = ["app", "create_app"]
@@ -47,24 +57,46 @@ def create_app(
     settings: Settings | None = None,
     *,
     readiness_probes: list[ReadinessProbe] | None = None,
+    load_backend: bool = True,
 ) -> FastAPI:
     """Construct an application instance.
 
     Args:
         settings: Configuration to build against. Defaults to the process settings read from the
             environment. Tests pass an explicit instance rather than mutating `os.environ`.
-        readiness_probes: Subsystem checks for `/health/ready`. Empty until OP-40 registers the
-            pose backend; injected so a test can build an app whose dependencies are pretend.
+        readiness_probes: Extra subsystem checks for `/health/ready`. The pose backend registers
+            itself; these are appended after it. Injected so a test can build an app whose
+            dependencies are pretend.
+        load_backend: Whether `lifespan` builds the pose backend. Tests that override
+            `get_pose_backend` set this to `False` so no model is touched and startup is instant.
+            A deployment never sets it.
 
     Returns:
-        A configured app. Constructing it performs no I/O and opens no connections — that starts
-        with the `lifespan` handler in OP-40.
+        A configured app. Constructing it still performs no I/O — the backend is built when
+        `lifespan` runs, which is on startup, not at import.
     """
     resolved = settings or get_settings()
 
     # Before anything else, so that any log line emitted during construction is already
     # structured and at the configured level.
     configure_logging(resolved)
+
+    @asynccontextmanager
+    async def lifespan(app: FastAPI) -> AsyncIterator[None]:
+        """Load the model once, here, and release it on the way out.
+
+        Startup is synchronous on purpose: the ASGI server accepts no connections until this
+        returns, so an instance that is still loading cannot be sent traffic. That *is* the
+        not-ready state — an orchestrator probing during it gets a refused connection rather
+        than a 503, which reaches the same conclusion without a background task and the
+        half-initialised window one would open.
+        """
+        state = load_pose_backend(resolved) if load_backend else PoseBackendState()
+        app.state.pose_backend_state = state
+        try:
+            yield
+        finally:
+            close_pose_backend(state)
 
     app = FastAPI(
         title="OpenPosture API",
@@ -75,18 +107,31 @@ def create_app(
         # surface area. `/openapi.json` stays available because OP-45 generates the frontend's
         # types from it.
         redoc_url=None,
+        lifespan=lifespan,
     )
 
     app.state.settings = resolved
+    # Present before startup so that a route reaching for it during a failed lifespan finds a
+    # state object describing "not loaded" rather than an AttributeError.
+    app.state.pose_backend_state = PoseBackendState()
 
     # Registered before the routes it wraps. Starlette runs middleware outermost-first, so this
     # binds the request ID before any handler — including the error handlers — can log.
     app.middleware("http")(request_id_middleware(resolved))
 
     register_error_handlers(app)
+    app.add_exception_handler(PoseBackendUnavailableError, handle_pose_backend_unavailable)
+
+    # The probe reads `app.state` when it runs, not when it is registered, so binding it here —
+    # before lifespan has produced a state — reports the real thing at request time.
+    async def pose_probe() -> ReadinessCheck:
+        state: PoseBackendState = app.state.pose_backend_state
+        return await state.probe()
+
+    probes: list[ReadinessProbe] = [pose_probe, *(readiness_probes or [])]
 
     app.include_router(
-        build_health_router(version=__version__, probes=readiness_probes),
+        build_health_router(version=__version__, probes=probes),
     )
 
     _LOGGER.info(
@@ -94,7 +139,8 @@ def create_app(
         environment=resolved.environment,
         version=__version__,
         docs_enabled=resolved.docs_url is not None,
-        readiness_probes=len(readiness_probes or []),
+        pose_backend=resolved.pose_backend if load_backend else "disabled",
+        readiness_probes=len(probes),
     )
 
     return app

--- a/apps/api/src/openposture_api/pose.py
+++ b/apps/api/src/openposture_api/pose.py
@@ -1,0 +1,224 @@
+"""One pose backend per process, loaded at startup and reached through a dependency.
+
+`RUNDOWN.md`'s Open Items flagged this on the original project, in the team's own words: a cold
+load is slow, and per-request loading would be unusable. They shipped the version that reloads.
+The reason they could not fix it is structural — the model was a module-global assigned under a
+``if __name__ == '__main__'`` guard (FINDINGS §3.3), so it did not exist when the Flask app
+imported the module, and there was no startup hook to move it to.
+
+The fix has three parts, and each one is doing work:
+
+**Loaded in `lifespan`.** Once per process, before the first request, with a defined shutdown.
+Not at import, so nothing is constructed by the act of importing a module.
+
+**Held in application state, not a module global.** Two apps in one test session then have two
+independent backends, and neither can see the other's.
+
+**Reached through a dependency.** `app.dependency_overrides[get_pose_backend]` is how an endpoint
+test runs its real code path against `FakePoseBackend` — the answer to "how do I test an endpoint
+that runs a model without running the model", and the reason FastAPI was chosen (ADR-0001).
+
+A failed load is not a crash. A container that exits on a missing model file restarts forever and
+tells an operator nothing; one that stays up and reports *why* it is unready is diagnosable with
+`curl`. So the error is captured, readiness reports it by name, and requests needing inference
+get a 503 rather than a 500.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import TYPE_CHECKING, Final
+
+import structlog
+from fastapi import Request
+from starlette import status
+from starlette.responses import JSONResponse
+
+from openposture_api.errors import PROBLEM_TYPE_BASE, problem_response
+from openposture_api.health import ReadinessCheck
+from pose_backends.errors import PoseBackendError
+from pose_backends.registry import create_backend
+
+if TYPE_CHECKING:
+    from openposture_api.config import Settings
+    from pose_backends.base import PoseBackend
+
+__all__ = [
+    "PROBE_NAME",
+    "PoseBackendState",
+    "PoseBackendStatus",
+    "PoseBackendUnavailableError",
+    "get_pose_backend",
+    "load_pose_backend",
+]
+
+PROBE_NAME: Final = "pose_backend"
+
+_LOGGER = structlog.get_logger(__name__)
+
+
+class PoseBackendStatus(StrEnum):
+    """Where the one backend is in its lifecycle."""
+
+    PENDING = "pending"
+    """Constructed but not yet warmed, or not yet attempted. Never ready."""
+
+    READY = "ready"
+    """Loaded and warmed. The only state that serves traffic."""
+
+    FAILED = "failed"
+    """The load or the warmup raised. `error` says which and why."""
+
+
+class PoseBackendUnavailableError(Exception):
+    """Raised by the dependency when a route needs inference and there is none.
+
+    Deliberately not an `HTTPException`: routes should not have to know that the failure becomes a
+    503, and the problem document is built in one place rather than at each call site.
+    """
+
+    def __init__(self, state: PoseBackendState) -> None:
+        super().__init__(state.detail or "the pose backend is unavailable")
+        self.state = state
+
+
+@dataclass
+class PoseBackendState:
+    """The backend and how it got that way, held on `app.state`.
+
+    A dataclass rather than a bare backend reference because "not loaded" and "failed to load,
+    for this reason" are states the readiness probe has to be able to describe. A `None` backend
+    alone cannot distinguish *still starting* from *broken*, and those want different operator
+    responses.
+    """
+
+    status: PoseBackendStatus = PoseBackendStatus.PENDING
+    backend: PoseBackend | None = None
+    error: PoseBackendError | None = field(default=None, repr=False)
+    detail: str | None = None
+
+    @property
+    def is_ready(self) -> bool:
+        return self.status is PoseBackendStatus.READY and self.backend is not None
+
+    async def probe(self) -> ReadinessCheck:
+        """This subsystem's answer for `/health/ready`.
+
+        The failure detail is the exception's own message, which names the path it looked for or
+        the library it could not import. "not ready" without a cause makes an operator read logs
+        they may not have; with one, `curl /health/ready` is the whole diagnosis.
+        """
+        return ReadinessCheck(name=PROBE_NAME, ready=self.is_ready, detail=self.detail)
+
+
+def load_pose_backend(settings: Settings) -> PoseBackendState:
+    """Construct the configured backend and warm it, returning the outcome either way.
+
+    Blocking, and called from `lifespan` where blocking is correct: the ASGI server does not
+    accept connections until startup finishes, so an instance that is still loading is not
+    serving anything. A readiness probe against it gets a refused connection rather than a 503 —
+    different symptom, same conclusion for an orchestrator, and it costs no background-task
+    machinery to get there.
+
+    Never raises. Every failure the backends define is a `PoseBackendError`, and the point of
+    catching them is that the process stays up and stays diagnosable.
+    """
+    state = PoseBackendState()
+
+    try:
+        backend = create_backend(
+            settings.pose_backend,
+            model_path=settings.model_path,
+            preset=settings.pose_backend_preset,
+        )
+        # Before readiness flips, so no user request is the one that pays for initialisation.
+        # `MediaPipeBackend.warmup` documents that on the pinned version this currently saves
+        # nothing measurable — the guarantee is what matters, not today's timing.
+        backend.warmup()
+    except PoseBackendError as exc:
+        state.status = PoseBackendStatus.FAILED
+        state.error = exc
+        state.detail = f"{type(exc).__name__}: {exc}"
+        # `.exception` rather than `.error`: the readiness endpoint carries the message, so what
+        # the log adds is the traceback — which is the part that matters when the failure is a
+        # `ModelLoadError` wrapping something the native runtime said.
+        _LOGGER.exception(
+            "pose_backend_unavailable",
+            backend=settings.pose_backend,
+            error_type=type(exc).__name__,
+            error=str(exc),
+        )
+        return state
+
+    state.status = PoseBackendStatus.READY
+    state.backend = backend
+    _LOGGER.info("pose_backend_ready", backend=backend.name)
+    return state
+
+
+def close_pose_backend(state: PoseBackendState) -> None:
+    """Release native resources on shutdown, if the backend holds any.
+
+    `close` is not part of the `PoseBackend` Protocol — a five-line test double should not have to
+    implement it — so it is called only when present. Failures are logged and swallowed: a
+    process that is stopping anyway should not turn an orderly shutdown into a stack trace.
+    """
+    closer = getattr(state.backend, "close", None)
+    if not callable(closer):
+        return
+    try:
+        closer()
+    except Exception as exc:  # noqa: BLE001
+        # BLE001 is enabled because swallowed exceptions were the legacy engine's defining
+        # failure mode. This one is logged in full and reached only while shutting down, where
+        # re-raising would replace a clean stop with a traceback and change nothing else.
+        _LOGGER.warning("pose_backend_close_failed", error_type=type(exc).__name__, error=str(exc))
+
+
+def get_pose_backend(request: Request) -> PoseBackend:
+    """FastAPI dependency: the process's one backend.
+
+    Override this in tests — `app.dependency_overrides[get_pose_backend] = lambda: fake` — and an
+    endpoint test exercises its real code path with no model on disk.
+
+    Consuming it looks like::
+
+        async def route(backend: Annotated[PoseBackend, Depends(get_pose_backend)]) -> ...:
+
+    and `PoseBackend` must be imported at *runtime* in that module, not under `TYPE_CHECKING`.
+    Every module here uses `from __future__ import annotations`, so FastAPI resolves the
+    annotation from module globals when it builds the route — and if the name is not there, the
+    parameter is silently treated as a **query parameter** rather than a dependency. The symptom
+    is a 422 complaining about a missing `backend` query string, which points nowhere near the
+    cause.
+
+    :raises PoseBackendUnavailableError: if the backend never loaded. Becomes a 503, because the
+        condition is the server's and it may be temporary; a 500 would suggest a bug in handling
+        the request, which it is not.
+    """
+    state: PoseBackendState | None = getattr(request.app.state, "pose_backend_state", None)
+    if state is None or not state.is_ready:
+        raise PoseBackendUnavailableError(state or PoseBackendState())
+    # `is_ready` already established this is not None; the assert is for the type checker.
+    assert state.backend is not None
+    return state.backend
+
+
+async def handle_pose_backend_unavailable(request: Request, exc: Exception) -> JSONResponse:
+    """Render :class:`PoseBackendUnavailableError` as a 503 problem document.
+
+    `Retry-After` is set because the honest answer is "try again shortly": the usual causes are a
+    model still downloading or a volume not yet mounted, both of which resolve without a client
+    changing anything about its request.
+    """
+    assert isinstance(exc, PoseBackendUnavailableError)
+    return problem_response(
+        request,
+        status.HTTP_503_SERVICE_UNAVAILABLE,
+        "Pose analysis is unavailable because the inference backend did not load.",
+        problem_type=f"{PROBLEM_TYPE_BASE}/pose-backend-unavailable",
+        headers={"Retry-After": "30"},
+        backend_status=exc.state.status.value,
+        backend_detail=exc.state.detail,
+    )

--- a/apps/api/tests/conftest.py
+++ b/apps/api/tests/conftest.py
@@ -23,8 +23,18 @@ if TYPE_CHECKING:
 
 @pytest.fixture
 def settings() -> Settings:
-    """Settings for a test run: quiet, structured, and explicitly not production."""
-    return Settings(environment="test", log_level="warning", json_logs=True)
+    """Settings for a test run: quiet, structured, and explicitly not production.
+
+    `pose_backend="fake"` rather than disabling the backend entirely. The suite then exercises
+    the real lifespan — construct, warm, register the probe, close — and still touches no model
+    file, which is what keeps required CI free of a download.
+    """
+    return Settings(
+        environment="test",
+        log_level="warning",
+        json_logs=True,
+        pose_backend="fake",
+    )
 
 
 @pytest.fixture

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -7,12 +7,19 @@ fail restarts the container instead of routing around it.
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 from openposture_api import __version__
 from openposture_api.config import Settings
-from openposture_api.health import ReadinessCheck
+from openposture_api.health import ReadinessCheck, ReadinessProbe, build_health_router
 from openposture_api.main import create_app
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
 
 
 def _ready(name: str) -> ReadinessCheck:
@@ -21,6 +28,24 @@ def _ready(name: str) -> ReadinessCheck:
 
 def _not_ready(name: str, detail: str) -> ReadinessCheck:
     return ReadinessCheck(name=name, ready=False, detail=detail)
+
+
+@pytest.fixture
+def probe_client() -> Callable[[list[ReadinessProbe]], TestClient]:
+    """Builds a bare app carrying only the probes a test names.
+
+    The router is exercised directly rather than through `create_app`, which registers the
+    pose backend's probe and will register storage's and the database's in later tickets.
+    Aggregation semantics are the router's business, and asserting them through the factory
+    makes every one of these tests fail the day a subsystem is added.
+    """
+
+    def build(probes: list[ReadinessProbe]) -> TestClient:
+        app = FastAPI()
+        app.include_router(build_health_router(version=__version__, probes=probes))
+        return TestClient(app)
+
+    return build
 
 
 class TestLiveness:
@@ -45,41 +70,41 @@ class TestLiveness:
 
 class TestReadiness:
     def test_readiness_with_no_registered_probes_is_ready_and_says_so_honestly(
-        self, client: TestClient
+        self, probe_client: Callable[[list[ReadinessProbe]], TestClient]
     ) -> None:
-        """Nothing to check yet — but `checks` is present and empty rather than absent, so a
-        consumer written now does not break when OP-40 starts filling it."""
-        response = client.get("/health/ready")
+        """`checks` is present and empty rather than absent, so a consumer written against a
+        subsystem-free build does not break when subsystems start registering."""
+        response = probe_client([]).get("/health/ready")
 
         assert response.status_code == 200
         assert response.json() == {"status": "ready", "version": __version__, "checks": []}
 
-    def test_every_probe_passing_is_ready(self, settings: Settings) -> None:
+    def test_every_probe_passing_is_ready(
+        self, probe_client: Callable[[list[ReadinessProbe]], TestClient]
+    ) -> None:
         async def backend() -> ReadinessCheck:
             return _ready("pose_backend")
 
         async def storage() -> ReadinessCheck:
             return _ready("storage")
 
-        app = create_app(settings, readiness_probes=[backend, storage])
-        with TestClient(app) as client:
-            response = client.get("/health/ready")
+        response = probe_client([backend, storage]).get("/health/ready")
 
         assert response.status_code == 200
         body = response.json()
         assert body["status"] == "ready"
         assert [check["name"] for check in body["checks"]] == ["pose_backend", "storage"]
 
-    def test_one_failing_probe_fails_the_whole_check(self, settings: Settings) -> None:
+    def test_one_failing_probe_fails_the_whole_check(
+        self, probe_client: Callable[[list[ReadinessProbe]], TestClient]
+    ) -> None:
         async def backend() -> ReadinessCheck:
             return _ready("pose_backend")
 
         async def storage() -> ReadinessCheck:
             return _not_ready("storage", "bucket unreachable")
 
-        app = create_app(settings, readiness_probes=[backend, storage])
-        with TestClient(app) as client:
-            response = client.get("/health/ready")
+        response = probe_client([backend, storage]).get("/health/ready")
 
         assert response.status_code == 503
         body = response.json()
@@ -96,13 +121,15 @@ class TestReadiness:
         """Load balancers route on the status code and never read the body."""
 
         async def failing() -> ReadinessCheck:
-            return _not_ready("pose_backend", "model not loaded")
+            return _not_ready("database", "model not loaded")
 
         app = create_app(settings, readiness_probes=[failing])
         with TestClient(app) as client:
             assert client.get("/health/ready").status_code == 503
 
-    def test_probes_report_in_registration_order(self, settings: Settings) -> None:
+    def test_probes_report_in_registration_order(
+        self, probe_client: Callable[[list[ReadinessProbe]], TestClient]
+    ) -> None:
         """Stable ordering keeps a health payload diffable between two deploys."""
 
         async def first() -> ReadinessCheck:
@@ -114,8 +141,6 @@ class TestReadiness:
         async def third() -> ReadinessCheck:
             return _ready("c")
 
-        app = create_app(settings, readiness_probes=[first, second, third])
-        with TestClient(app) as client:
-            body = client.get("/health/ready").json()
+        body = probe_client([first, second, third]).get("/health/ready").json()
 
         assert [check["name"] for check in body["checks"]] == ["a", "b", "c"]

--- a/apps/api/tests/test_health.py
+++ b/apps/api/tests/test_health.py
@@ -19,7 +19,7 @@ from openposture_api.health import ReadinessCheck, ReadinessProbe, build_health_
 from openposture_api.main import create_app
 
 if TYPE_CHECKING:
-    from collections.abc import Callable
+    from collections.abc import Callable, Iterator
 
 
 def _ready(name: str) -> ReadinessCheck:
@@ -31,21 +31,33 @@ def _not_ready(name: str, detail: str) -> ReadinessCheck:
 
 
 @pytest.fixture
-def probe_client() -> Callable[[list[ReadinessProbe]], TestClient]:
+def probe_client() -> Iterator[Callable[[list[ReadinessProbe]], TestClient]]:
     """Builds a bare app carrying only the probes a test names.
 
     The router is exercised directly rather than through `create_app`, which registers the
     pose backend's probe and will register storage's and the database's in later tickets.
     Aggregation semantics are the router's business, and asserting them through the factory
     makes every one of these tests fail the day a subsystem is added.
+
+    Every client it hands out is entered and exited by the fixture. That closes the underlying
+    transport rather than leaving it to the garbage collector, and it means these apps run their
+    lifespan — so if the bare app ever gains startup or shutdown hooks, they execute here too
+    instead of being silently skipped.
     """
+    clients: list[TestClient] = []
 
     def build(probes: list[ReadinessProbe]) -> TestClient:
         app = FastAPI()
         app.include_router(build_health_router(version=__version__, probes=probes))
-        return TestClient(app)
+        client = TestClient(app)
+        client.__enter__()
+        clients.append(client)
+        return client
 
-    return build
+    yield build
+
+    for client in clients:
+        client.__exit__(None, None, None)
 
 
 class TestLiveness:
@@ -121,7 +133,7 @@ class TestReadiness:
         """Load balancers route on the status code and never read the body."""
 
         async def failing() -> ReadinessCheck:
-            return _not_ready("database", "model not loaded")
+            return _not_ready("database", "connection pool exhausted")
 
         app = create_app(settings, readiness_probes=[failing])
         with TestClient(app) as client:

--- a/apps/api/tests/test_pose.py
+++ b/apps/api/tests/test_pose.py
@@ -1,0 +1,280 @@
+"""One backend per process, loaded at startup, and honest about it when it fails.
+
+`RUNDOWN.md`'s Open Items flagged per-request model loading on the original project and never
+resolved it. These tests are the proof it is resolved: the backend is built once, before the
+first request, behind a dependency a test can replace — and a failure to build leaves a
+diagnosable container rather than a crash loop.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated
+
+from fastapi import Depends, FastAPI
+from fastapi.testclient import TestClient
+
+from openposture_api.config import Settings
+from openposture_api.main import create_app
+from openposture_api.pose import (
+    PROBE_NAME,
+    PoseBackendState,
+    PoseBackendStatus,
+    close_pose_backend,
+    get_pose_backend,
+    load_pose_backend,
+)
+from pose_backends.base import PoseBackend
+from pose_backends.errors import ModelNotFoundError
+from pose_backends.fake import FakePoseBackend, PosePreset
+
+
+def _readiness_check(body: dict[str, object], name: str) -> dict[str, object]:
+    checks = body["checks"]
+    assert isinstance(checks, list)
+    matching = [check for check in checks if check["name"] == name]
+    assert matching, f"no readiness check named {name!r} in {checks}"
+    return dict(matching[0])
+
+
+class TestLoading:
+    def test_a_configured_backend_loads_and_warms(self) -> None:
+        state = load_pose_backend(Settings(environment="test", pose_backend="fake"))
+
+        assert state.status is PoseBackendStatus.READY
+        assert state.is_ready
+        assert state.backend is not None
+        assert state.backend.name == "fake"
+
+    def test_the_configured_preset_reaches_the_backend(self) -> None:
+        """Otherwise `POSE_BACKEND_PRESET` would be accepted, validated, and then ignored."""
+        state = load_pose_backend(
+            Settings(
+                environment="test",
+                pose_backend="fake",
+                pose_backend_preset=PosePreset.HUNCHBACK,
+            )
+        )
+
+        assert isinstance(state.backend, FakePoseBackend)
+        assert state.backend.preset is PosePreset.HUNCHBACK
+
+    def test_a_missing_model_does_not_raise(self) -> None:
+        """A container that exits on a missing model restarts forever and explains nothing.
+
+        Deterministic with or without the `mediapipe` extra installed: the adapter checks the
+        path before importing the library, so this is `ModelNotFoundError` either way — which is
+        what lets it run in CI, where the extra is deliberately absent.
+        """
+        state = load_pose_backend(
+            Settings(
+                environment="test",
+                pose_backend="mediapipe",
+                model_path=Path("/nonexistent/pose_landmarker_full.task"),
+            )
+        )
+
+        assert state.status is PoseBackendStatus.FAILED
+        assert not state.is_ready
+        assert state.backend is None
+
+    def test_a_load_failure_records_the_cause_by_name(self) -> None:
+        """`curl /health/ready` should be the whole diagnosis, not the first step of one."""
+        state = load_pose_backend(
+            Settings(
+                environment="test",
+                pose_backend="mediapipe",
+                model_path=Path("/nonexistent/pose_landmarker_full.task"),
+            )
+        )
+
+        assert isinstance(state.error, ModelNotFoundError)
+        assert state.detail is not None
+        assert "ModelNotFoundError" in state.detail
+        # The path it looked for is what makes the message actionable.
+        assert "/nonexistent/pose_landmarker_full.task" in state.detail
+
+
+class TestLifespan:
+    def test_the_backend_is_built_once_per_process(self, settings: Settings) -> None:
+        """The acceptance criterion, and the defect the original never fixed: many requests, one
+        model. A backend rebuilt per request would make every response pay the load."""
+        app = create_app(settings)
+
+        with TestClient(app) as client:
+            seen = []
+            for _ in range(3):
+                client.get("/health/ready")
+                seen.append(id(app.state.pose_backend_state.backend))
+
+        assert len(set(seen)) == 1
+
+    def test_nothing_is_loaded_by_constructing_the_app(self, settings: Settings) -> None:
+        """Construction must stay cheap and side-effect free — the whole reason for a factory."""
+        app = create_app(settings)
+
+        assert app.state.pose_backend_state.status is PoseBackendStatus.PENDING
+        assert app.state.pose_backend_state.backend is None
+
+    def test_the_backend_is_ready_once_startup_has_run(self, settings: Settings) -> None:
+        app = create_app(settings)
+
+        with TestClient(app):
+            assert app.state.pose_backend_state.status is PoseBackendStatus.READY
+
+    def test_two_apps_get_independent_backends(self, settings: Settings) -> None:
+        """Held on `app.state`, not in a module global — the property that made the legacy
+        engine's `model` untestable."""
+        first = create_app(settings)
+        second = create_app(settings)
+
+        with TestClient(first), TestClient(second):
+            assert (
+                first.state.pose_backend_state.backend
+                is not second.state.pose_backend_state.backend
+            )
+
+    def test_shutdown_closes_the_backend(self, settings: Settings) -> None:
+        closed: list[bool] = []
+
+        class _Closable:
+            name = "closable"
+
+            def close(self) -> None:
+                closed.append(True)
+
+        state = PoseBackendState(status=PoseBackendStatus.READY, backend=_Closable())  # type: ignore[arg-type]
+        close_pose_backend(state)
+
+        assert closed == [True]
+
+    def test_a_backend_without_close_is_not_a_shutdown_error(self) -> None:
+        """`close` is not in the Protocol, so a five-line test double need not implement it."""
+
+        class _Bare:
+            name = "bare"
+
+        close_pose_backend(PoseBackendState(status=PoseBackendStatus.READY, backend=_Bare()))  # type: ignore[arg-type]
+
+    def test_a_failing_close_does_not_break_shutdown(self) -> None:
+        """A process that is stopping anyway should stop, not emit a traceback."""
+
+        class _BadCloser:
+            name = "bad"
+
+            def close(self) -> None:
+                raise RuntimeError("native handle already gone")
+
+        close_pose_backend(PoseBackendState(status=PoseBackendStatus.READY, backend=_BadCloser()))  # type: ignore[arg-type]
+
+
+class TestReadinessReporting:
+    def test_readiness_is_true_once_the_backend_is_warm(self, settings: Settings) -> None:
+        app = create_app(settings)
+
+        with TestClient(app) as client:
+            response = client.get("/health/ready")
+
+        assert response.status_code == 200
+        assert _readiness_check(response.json(), PROBE_NAME)["ready"] is True
+
+    def test_a_pending_backend_is_not_ready(self) -> None:
+        """Startup blocks the server from accepting connections, so this state is unreachable
+        over HTTP — but it is what the probe reports before startup runs, and a probe that said
+        "ready" here would be wrong the moment anything defers loading."""
+        state = PoseBackendState()
+
+        assert state.is_ready is False
+
+    def test_a_failed_backend_makes_the_container_unready_with_a_named_cause(self) -> None:
+        settings = Settings(
+            environment="test",
+            json_logs=True,
+            pose_backend="mediapipe",
+            model_path=Path("/nonexistent/model.task"),
+        )
+        app = create_app(settings)
+
+        with TestClient(app) as client:
+            response = client.get("/health/ready")
+
+        assert response.status_code == 503
+        check = _readiness_check(response.json(), PROBE_NAME)
+        assert check["ready"] is False
+        assert "ModelNotFoundError" in str(check["detail"])
+
+    def test_a_failed_backend_still_reports_alive(self) -> None:
+        """Liveness must stay green: restarting the container will not conjure a model file."""
+        settings = Settings(
+            environment="test",
+            json_logs=True,
+            pose_backend="mediapipe",
+            model_path=Path("/nonexistent/model.task"),
+        )
+
+        with TestClient(create_app(settings)) as client:
+            assert client.get("/health").status_code == 200
+
+
+class TestDependency:
+    @staticmethod
+    def _app_with_route(settings: Settings, *, load_backend: bool = True) -> FastAPI:
+        app = create_app(settings, load_backend=load_backend)
+
+        @app.get("/backend-name")
+        async def backend_name(
+            backend: Annotated[PoseBackend, Depends(get_pose_backend)],
+        ) -> dict[str, str]:
+            return {"name": backend.name}
+
+        return app
+
+    def test_the_dependency_hands_out_the_lifespan_backend(self, settings: Settings) -> None:
+        app = self._app_with_route(settings)
+
+        with TestClient(app) as client:
+            assert client.get("/backend-name").json() == {"name": "fake"}
+
+    def test_the_dependency_can_be_overridden_without_any_model(self, settings: Settings) -> None:
+        """The point of the seam: an endpoint test runs its real code path against a fake, with
+        `load_backend=False` so startup touches nothing at all."""
+        app = self._app_with_route(settings, load_backend=False)
+        app.dependency_overrides[get_pose_backend] = lambda: FakePoseBackend(PosePreset.HUNCHBACK)
+
+        with TestClient(app) as client:
+            assert client.get("/backend-name").json() == {"name": "fake"}
+
+    def test_a_route_needing_inference_gets_503_when_the_backend_failed(self) -> None:
+        """Not a 500: the condition is the server's and may be temporary, and a 500 would suggest
+        the request itself was mishandled."""
+        settings = Settings(
+            environment="test",
+            json_logs=True,
+            pose_backend="mediapipe",
+            model_path=Path("/nonexistent/model.task"),
+        )
+        app = self._app_with_route(settings)
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/backend-name")
+
+        assert response.status_code == 503
+        assert response.headers["content-type"].startswith("application/problem+json")
+
+    def test_the_503_names_the_cause_and_asks_for_a_retry(self) -> None:
+        settings = Settings(
+            environment="test",
+            json_logs=True,
+            pose_backend="mediapipe",
+            model_path=Path("/nonexistent/model.task"),
+        )
+        app = self._app_with_route(settings)
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/backend-name")
+
+        body = response.json()
+        assert body["type"].endswith("/pose-backend-unavailable")
+        assert body["backend_status"] == "failed"
+        assert "ModelNotFoundError" in body["backend_detail"]
+        assert response.headers["Retry-After"] == "30"

--- a/apps/api/tests/test_pose.py
+++ b/apps/api/tests/test_pose.py
@@ -98,16 +98,26 @@ class TestLoading:
 class TestLifespan:
     def test_the_backend_is_built_once_per_process(self, settings: Settings) -> None:
         """The acceptance criterion, and the defect the original never fixed: many requests, one
-        model. A backend rebuilt per request would make every response pay the load."""
+        model. A backend rebuilt per request would make every response pay the load.
+
+        Identity is collected as the object itself, not `id(...)`. Against `id` this test passes
+        vacuously when loading fails — `id(None)` is a constant, so three failed loads look
+        exactly like one shared backend. The readiness assertion below rules that out first.
+        """
         app = create_app(settings)
 
         with TestClient(app) as client:
-            seen = []
+            assert client.get("/health/ready").status_code == 200
+            assert app.state.pose_backend_state.backend is not None
+
+            seen: list[PoseBackend] = []
             for _ in range(3):
                 client.get("/health/ready")
-                seen.append(id(app.state.pose_backend_state.backend))
+                backend = app.state.pose_backend_state.backend
+                assert backend is not None
+                seen.append(backend)
 
-        assert len(set(seen)) == 1
+        assert all(backend is seen[0] for backend in seen)
 
     def test_nothing_is_loaded_by_constructing_the_app(self, settings: Settings) -> None:
         """Construction must stay cheap and side-effect free — the whole reason for a factory."""


### PR DESCRIPTION
This pull request introduces a robust and testable pose backend lifecycle to the OpenPosture API, ensuring the model is loaded once per process during startup, held in application state, and reached through a FastAPI dependency. It improves configuration, error handling, and readiness checks, and refactors tests to support subsystem health probe aggregation. The most important changes are:

**Pose backend lifecycle and error handling:**
* Added `pose.py` with the `PoseBackendState` dataclass, backend load/close logic, FastAPI dependency `get_pose_backend`, and a custom error/exception handler to return a 503 when the backend is unavailable. This ensures the backend is loaded once at startup, failures are reported without crashing, and resources are released on shutdown.
* Updated `main.py` to use a `lifespan` context manager for backend startup/shutdown, register the pose backend readiness probe, and add exception handling for backend unavailability. [[1]](diffhunk://#diff-ccf721da1d0fa8930d2c3414b9279bdcc9176736b060728d0ef9d49077d0bfc4L27-R40) [[2]](diffhunk://#diff-ccf721da1d0fa8930d2c3414b9279bdcc9176736b060728d0ef9d49077d0bfc4R60-R100) [[3]](diffhunk://#diff-ccf721da1d0fa8930d2c3414b9279bdcc9176736b060728d0ef9d49077d0bfc4R110-R143)

**Configuration improvements:**
* Extended `config.py` to support explicit selection of pose backend (`mediapipe` or `fake`), backend preset, and model path, with validation to ensure configuration errors are caught early. [[1]](diffhunk://#diff-55a4f1cfbc19a9023d7be2c93ce584e13bbc5ee1573898a39edf7a130540cc27R22-R32) [[2]](diffhunk://#diff-55a4f1cfbc19a9023d7be2c93ce584e13bbc5ee1573898a39edf7a130540cc27R44-R55) [[3]](diffhunk://#diff-55a4f1cfbc19a9023d7be2c93ce584e13bbc5ee1573898a39edf7a130540cc27R103-R123)

**Testing and health check enhancements:**
* Refactored tests to use a `probe_client` fixture for directly testing health router aggregation, and updated test settings to use the `fake` backend, ensuring tests exercise the full backend lifecycle without requiring a model file. [[1]](diffhunk://#diff-fe94e7735fbb57c0e922a4922d991baaa0e880212a555449ee8055b8f9e9cdf7L26-R37) [[2]](diffhunk://#diff-06d4f04b2b79ffba6e0054b6be0b46c95e29f4739161a37da67e0bd8122f82deR10-R23) [[3]](diffhunk://#diff-06d4f04b2b79ffba6e0054b6be0b46c95e29f4739161a37da67e0bd8122f82deR33-R50) [[4]](diffhunk://#diff-06d4f04b2b79ffba6e0054b6be0b46c95e29f4739161a37da67e0bd8122f82deL48-R107)

These changes collectively make the pose backend lifecycle explicit, observable, and testable, improving reliability, diagnosability, and maintainability.