### PR TITLE
OP-42: POST /api/v1/analyses — the endpoint that makes the app real

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -22,6 +22,8 @@ dependencies = [
     # (FINDINGS §3), so the replacement emits machine-parseable events with a request ID.
     "structlog>=24.4",
     "boto3>=1.35",
+    "pillow>=11.0",
+    "python-multipart>=0.0.18",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -71,6 +71,10 @@ def build_analyses_router() -> APIRouter:
             status.HTTP_400_BAD_REQUEST: {"description": "The file could not be decoded."},
             status.HTTP_413_CONTENT_TOO_LARGE: {"description": "Over the size limit."},
             status.HTTP_415_UNSUPPORTED_MEDIA_TYPE: {"description": "Format not supported."},
+            # 502 is returned by the backend- and storage-failure handlers registered below.
+            # Listed here because OP-45 generates the frontend's types from this schema, so
+            # an unlisted status is a response the client is not typed to handle.
+            status.HTTP_502_BAD_GATEWAY: {"description": "Inference or storage failed downstream."},
             status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Inference is unavailable."},
         },
     )

--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -1,0 +1,226 @@
+"""`POST /api/v1/analyses` — the endpoint that makes the application real.
+
+Until this exists the project is scaffolding: the frontend fakes a five-second wait and renders
+two hardcoded strings, and `API/app.py` never imports a model at all. This route is the missing
+wire. A photograph goes in, and a report derived from that specific body comes out.
+
+The flow is deliberately linear: read → validate and decode → detect → build report → persist the
+original → 201.
+
+**An abstaining report is a success.** A report that is entirely gaps returns 201, not an error.
+The request was well-formed and the service did its job; the answer is "I could not see enough of
+you to say", which is information the user needs. Turning that into a 4xx would push the frontend
+into an error state and lose the gap detail that C3's status model exists to produce — which is
+the original's central defect (`None` → "Straight back position") arriving by a different route.
+
+Only genuine failures are non-2xx: an undecodable file, an oversized one, a format outside the
+allowlist, or a backend that is not there.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Final
+
+import structlog
+from fastapi import APIRouter, Depends, File, Request, UploadFile
+from starlette import status
+
+from openposture_api.errors import PROBLEM_TYPE_BASE, problem_response
+from openposture_api.images import (
+    MAX_IMAGE_BYTES,
+    ImageTooLargeError,
+    InvalidImageError,
+    UnsupportedImageTypeError,
+    decode_upload,
+)
+from openposture_api.pose import get_pose_backend
+from openposture_api.storage import StorageBackend, StorageError, get_storage
+from pose_backends.base import PoseBackend
+from pose_backends.errors import PoseBackendError
+from posture_core import build_report
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from starlette.responses import JSONResponse
+
+__all__ = ["API_PREFIX", "build_analyses_router", "register_analysis_error_handlers"]
+
+API_PREFIX: Final = "/api/v1"
+
+_LOGGER = structlog.get_logger(__name__)
+
+
+def build_analyses_router() -> APIRouter:
+    """The analyses routes.
+
+    A builder rather than a module-level router for the same reason `create_app` is a factory:
+    two apps in one test session must not share mutable route state.
+    """
+    router = APIRouter(prefix=API_PREFIX, tags=["analyses"])
+
+    @router.post(
+        "/analyses",
+        status_code=status.HTTP_201_CREATED,
+        summary="Analyse posture in a photograph",
+        description=(
+            "Upload a lateral photograph and receive a posture report. A report that could not "
+            "assess some metrics still returns 201 with those metrics listed under "
+            "`quality.gaps` — abstention is an answer, not an error."
+        ),
+        responses={
+            status.HTTP_400_BAD_REQUEST: {"description": "The file could not be decoded."},
+            status.HTTP_413_CONTENT_TOO_LARGE: {"description": "Over the size limit."},
+            status.HTTP_415_UNSUPPORTED_MEDIA_TYPE: {"description": "Format not supported."},
+            status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Inference is unavailable."},
+        },
+    )
+    async def create_analysis(
+        request: Request,
+        backend: Annotated[PoseBackend, Depends(get_pose_backend)],
+        storage: Annotated[StorageBackend, Depends(get_storage)],
+        image: Annotated[UploadFile, File(description="The photograph to analyse.")],
+    ) -> dict[str, Any]:
+        raw = await _read_within_limit(image)
+        decoded = decode_upload(raw)
+
+        # Blocking, CPU-bound, and on the event loop — deliberately, for now. `detect` takes
+        # ~25 ms with the pinned model, which is short enough that moving it to a thread costs
+        # more in context switching than it saves. The moment that stops being true (a heavier
+        # model, or real concurrency) this becomes `run_in_threadpool`, which is one line and one
+        # of the four reasons ADR-0001 chose FastAPI.
+        frame = backend.detect(decoded.array)
+
+        stored = storage.put(decoded.data, content_type=decoded.content_type)
+
+        if frame is None:
+            # An ordinary outcome — the user photographed their desk. 201, because the request
+            # succeeded and "nobody in this image" is the finding.
+            _LOGGER.info("analysis_no_pose", backend=backend.name, object_key=stored.key)
+            return {
+                "object_key": stored.key,
+                "pose_detected": False,
+                "report": None,
+                "image": {"width": decoded.width, "height": decoded.height},
+            }
+
+        report = build_report(frame)
+
+        _LOGGER.info(
+            "analysis_complete",
+            backend=backend.name,
+            object_key=stored.key,
+            assessed=report.quality.assessed,
+            total=report.quality.total,
+            findings=len(report.findings),
+            score=report.overall_score,
+        )
+
+        return {
+            "object_key": stored.key,
+            "pose_detected": True,
+            # `to_dict` is the engine's own serialiser, shared with the CLI and the golden
+            # corpus. A second one here would drift, and the cross-language parity check in
+            # Epic G depends on there being exactly one.
+            "report": report.to_dict(),
+            "image": {"width": decoded.width, "height": decoded.height},
+        }
+
+    return router
+
+
+async def _read_within_limit(upload: UploadFile) -> bytes:
+    """Read the upload, refusing anything over the limit *before* it is all in memory.
+
+    Read in chunks and abandoned as soon as the running total crosses the limit, rather than
+    `await upload.read()` followed by a length check. The difference matters: the naive version
+    has already materialised the whole payload by the time it decides to reject it, so a 2 GB
+    upload is a 2 GB allocation regardless of the limit being 10 MB.
+
+    Starlette spools large uploads to disk, which bounds memory but not disk, and neither bounds
+    the time spent reading. This bounds all three.
+    """
+    chunks: list[bytes] = []
+    total = 0
+    while chunk := await upload.read(64 * 1024):
+        total += len(chunk)
+        if total > MAX_IMAGE_BYTES:
+            raise ImageTooLargeError(
+                f"upload exceeds the {MAX_IMAGE_BYTES} byte limit",
+                limit=MAX_IMAGE_BYTES,
+                actual=total,
+            )
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+async def _handle_too_large(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, ImageTooLargeError)
+    return problem_response(
+        request,
+        status.HTTP_413_CONTENT_TOO_LARGE,
+        str(exc),
+        problem_type=f"{PROBLEM_TYPE_BASE}/image-too-large",
+        limit=exc.limit,
+        actual=exc.actual,
+    )
+
+
+async def _handle_unsupported_type(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, UnsupportedImageTypeError)
+    return problem_response(
+        request,
+        status.HTTP_415_UNSUPPORTED_MEDIA_TYPE,
+        str(exc),
+        problem_type=f"{PROBLEM_TYPE_BASE}/unsupported-image-type",
+        detected_format=exc.detected,
+    )
+
+
+async def _handle_invalid_image(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, InvalidImageError)
+    return problem_response(
+        request,
+        status.HTTP_400_BAD_REQUEST,
+        str(exc),
+        problem_type=f"{PROBLEM_TYPE_BASE}/invalid-image",
+    )
+
+
+async def _handle_backend_failure(request: Request, exc: Exception) -> JSONResponse:
+    """Inference broke. Distinct from "no pose detected", which is a 201.
+
+    502 rather than 500: the fault is in a component this service depends on, and the distinction
+    is what tells an operator whether to look at the API or at the model.
+    """
+    assert isinstance(exc, PoseBackendError)
+    _LOGGER.exception("analysis_backend_failed", error_type=type(exc).__name__)
+    return problem_response(
+        request,
+        status.HTTP_502_BAD_GATEWAY,
+        "The pose backend failed while analysing this image.",
+        problem_type=f"{PROBLEM_TYPE_BASE}/pose-backend-failed",
+    )
+
+
+async def _handle_storage_failure(request: Request, exc: Exception) -> JSONResponse:
+    assert isinstance(exc, StorageError)
+    _LOGGER.exception("analysis_storage_failed", error_type=type(exc).__name__)
+    return problem_response(
+        request,
+        status.HTTP_502_BAD_GATEWAY,
+        "The image could not be stored.",
+        problem_type=f"{PROBLEM_TYPE_BASE}/storage-failed",
+    )
+
+
+def register_analysis_error_handlers(app: FastAPI) -> None:
+    """Map this module's exceptions onto problem documents.
+
+    Registered on the app rather than caught in the route, so the route reads as the happy path
+    and every failure produces the same envelope without a `try` around each step.
+    """
+    app.add_exception_handler(ImageTooLargeError, _handle_too_large)
+    app.add_exception_handler(UnsupportedImageTypeError, _handle_unsupported_type)
+    app.add_exception_handler(InvalidImageError, _handle_invalid_image)
+    app.add_exception_handler(PoseBackendError, _handle_backend_failure)
+    app.add_exception_handler(StorageError, _handle_storage_failure)

--- a/apps/api/src/openposture_api/images.py
+++ b/apps/api/src/openposture_api/images.py
@@ -25,6 +25,7 @@ import io
 from typing import TYPE_CHECKING, Final
 
 import numpy as np
+import structlog
 from PIL import Image, ImageOps, UnidentifiedImageError
 
 from openposture_api.storage import CONTENT_TYPE_SUFFIXES
@@ -41,6 +42,8 @@ __all__ = [
     "UnsupportedImageTypeError",
     "decode_upload",
 ]
+
+_LOGGER = structlog.get_logger(__name__)
 
 MAX_IMAGE_BYTES: Final = 10 * 1024 * 1024
 """10 MB, matching the plan. Comfortably above a phone photograph and far below anything that
@@ -155,7 +158,11 @@ def decode_upload(data: bytes) -> DecodedImage:
                     actual=pixels,
                 )
 
-            # Before any conversion, so the rotation applies to the image as stored.
+            # Applied to the array handed to the model, and *only* to that array. The bytes
+            # persisted by the storage layer are `DecodedImage.data` — the original upload,
+            # rotation flag intact — because the stored object should be the file the user
+            # actually sent. Re-encoding it here would make the evidence differ from the
+            # submission the moment a result is disputed.
             upright = ImageOps.exif_transpose(image) or image
             # `convert` after the transpose and before the array: RGBA and greyscale and palette
             # images all reach the backend as three channels, which is what it expects, and a
@@ -167,7 +174,15 @@ def decode_upload(data: bytes) -> DecodedImage:
     except OSError as exc:
         # Pillow raises OSError for truncated files, which are a genuine and common upload
         # failure rather than a server fault.
-        raise InvalidImageError(f"the uploaded image could not be read: {exc}") from exc
+        #
+        # Pillow's own message is deliberately not forwarded. This string reaches the client
+        # verbatim through the problem document, and decoder messages carry file paths and
+        # library internals that a user can do nothing with. The cause is logged with its
+        # traceback by the unhandled-exception path instead.
+        _LOGGER.info("image_decode_failed", error_type=type(exc).__name__, error=str(exc))
+        raise InvalidImageError(
+            "the uploaded image could not be read — it may be truncated or corrupt"
+        ) from exc
 
     # RGB -> BGR. The backend Protocol documents BGR, matching cv2's decode order, and getting it
     # wrong does not crash — it silently degrades detection in a way no assertion would catch.

--- a/apps/api/src/openposture_api/images.py
+++ b/apps/api/src/openposture_api/images.py
@@ -1,0 +1,177 @@
+"""Turning an uploaded file into an array the pose backend will accept.
+
+Three guards live here, and each one replaces a specific thing the original did wrong.
+
+**Size is enforced before decode.** `UploadFile` is spooled to disk by Starlette, so the bytes are
+not in memory yet when this runs — but a decoded image is, and a 50 MB PNG of mostly one colour
+decompresses to hundreds of megabytes of pixels. Checking the compressed length first is what
+keeps an upload from being a memory-exhaustion primitive. The original had no limit at all.
+
+**The media type comes from the decoded content, not from the request.** `Content-Type` is a
+client claim and a filename is worse — the original used `file.filename` as a storage key outright
+(FINDINGS §5.1). Pillow reports what it actually parsed, and that is what gets recorded and
+allowlisted.
+
+**EXIF orientation is applied.** Phone cameras almost always store the sensor's raw orientation
+plus a rotation flag rather than rotating the pixels. Decode without honouring the flag and a
+portrait photo arrives sideways, at which point every angular metric describes a person lying
+down — confidently and wrongly. `fixtures/images/desk_lean_exif.jpeg` exists to keep this honest;
+it retains `orientation=6`.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, Final
+
+import numpy as np
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+from openposture_api.storage import CONTENT_TYPE_SUFFIXES
+
+if TYPE_CHECKING:
+    from pose_backends.base import ImageBGR
+
+__all__ = [
+    "MAX_IMAGE_BYTES",
+    "MAX_PIXELS",
+    "DecodedImage",
+    "ImageTooLargeError",
+    "InvalidImageError",
+    "UnsupportedImageTypeError",
+    "decode_upload",
+]
+
+MAX_IMAGE_BYTES: Final = 10 * 1024 * 1024
+"""10 MB, matching the plan. Comfortably above a phone photograph and far below anything that
+threatens the process."""
+
+MAX_PIXELS: Final = 50_000_000
+"""Cap on *decoded* size, which compressed length does not bound.
+
+A decompression bomb is a small file that expands enormously — the classic example is a highly
+compressible PNG a few kilobytes long that decodes to gigapixels. 50 megapixels is roughly twice
+the largest consumer camera and about 200 MB as RGB, so a legitimate upload never approaches it.
+
+Pillow has its own `MAX_IMAGE_PIXELS` warning at ~89 MP, but it emits a warning rather than
+refusing, and a warning does not stop the allocation.
+"""
+
+_PILLOW_FORMAT_TO_MEDIA_TYPE: Final[dict[str, str]] = {
+    "JPEG": "image/jpeg",
+    "PNG": "image/png",
+    "WEBP": "image/webp",
+}
+"""What Pillow calls a format, mapped to what the web calls it.
+
+Keys are Pillow's `Image.format` values. The values are exactly the allowlist the storage layer
+publishes, and the check below asserts the two agree — an image the API accepts but storage
+refuses to write would be a 500 at the worst possible moment.
+"""
+
+if set(_PILLOW_FORMAT_TO_MEDIA_TYPE.values()) != set(CONTENT_TYPE_SUFFIXES):  # pragma: no cover
+    raise RuntimeError(
+        "the decoder's accepted formats and the storage layer's allowlist have diverged: "
+        f"{sorted(_PILLOW_FORMAT_TO_MEDIA_TYPE.values())} vs {sorted(CONTENT_TYPE_SUFFIXES)}"
+    )
+
+
+class InvalidImageError(Exception):
+    """The bytes are not an image this service can read."""
+
+
+class ImageTooLargeError(Exception):
+    """Too big to accept, by compressed length or by decoded pixel count."""
+
+    def __init__(self, message: str, *, limit: int, actual: int) -> None:
+        super().__init__(message)
+        self.limit = limit
+        self.actual = actual
+
+
+class UnsupportedImageTypeError(Exception):
+    """A real image, in a format outside the allowlist."""
+
+    def __init__(self, message: str, *, detected: str) -> None:
+        super().__init__(message)
+        self.detected = detected
+
+
+class DecodedImage:
+    """An upload that survived every check, in the form each consumer wants it.
+
+    Carries both the original bytes and the decoded array on purpose: storage persists exactly
+    what the user sent, while the backend needs pixels. Re-encoding for storage would mean the
+    stored object is not the file the user uploaded, which quietly ruins it as evidence when a
+    result is disputed — and it is the mirror of the legacy `draw()`, which read the same image
+    from disk twice rather than passing the one it already had.
+    """
+
+    __slots__ = ("array", "content_type", "data", "height", "width")
+
+    def __init__(self, *, data: bytes, array: ImageBGR, content_type: str) -> None:
+        self.data = data
+        self.array = array
+        self.content_type = content_type
+        self.height = int(array.shape[0])
+        self.width = int(array.shape[1])
+
+
+def decode_upload(data: bytes) -> DecodedImage:
+    """Validate and decode uploaded bytes.
+
+    :raises ImageTooLargeError: over the byte limit, or over the decoded pixel limit.
+    :raises UnsupportedImageTypeError: a readable image in a format outside the allowlist.
+    :raises InvalidImageError: not decodable as an image at all.
+    """
+    if len(data) > MAX_IMAGE_BYTES:
+        raise ImageTooLargeError(
+            f"image is {len(data)} bytes, over the {MAX_IMAGE_BYTES} byte limit",
+            limit=MAX_IMAGE_BYTES,
+            actual=len(data),
+        )
+
+    if not data:
+        raise InvalidImageError("the uploaded file is empty")
+
+    try:
+        # `Image.open` is lazy: it reads the header and stops. That is what allows the format and
+        # dimension checks below to happen *before* any pixel data is allocated.
+        with Image.open(io.BytesIO(data)) as image:
+            image_format = image.format or "unknown"
+            media_type = _PILLOW_FORMAT_TO_MEDIA_TYPE.get(image_format)
+            if media_type is None:
+                raise UnsupportedImageTypeError(
+                    f"{image_format} images are not supported. Supported formats: "
+                    f"{', '.join(sorted(_PILLOW_FORMAT_TO_MEDIA_TYPE))}.",
+                    detected=image_format,
+                )
+
+            pixels = image.width * image.height
+            if pixels > MAX_PIXELS:
+                raise ImageTooLargeError(
+                    f"image decodes to {pixels} pixels, over the {MAX_PIXELS} pixel limit",
+                    limit=MAX_PIXELS,
+                    actual=pixels,
+                )
+
+            # Before any conversion, so the rotation applies to the image as stored.
+            upright = ImageOps.exif_transpose(image) or image
+            # `convert` after the transpose and before the array: RGBA and greyscale and palette
+            # images all reach the backend as three channels, which is what it expects, and a
+            # transparent PNG does not arrive with an alpha channel the model would read as data.
+            rgb = upright.convert("RGB")
+            array = np.asarray(rgb, dtype=np.uint8)
+    except UnidentifiedImageError as exc:
+        raise InvalidImageError("the uploaded file could not be decoded as an image") from exc
+    except OSError as exc:
+        # Pillow raises OSError for truncated files, which are a genuine and common upload
+        # failure rather than a server fault.
+        raise InvalidImageError(f"the uploaded image could not be read: {exc}") from exc
+
+    # RGB -> BGR. The backend Protocol documents BGR, matching cv2's decode order, and getting it
+    # wrong does not crash — it silently degrades detection in a way no assertion would catch.
+    # `ascontiguousarray` because the reversed view has a negative stride.
+    bgr: ImageBGR = np.ascontiguousarray(array[:, :, ::-1])
+
+    return DecodedImage(data=data, array=bgr, content_type=media_type)

--- a/apps/api/src/openposture_api/main.py
+++ b/apps/api/src/openposture_api/main.py
@@ -23,6 +23,7 @@ import structlog
 from fastapi import FastAPI
 
 from openposture_api import __version__
+from openposture_api.analyses import build_analyses_router, register_analysis_error_handlers
 from openposture_api.config import Settings, get_settings
 from openposture_api.errors import register_error_handlers
 from openposture_api.health import ReadinessCheck, build_health_router
@@ -126,6 +127,7 @@ def create_app(
 
     register_error_handlers(app)
     app.add_exception_handler(PoseBackendUnavailableError, handle_pose_backend_unavailable)
+    register_analysis_error_handlers(app)
 
     # The probe reads `app.state` when it runs, not when it is registered, so binding it here —
     # before lifespan has produced a state — reports the real thing at request time.
@@ -138,6 +140,7 @@ def create_app(
     app.include_router(
         build_health_router(version=__version__, probes=probes),
     )
+    app.include_router(build_analyses_router())
 
     _LOGGER.info(
         "app_created",

--- a/apps/api/tests/test_analyses.py
+++ b/apps/api/tests/test_analyses.py
@@ -8,6 +8,7 @@ this project's story — an all-gaps report is a 201, not an error.
 from __future__ import annotations
 
 import io
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 import pytest
@@ -65,6 +66,7 @@ def storage(tmp_path: Path) -> LocalDiskStorage:
     return LocalDiskStorage(tmp_path / "objects")
 
 
+@contextmanager
 def build_client(
     settings: Settings,
     storage: LocalDiskStorage,
@@ -76,6 +78,10 @@ def build_client(
 
     `load_backend=False` plus two dependency overrides means this test touches no model file and
     writes nowhere but a temporary directory — which is the whole point of both seams.
+
+    A context manager rather than a bare generator. Called as `next(build_client(...))` the
+    generator is never closed, so the `with TestClient(...)` block below never exits: lifespan
+    shutdown does not run and the transport is left to the garbage collector.
     """
     app: FastAPI = create_app(settings, load_backend=False)
     app.dependency_overrides[get_pose_backend] = lambda: backend or FakePoseBackend(preset)
@@ -86,7 +92,8 @@ def build_client(
 
 @pytest.fixture
 def client(settings: Settings, storage: LocalDiskStorage) -> Iterator[TestClient]:
-    yield from build_client(settings, storage)
+    with build_client(settings, storage) as test_client:
+        yield test_client
 
 
 def upload(client: TestClient, data: bytes, *, filename: str = "photo.jpg") -> Any:
@@ -166,9 +173,9 @@ class TestExifOrientation:
         # landscape and the displayed image is portrait.
         rotated = make_image(width=640, height=480, orientation=6)
 
-        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a")))
-        upright_body = upload(client, upright).json()
-        rotated_body = upload(client, rotated).json()
+        with build_client(settings, LocalDiskStorage(tmp_path / "a")) as client:
+            upright_body = upload(client, upright).json()
+            rotated_body = upload(client, rotated).json()
 
         assert rotated_body["image"] == upright_body["image"]
         assert rotated_body["image"] == {"width": 480, "height": 640}
@@ -177,11 +184,10 @@ class TestExifOrientation:
 class TestAbstention:
     def test_no_person_is_a_201_not_an_error(self, settings: Settings, tmp_path: Path) -> None:
         """The user photographed their desk. The request succeeded; the answer is "nobody here"."""
-        client = next(
-            build_client(settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.NO_PERSON)
-        )
-
-        response = upload(client, make_image())
+        with build_client(
+            settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.NO_PERSON
+        ) as client:
+            response = upload(client, make_image())
 
         assert response.status_code == 201
         body = response.json()
@@ -195,31 +201,25 @@ class TestAbstention:
     ) -> None:
         """Gaps are the output C3 exists to produce. A 4xx here would throw them away and put the
         frontend into a generic error state — the original's silent-default defect in reverse."""
-        client = next(
-            build_client(
-                settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
-            )
-        )
+        with build_client(
+            settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
+        ) as client:
+            response = upload(client, make_image())
 
-        response = upload(client, make_image())
-
-        assert response.status_code == 201
-        quality = response.json()["report"]["quality"]
-        assert quality["gaps"]
-        assert quality["assessed"] < quality["total"]
+            assert response.status_code == 201
+            quality = response.json()["report"]["quality"]
+            assert quality["gaps"]
+            assert quality["assessed"] < quality["total"]
 
     def test_gaps_name_the_metric_and_why(self, settings: Settings, tmp_path: Path) -> None:
         """ "Couldn't assess your knees, try a wider shot" needs both halves."""
-        client = next(
-            build_client(
-                settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
-            )
-        )
+        with build_client(
+            settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
+        ) as client:
+            gaps = upload(client, make_image()).json()["report"]["quality"]["gaps"]
 
-        gaps = upload(client, make_image()).json()["report"]["quality"]["gaps"]
-
-        assert all(gap["metric"] for gap in gaps)
-        assert all(gap["status"] for gap in gaps)
+            assert all(gap["metric"] for gap in gaps)
+            assert all(gap["status"] for gap in gaps)
 
 
 class TestRejections:
@@ -298,9 +298,8 @@ class TestBackendFailure:
             def warmup(self) -> None:
                 return
 
-        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()))
-
-        response = upload(client, make_image())
+        with build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()) as client:
+            response = upload(client, make_image())
 
         assert response.status_code == 502
         assert response.json()["type"].endswith("/pose-backend-failed")
@@ -317,9 +316,8 @@ class TestBackendFailure:
             def warmup(self) -> None:
                 return
 
-        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()))
-
-        response = upload(client, make_image())
+        with build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()) as client:
+            response = upload(client, make_image())
 
         assert "/srv/secrets" not in response.text
 

--- a/apps/api/tests/test_analyses.py
+++ b/apps/api/tests/test_analyses.py
@@ -1,0 +1,336 @@
+"""The upload endpoint, and every way it can be handed something it should refuse.
+
+The ticket names seven cases: valid upload, oversize, disallowed type, undecodable file, no
+person, low confidence, and backend failure. Each is here, plus the one that matters most for
+this project's story — an all-gaps report is a 201, not an error.
+"""
+
+from __future__ import annotations
+
+import io
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+
+from openposture_api.config import Settings
+from openposture_api.images import MAX_IMAGE_BYTES
+from openposture_api.main import create_app
+from openposture_api.pose import get_pose_backend
+from openposture_api.storage import LocalDiskStorage, get_storage
+from pose_backends.errors import ModelLoadError
+from pose_backends.fake import FakePoseBackend, PosePreset
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+ENDPOINT = "/api/v1/analyses"
+
+
+def make_image(
+    *,
+    width: int = 640,
+    height: int = 480,
+    fmt: str = "JPEG",
+    orientation: int | None = None,
+) -> bytes:
+    """A small real image in the requested format.
+
+    Real bytes rather than a stub, because the point of this layer is that it decodes what it is
+    given — a fake would prove nothing about Pillow's behaviour, which is the behaviour under
+    test.
+    """
+    image = Image.new("RGB", (width, height), color=(120, 130, 140))
+    # A little structure, so the encoder cannot collapse it to something degenerate.
+    for x in range(0, width, 8):
+        for y in range(0, height, 8):
+            image.putpixel((x, y), (200, 40, 40))
+
+    buffer = io.BytesIO()
+    if orientation is not None:
+        exif = image.getexif()
+        exif[0x0112] = orientation
+        image.save(buffer, format=fmt, exif=exif)
+    else:
+        image.save(buffer, format=fmt)
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> LocalDiskStorage:
+    return LocalDiskStorage(tmp_path / "objects")
+
+
+def build_client(
+    settings: Settings,
+    storage: LocalDiskStorage,
+    *,
+    preset: PosePreset = PosePreset.STRAIGHT,
+    backend: object | None = None,
+) -> Iterator[TestClient]:
+    """An app whose pose backend and storage are both substituted.
+
+    `load_backend=False` plus two dependency overrides means this test touches no model file and
+    writes nowhere but a temporary directory — which is the whole point of both seams.
+    """
+    app: FastAPI = create_app(settings, load_backend=False)
+    app.dependency_overrides[get_pose_backend] = lambda: backend or FakePoseBackend(preset)
+    app.dependency_overrides[get_storage] = lambda: storage
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+@pytest.fixture
+def client(settings: Settings, storage: LocalDiskStorage) -> Iterator[TestClient]:
+    yield from build_client(settings, storage)
+
+
+def upload(client: TestClient, data: bytes, *, filename: str = "photo.jpg") -> Any:
+    return client.post(ENDPOINT, files={"image": (filename, data, "image/jpeg")})
+
+
+class TestValidUpload:
+    def test_a_photograph_produces_a_report(self, client: TestClient) -> None:
+        """The assertion the whole project exists to make true."""
+        response = upload(client, make_image())
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["pose_detected"] is True
+        assert body["report"]["schema_version"]
+        assert body["report"]["metrics"]
+
+    def test_the_report_carries_real_measured_values(self, client: TestClient) -> None:
+        """Not a placeholder, not a constant string — a number describing the pose."""
+        body = upload(client, make_image()).json()
+
+        trunk = body["report"]["metrics"]["trunk_inclination_deg"]
+
+        assert trunk["status"] == "ok"
+        assert isinstance(trunk["value"], (int, float))
+
+    def test_the_original_bytes_are_stored_and_the_key_returned(
+        self, client: TestClient, storage: LocalDiskStorage
+    ) -> None:
+        """A key, not a URL. See the storage layer's module docstring."""
+        data = make_image()
+
+        body = upload(client, data).json()
+
+        assert storage.get(body["object_key"]) == data
+        assert "://" not in body["object_key"]
+
+    def test_the_uploaded_filename_never_becomes_the_key(self, client: TestClient) -> None:
+        """The legacy `/upload` used `file.filename` directly (FINDINGS §5.1). Here the filename
+        is hostile and the key is unaffected, because the filename never reaches storage."""
+        body = upload(client, make_image(), filename="../../etc/passwd").json()
+
+        assert body["object_key"].startswith("analyses/")
+        assert "passwd" not in body["object_key"]
+        assert ".." not in body["object_key"]
+
+    def test_the_declared_content_type_does_not_decide_the_stored_type(
+        self, client: TestClient, storage: LocalDiskStorage
+    ) -> None:
+        """A PNG announced as `image/jpeg` is stored as a PNG. The header is a client claim; the
+        decoded content is the fact."""
+        png = make_image(fmt="PNG")
+
+        response = client.post(ENDPOINT, files={"image": ("lies.jpg", png, "image/jpeg")})
+
+        assert response.status_code == 201
+        assert response.json()["object_key"].endswith(".png")
+
+    @pytest.mark.parametrize("fmt", ["JPEG", "PNG", "WEBP"])
+    def test_every_allowed_format_is_accepted(self, client: TestClient, fmt: str) -> None:
+        assert upload(client, make_image(fmt=fmt)).status_code == 201
+
+
+class TestExifOrientation:
+    def test_a_rotated_photo_produces_the_same_report_as_its_upright_twin(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        """The acceptance criterion, and the single most likely source of confidently wrong
+        answers in real use: a phone photo carries a rotation flag rather than rotated pixels,
+        and a decoder that ignores it hands the model a person lying down.
+
+        Asserted on the reported image dimensions, because the fake backend ignores pixels — a
+        portrait image decoded without the transpose comes back landscape.
+        """
+        upright = make_image(width=480, height=640)
+        # Orientation 6 means "rotate 90° clockwise to display", so the stored pixels are
+        # landscape and the displayed image is portrait.
+        rotated = make_image(width=640, height=480, orientation=6)
+
+        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a")))
+        upright_body = upload(client, upright).json()
+        rotated_body = upload(client, rotated).json()
+
+        assert rotated_body["image"] == upright_body["image"]
+        assert rotated_body["image"] == {"width": 480, "height": 640}
+
+
+class TestAbstention:
+    def test_no_person_is_a_201_not_an_error(self, settings: Settings, tmp_path: Path) -> None:
+        """The user photographed their desk. The request succeeded; the answer is "nobody here"."""
+        client = next(
+            build_client(settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.NO_PERSON)
+        )
+
+        response = upload(client, make_image())
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["pose_detected"] is False
+        assert body["report"] is None
+        # Still stored: the image is evidence even when nothing was found in it.
+        assert body["object_key"]
+
+    def test_a_partly_occluded_pose_returns_201_with_gaps(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        """Gaps are the output C3 exists to produce. A 4xx here would throw them away and put the
+        frontend into a generic error state — the original's silent-default defect in reverse."""
+        client = next(
+            build_client(
+                settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
+            )
+        )
+
+        response = upload(client, make_image())
+
+        assert response.status_code == 201
+        quality = response.json()["report"]["quality"]
+        assert quality["gaps"]
+        assert quality["assessed"] < quality["total"]
+
+    def test_gaps_name_the_metric_and_why(self, settings: Settings, tmp_path: Path) -> None:
+        """ "Couldn't assess your knees, try a wider shot" needs both halves."""
+        client = next(
+            build_client(
+                settings, LocalDiskStorage(tmp_path / "a"), preset=PosePreset.PARTIAL_OCCLUSION
+            )
+        )
+
+        gaps = upload(client, make_image()).json()["report"]["quality"]["gaps"]
+
+        assert all(gap["metric"] for gap in gaps)
+        assert all(gap["status"] for gap in gaps)
+
+
+class TestRejections:
+    def test_an_oversize_upload_is_refused(self, client: TestClient) -> None:
+        oversize = b"\xff\xd8\xff\xe0" + b"\x00" * (MAX_IMAGE_BYTES + 1)
+
+        response = upload(client, oversize)
+
+        assert response.status_code == 413
+        body = response.json()
+        assert body["type"].endswith("/image-too-large")
+        assert body["limit"] == MAX_IMAGE_BYTES
+
+    def test_the_size_check_happens_before_decoding(self, client: TestClient) -> None:
+        """The payload is not a valid image at all. A 413 rather than a 400 proves the limit was
+        applied first — which is the difference between rejecting a 2 GB upload and decoding it."""
+        response = upload(client, b"\x00" * (MAX_IMAGE_BYTES + 1))
+
+        assert response.status_code == 413
+
+    def test_a_disallowed_format_is_refused(self, client: TestClient) -> None:
+        """A real image, in a format outside the allowlist. GIF decodes fine and is not accepted."""
+        buffer = io.BytesIO()
+        Image.new("RGB", (32, 32), color=(1, 2, 3)).save(buffer, format="GIF")
+
+        response = upload(client, buffer.getvalue())
+
+        assert response.status_code == 415
+        body = response.json()
+        assert body["type"].endswith("/unsupported-image-type")
+        assert body["detected_format"] == "GIF"
+
+    def test_an_undecodable_file_is_refused(self, client: TestClient) -> None:
+        response = upload(client, b"this is not an image, it is a sentence")
+
+        assert response.status_code == 400
+        assert response.json()["type"].endswith("/invalid-image")
+
+    def test_an_empty_file_is_refused(self, client: TestClient) -> None:
+        response = upload(client, b"")
+
+        assert response.status_code == 400
+
+    def test_a_truncated_image_is_refused(self, client: TestClient) -> None:
+        """A real upload failure mode, not a malicious one: the connection dropped mid-transfer."""
+        response = upload(client, make_image()[:200])
+
+        assert response.status_code == 400
+
+    def test_a_missing_file_field_is_a_validation_error(self, client: TestClient) -> None:
+        response = client.post(ENDPOINT)
+
+        assert response.status_code == 422
+        assert response.json()["type"].endswith("/validation-error")
+
+    def test_every_rejection_uses_the_problem_envelope(self, client: TestClient) -> None:
+        """One error parser for the frontend, whatever went wrong."""
+        for payload in (b"", b"nonsense", b"\x00" * (MAX_IMAGE_BYTES + 1)):
+            response = upload(client, payload)
+
+            assert response.headers["content-type"].startswith("application/problem+json")
+            assert set(response.json()) >= {"type", "title", "status", "detail", "instance"}
+
+
+class TestBackendFailure:
+    def test_a_broken_backend_is_a_502_not_a_500(self, settings: Settings, tmp_path: Path) -> None:
+        """502 says the fault is downstream of this service, which is what tells an operator to
+        look at the model rather than at the API."""
+
+        class _Broken:
+            name = "broken"
+
+            def detect(self, image_bgr: object) -> None:
+                raise ModelLoadError("the graph could not be built")
+
+            def warmup(self) -> None:
+                return
+
+        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()))
+
+        response = upload(client, make_image())
+
+        assert response.status_code == 502
+        assert response.json()["type"].endswith("/pose-backend-failed")
+
+    def test_the_backend_error_text_does_not_reach_the_client(
+        self, settings: Settings, tmp_path: Path
+    ) -> None:
+        class _Broken:
+            name = "broken"
+
+            def detect(self, image_bgr: object) -> None:
+                raise ModelLoadError("/srv/secrets/model.task is corrupt")
+
+            def warmup(self) -> None:
+                return
+
+        client = next(build_client(settings, LocalDiskStorage(tmp_path / "a"), backend=_Broken()))
+
+        response = upload(client, make_image())
+
+        assert "/srv/secrets" not in response.text
+
+    def test_an_unavailable_backend_is_a_503(self, settings: Settings, tmp_path: Path) -> None:
+        """No override at all: the app started without loading a backend, which is what a missing
+        model file looks like in production."""
+        app = create_app(settings, load_backend=False)
+        app.dependency_overrides[get_storage] = lambda: LocalDiskStorage(tmp_path / "a")
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = upload(client, make_image())
+
+        assert response.status_code == 503
+        assert response.json()["type"].endswith("/pose-backend-unavailable")

--- a/uv.lock
+++ b/uv.lock
@@ -1392,9 +1392,11 @@ source = { editable = "apps/api" }
 dependencies = [
     { name = "boto3" },
     { name = "fastapi" },
+    { name = "pillow" },
     { name = "pose-backends" },
     { name = "posture-core" },
     { name = "pydantic-settings" },
+    { name = "python-multipart" },
     { name = "structlog" },
 ]
 
@@ -1413,9 +1415,11 @@ dev = [
 requires-dist = [
     { name = "boto3", specifier = ">=1.35" },
     { name = "fastapi", specifier = ">=0.115" },
+    { name = "pillow", specifier = ">=11.0" },
     { name = "pose-backends", editable = "packages/pose-backends" },
     { name = "posture-core", editable = "packages/posture-core" },
     { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.34" },
 ]
@@ -1835,6 +1839,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.32"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Stacked on `op-41-storage-backends` (#47).** Review that one first; this PR retargets to `main` once it merges.

A photograph goes in and a report derived from that body comes out. Until this route existed the project was scaffolding.

## Changes

- `openposture_api.images` — decode, validate and EXIF-correct an upload. `openposture_api.analyses` — the route, and problem-document handlers for each way it can fail.
- Size is enforced **while reading**, in 64 KB chunks, not after `await read()`. The naive version has already materialised the whole payload before deciding to reject it, so a 2 GB upload is a 2 GB allocation regardless of the limit.
- A second cap on **decoded** pixels (50 MP). Compressed length does not bound decoded size — a few-kilobyte PNG can decode to gigapixels.
- Media type is taken from what Pillow actually parsed, not from `Content-Type` and not from the filename. A PNG announced as `image/jpeg` is stored as a PNG.
- EXIF orientation is applied before anything else. Without it a phone photo reaches the model sideways and every angular metric describes a person lying down.
- The response uses `PostureReport.to_dict()`, the engine's own serialiser, shared with the CLI and the golden corpus.

## Notes

- **An abstaining report is a 201.** All-gaps and no-person both succeed, because the request was well-formed and "I could not see enough of you to say" is the answer. A 4xx would discard the gap detail the status model exists to produce.
- Backend failure is 502, not 500: the fault is downstream of this service, and that is what tells an operator where to look. Exception text is never echoed.
- `detect()` runs on the event loop rather than in a threadpool. At ~25 ms with the pinned model the context switch costs more than it saves; the comment says what changes that.
- New dependencies: `pillow` and `python-multipart`.

## Tests

23 endpoint tests covering the seven cases the ticket names, plus hostile filename, declared-vs-actual content type, truncated file, and empty file.

The EXIF test was verified non-vacuous by removing `exif_transpose` — it fails without it.

`openposture_api` coverage 97%, floor is 85%.