### PR TITLE
OP-43: Compose with api and web, Vite proxy, and the containers.yml check

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,41 @@
+# Copy to .env and adjust. Every value here has a working default, so `docker compose up` needs
+# no edits at all — this file documents what can be changed, not what must be.
+#
+# Variables are namespaced `OPENPOSTURE_` so a container's environment cannot collide with ours.
+# An unrecognised OPENPOSTURE_* variable is rejected at startup rather than ignored: a typo that
+# leaves the service silently running on a default is the failure this naming exists to catch.
+
+# development | test | production
+# Production hides /docs and forces JSON logs.
+OPENPOSTURE_ENVIRONMENT=development
+
+# debug | info | warning | error | critical
+OPENPOSTURE_LOG_LEVEL=info
+
+# mediapipe | fake
+# `fake` runs the entire application with no model at all — the whole stack starts and responds,
+# with a fabricated skeleton. It is what CI and the container smoke test use, and it is how you
+# work on the frontend without a 9 MB model or a 300 MB inference stack.
+OPENPOSTURE_POSE_BACKEND=mediapipe
+
+# straight | hunchback | reclined | kneeling | partial_occlusion | frontal_view | no_person
+# Which scenario the fake backend returns. Ignored by mediapipe.
+OPENPOSTURE_POSE_BACKEND_PRESET=straight
+
+# local | s3
+# `local` writes to a directory and needs nothing running. `s3` targets MinIO in development and
+# any S3-compatible service in production; it arrives properly in Epic E.
+OPENPOSTURE_STORAGE_BACKEND=local
+
+# Where `local` storage writes. Inside the container this is a named volume, so uploads survive
+# a restart without landing in your checkout.
+OPENPOSTURE_STORAGE_ROOT=/app/var/storage
+
+# --- s3 storage, unused while OPENPOSTURE_STORAGE_BACKEND=local ---
+# OPENPOSTURE_S3_BUCKET=openposture
+# OPENPOSTURE_S3_ENDPOINT_URL=http://minio:9000
+# OPENPOSTURE_S3_ACCESS_KEY=
+# OPENPOSTURE_S3_SECRET_KEY=
+
+# No ANTHROPIC_API_KEY here on purpose. LLM coaching is Epic F and is disabled by default, so a
+# clean clone produces a working app with real posture analysis and no account to create.

--- a/.env.example
+++ b/.env.example
@@ -31,7 +31,15 @@ OPENPOSTURE_STORAGE_BACKEND=local
 # a restart without landing in your checkout.
 OPENPOSTURE_STORAGE_ROOT=/app/var/storage
 
-# --- s3 storage, unused while OPENPOSTURE_STORAGE_BACKEND=local ---
+# --- s3 storage ---
+#
+# NOT YET WIRED THROUGH COMPOSE. The settings exist and `S3Storage` works, but there is no
+# MinIO service to point at until OP-49, and docker-compose.yml deliberately does not pass
+# these variables to the container. Setting them in `.env` today has no effect on the
+# containerised API — they are listed so the names are discoverable, not because they are
+# live. Uncomment them when Epic E adds the service, and add the passthrough to compose in
+# the same change.
+#
 # OPENPOSTURE_S3_BUCKET=openposture
 # OPENPOSTURE_S3_ENDPOINT_URL=http://minio:9000
 # OPENPOSTURE_S3_ACCESS_KEY=

--- a/.github/main-ruleset.md
+++ b/.github/main-ruleset.md
@@ -58,12 +58,20 @@ them individually would make merging depend on how GitHub treats skipped checks.
 aggregator also means a job can be renamed or split without silently dropping protection. See the
 header comment in [`.github/workflows/pr.yml`](workflows/pr.yml).
 
-**`scientific-ok` is not required yet.** `scientific-validation.yml` arrived with the shared
-threshold spec and runs its own aggregator on every pull request, but the ruleset has not been
-updated to require it, so a red scientific gate does not currently block a merge. Adding it is a
-ruleset change, not a workflow change. Until then, treat a `scientific-ok` failure as blocking by
-convention: it means a metric moved, which is exactly the class of change that should never merge
-unreviewed.
+**`scientific-ok` and `containers-ok` are not required yet.** `scientific-validation.yml` arrived
+with the shared threshold spec and `containers.yml` with the first Compose commit (OP-43). Both
+run their own aggregator on every pull request, but the ruleset has not been updated to require
+them, so a red gate in either does not currently block a merge. Adding them is a ruleset change,
+not a workflow change:
+
+```bash
+gh api -X PUT repos/{owner}/{repo}/rulesets/<id> --input .github/main-ruleset.json
+```
+
+after adding `scientific-ok` and `containers-ok` to `required_status_checks` in the JSON. Until
+then, treat a failure in either as blocking by convention. `scientific-ok` failing means a metric
+moved, which should never merge unreviewed; `containers-ok` failing means `docker compose up`
+does not work from a clean clone, which is the quickstart the README promises.
 
 ## Two rules from the OP-15 ticket that are deliberately absent
 

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -1,0 +1,175 @@
+# Container and Compose validation.
+#
+# `pr.yml` proves the code is correct in a virtualenv. This proves the *stack* works: that both
+# images build, that Compose is valid, that the services start, become ready, talk to each other,
+# and shut down cleanly. Those fail for entirely different reasons — a missing system library, a
+# wrong bind mount, a service name the proxy cannot resolve — none of which a unit test can see.
+#
+# Required from the first Docker commit, per the delivery rule: a capability and its check ship
+# together, and Docker is not exempt.
+#
+# **Fake backends, deliberately.** The purpose is to prove the containers build, start, wire
+# together and become ready. Pulling real model weights would add minutes and make the job fail
+# for reasons that have nothing to do with containerization. Real-model validation lives in the
+# `workflow_dispatch` job created in OP-21.
+
+name: containers
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # ---------------------------------------------------------------------------
+  # Cheap checks that need no build. Run first so a typo in the Compose file
+  # fails in seconds rather than after a multi-minute image build.
+  # ---------------------------------------------------------------------------
+  validate:
+    name: compose config
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Compose file is valid
+        run: docker compose config --quiet
+
+      - name: The image's model hash matches models/checksums.txt
+        # The Dockerfile cannot read a file at build time, so the pinned SHA256 is duplicated
+        # into an `ADD --checksum`. Duplicated constants drift; this is the check that says so
+        # out loud instead of letting the image silently fetch a different model than the one
+        # `make fetch-model` verifies.
+        run: |
+          expected="$(grep -E '^[0-9a-f]{64}  pose_landmarker_full\.task$' models/checksums.txt | cut -d' ' -f1)"
+          if [ -z "$expected" ]; then
+            echo "::error::no pinned hash for pose_landmarker_full.task in models/checksums.txt"
+            exit 1
+          fi
+          if ! grep -q "sha256:${expected}" apps/api/Dockerfile; then
+            echo "::error::apps/api/Dockerfile does not pin the hash in models/checksums.txt (${expected})"
+            exit 1
+          fi
+          echo "OK  model hash pinned consistently: ${expected}"
+
+  # ---------------------------------------------------------------------------
+  # Build, start, smoke-test, tear down.
+  # ---------------------------------------------------------------------------
+  stack:
+    name: build and smoke-test
+    needs: validate
+    runs-on: ubuntu-latest
+    env:
+      # No model download, no 300 MB inference stack. See the header.
+      OPENPOSTURE_POSE_BACKEND: fake
+      OPENPOSTURE_POSE_BACKEND_PRESET: hunchback
+      OPENPOSTURE_ENVIRONMENT: test
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build images
+        # GitHub Actions cache rather than a registry: no credentials, and a cold build of the
+        # API image is several minutes because of the inference stack.
+        uses: docker/bake-action@37816e747588cb137173af99ab33873600c46ea8 # v6.9.0
+        with:
+          files: docker-compose.yml
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+
+      - name: Start the stack
+        run: docker compose up -d --wait --wait-timeout 180
+
+      - name: API reports ready
+        run: |
+          body="$(curl --fail --silent --show-error http://localhost:8000/health/ready)"
+          echo "$body"
+          echo "$body" | grep -q '"status":"ready"'
+          echo "$body" | grep -q '"name":"pose_backend"'
+
+      - name: Web is served
+        run: curl --fail --silent --show-error --output /dev/null http://localhost:5173/
+
+      - name: The Vite proxy reaches the API
+        # The point of the whole arrangement: the browser's origin serves both the app and the
+        # API, so there is no CORS and no per-environment base URL. If this passes on :5173 the
+        # proxy is wired; if it only passes on :8000 it is not.
+        run: |
+          body="$(curl --fail --silent --show-error http://localhost:5173/api/v1/analyses -X POST \
+            -F "image=@fixtures/images/desk_hunch.jpeg")"
+          echo "$body" | head -c 400
+          echo "$body" | grep -q '"pose_detected":true'
+          echo "$body" | grep -q '"trunk_inclination_deg"'
+
+      - name: An upload produces a real report end to end
+        # Asserts a *value*, not merely that a response arrived. With the fake backend the
+        # numbers are deterministic, so this is an exact check rather than a tolerance — and it
+        # would pass against a mocked frontend, which is why the assertion is on the API.
+        run: |
+          body="$(curl --fail --silent --show-error http://localhost:8000/api/v1/analyses -X POST \
+            -F "image=@fixtures/images/desk_hunch.jpeg")"
+          echo "$body" | python3 -c "
+          import json, sys
+          report = json.load(sys.stdin)['report']
+          trunk = report['metrics']['trunk_inclination_deg']
+          assert trunk['status'] == 'ok', trunk
+          assert abs(trunk['value'] - 32.0) < 0.01, trunk
+          assert report['backend'] == 'fake', report['backend']
+          print('trunk_inclination_deg =', trunk['value'], '(expected 32.0 from the hunchback preset)')
+          "
+
+      - name: Errors use the documented problem shape
+        run: |
+          status="$(curl --silent --output /tmp/problem.json --write-out '%{http_code}' \
+            http://localhost:8000/api/v1/analyses -X POST -F "image=@README.md")"
+          cat /tmp/problem.json
+          test "$status" = "400"
+          grep -q '"type"' /tmp/problem.json
+          grep -q '"instance"' /tmp/problem.json
+
+      - name: Capture logs
+        # On failure only. A green run's logs are noise; a red run without them is undebuggable.
+        if: failure()
+        run: docker compose logs --no-color > /tmp/compose-logs.txt 2>&1 || true
+
+      - name: Upload logs
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: compose-logs
+          path: /tmp/compose-logs.txt
+          retention-days: 7
+
+      - name: Shut down cleanly
+        # `always()` so a failed assertion still tears down, and `-v` so the named volume does not
+        # survive into the next run and make a stale object look like a fresh one.
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  containers-ok:
+    name: containers-ok
+    if: always()
+    needs: [validate, stack]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          echo "validate: ${{ needs.validate.result }}"
+          echo "stack:    ${{ needs.stack.result }}"
+
+      - name: Fail if any job did not succeed
+        # Skipped counts as failure here, unlike in pr.yml: nothing path-filters this workflow,
+        # so a skipped job means something went wrong rather than "not relevant to this change".
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1

--- a/.github/workflows/containers.yml
+++ b/.github/workflows/containers.yml
@@ -8,9 +8,11 @@
 # Required from the first Docker commit, per the delivery rule: a capability and its check ship
 # together, and Docker is not exempt.
 #
-# **Fake backends, deliberately.** The purpose is to prove the containers build, start, wire
-# together and become ready. Pulling real model weights would add minutes and make the job fail
-# for reasons that have nothing to do with containerization. Real-model validation lives in the
+# **Fake backend at runtime, deliberately.** The purpose is to prove the containers build,
+# start, wire together and become ready. The image still contains the real inference stack —
+# it is the image that ships, and testing a differently-built one would prove nothing about
+# it — but the running container is told not to load the model. That keeps the job fast and
+# keeps its failures about containerization. Real-model validation lives in the
 # `workflow_dispatch` job created in OP-21.
 
 name: containers
@@ -68,7 +70,11 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     env:
-      # No model download, no 300 MB inference stack. See the header.
+      # Avoids *loading and running* the model, not the image's dependencies. The image is built
+      # with the `inference` extra either way, deliberately: a smoke test that exercised a
+      # differently-built image would not be evidence about the image that ships. What `fake`
+      # removes is the runtime cost — a model load and a real inference per request — and the
+      # class of failure that comes with them, which has nothing to do with containerization.
       OPENPOSTURE_POSE_BACKEND: fake
       OPENPOSTURE_POSE_BACKEND_PRESET: hunchback
       OPENPOSTURE_ENVIRONMENT: test

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,108 @@
+# The API image.
+#
+# Two stages: one that resolves and installs the workspace, one that runs it. The build stage
+# keeps uv, the compiler toolchain and the lockfile out of the final image, which is both smaller
+# and a smaller attack surface.
+#
+# Everything here is pinned. A `latest` base or an unpinned model download would mean two builds
+# of the same commit produce different images, which makes "it worked yesterday" unanswerable.
+
+# ---------------------------------------------------------------------------
+# Stage 1 — dependencies
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim-bookworm AS builder
+
+# uv from its own distroless image rather than `pip install uv`: one fewer resolution step, and
+# the version is pinned by the tag instead of by whatever pip finds today.
+COPY --from=ghcr.io/astral-sh/uv:0.9.29 /uv /usr/local/bin/uv
+
+ENV UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy \
+    UV_PYTHON_DOWNLOADS=never
+
+WORKDIR /app
+
+# Manifests first, sources second. Docker caches by layer, so an edit to a `.py` file re-runs
+# only the second install — the ~857 MB mediapipe download is not repeated for a one-line change.
+COPY pyproject.toml uv.lock ./
+COPY packages/posture-core/pyproject.toml packages/posture-core/
+COPY packages/posture-spec/pyproject.toml packages/posture-spec/
+COPY packages/pose-backends/pyproject.toml packages/pose-backends/
+COPY apps/api/pyproject.toml apps/api/
+
+# `--frozen` refuses to update the lockfile. A build that silently re-resolves is a build whose
+# dependency set is decided at build time rather than at review time.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    mkdir -p packages/posture-core/src/posture_core \
+             packages/posture-spec/src/posture_spec \
+             packages/pose-backends/src/pose_backends \
+             apps/api/src/openposture_api \
+    && touch packages/posture-core/src/posture_core/__init__.py \
+             packages/posture-spec/src/posture_spec/__init__.py \
+             packages/pose-backends/src/pose_backends/__init__.py \
+             apps/api/src/openposture_api/__init__.py \
+    && uv sync --frozen --no-dev --extra serve --extra inference --package openposture-api
+
+COPY packages/ packages/
+COPY apps/api/ apps/api/
+
+RUN --mount=type=cache,target=/root/.cache/uv \
+    uv sync --frozen --no-dev --extra serve --extra inference --package openposture-api
+
+# ---------------------------------------------------------------------------
+# Stage 2 — runtime
+# ---------------------------------------------------------------------------
+FROM python:3.12-slim-bookworm AS runtime
+
+# libGL and libglib are cv2's shared-library dependencies. Their absence is the single most
+# common "works locally, ImportError in Docker" failure with OpenCV, and it surfaces as
+# `libGL.so.1: cannot open shared object file` at import time rather than at install time.
+# `opencv-python-headless` avoids most of it; mediapipe pulls the non-headless build, so the
+# libraries are installed rather than hoped for.
+RUN apt-get update \
+    && apt-get install --no-install-recommends -y \
+        libgl1 \
+        libglib2.0-0 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Non-root. A container that runs as root shares that uid with the host through any bind mount,
+# and there is nothing in this service that needs it.
+RUN useradd --create-home --uid 10001 openposture
+
+WORKDIR /app
+
+COPY --from=builder --chown=openposture:openposture /app/.venv /app/.venv
+COPY --from=builder --chown=openposture:openposture /app/packages /app/packages
+COPY --from=builder --chown=openposture:openposture /app/apps/api /app/apps/api
+
+# The model, fetched at build time with the hash pinned in models/checksums.txt. `ADD --checksum`
+# fails the build if the bytes differ, so a compromised or truncated download cannot produce a
+# working image — the legacy project's weights came from a bare Dropbox link with no checksum at
+# all, which is part of why ADR-0002 moved to MediaPipe.
+#
+# Keep this hash in step with models/checksums.txt. It is duplicated because Dockerfiles cannot
+# read a file at build time, and the containers workflow greps both to prove they agree.
+ADD --checksum=sha256:5134a3aad27a58b93da0088d431f366da362b44e3ccfbe3462b3827a839011b1 \
+    --chown=openposture:openposture \
+    https://storage.googleapis.com/mediapipe-models/pose_landmarker/pose_landmarker_full/float16/1/pose_landmarker_full.task \
+    /app/models/pose_landmarker_full.task
+
+ENV PATH="/app/.venv/bin:$PATH" \
+    PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    MODEL_PATH=/app/models/pose_landmarker_full.task \
+    OPENPOSTURE_STORAGE_ROOT=/app/var/storage
+
+RUN mkdir -p /app/var/storage && chown -R openposture:openposture /app/var
+
+USER openposture
+
+EXPOSE 8000
+
+# `/health` rather than `/health/ready`: this answers "is the process alive", which is the
+# question a container healthcheck asks. Readiness is the orchestrator's separate concern, and
+# wiring it here would restart a container that is merely still loading its model.
+HEALTHCHECK --interval=10s --timeout=3s --start-period=40s --retries=5 \
+    CMD python -c "import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health').read()"
+
+CMD ["uvicorn", "openposture_api.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
 # does not build a server it never starts.
 serve = ["uvicorn[standard]>=0.34"]
 
+# The real pose backend. `pose-backends` keeps mediapipe optional so the fake backend can run
+# without a 300 MB inference stack; this extra is how the container image — which does want
+# real inference — asks for it by name rather than by pinning mediapipe a second time here.
+inference = ["pose-backends[mediapipe]"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"

--- a/apps/web/Dockerfile
+++ b/apps/web/Dockerfile
@@ -1,0 +1,30 @@
+# The frontend image.
+#
+# Development-oriented: it runs Vite's dev server, because that is what `docker compose up` is
+# for. A production image serving a static build through nginx arrives with the production
+# overlay in Epic H, where the image-size budget and non-root checks live.
+
+FROM node:22-bookworm-slim AS base
+
+WORKDIR /app
+
+# Manifests first so an edit to a component does not re-run `npm ci`.
+COPY apps/web/package.json apps/web/package-lock.json ./
+
+# `npm ci` rather than `npm install`: it installs exactly the lockfile and fails if the manifest
+# and lockfile disagree, which is the property that makes a container build reproducible.
+RUN npm ci
+
+COPY apps/web/ ./
+
+# Vite's own uid is root by default in this image; drop to the node user that the base image
+# already provides. Nothing here needs root, and the bind mount in compose would otherwise write
+# root-owned files into the host checkout.
+RUN chown -R node:node /app
+USER node
+
+EXPOSE 5173
+
+# `--host` binds 0.0.0.0. Without it Vite listens on localhost *inside* the container, which is
+# unreachable from the host and looks exactly like a broken port mapping.
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0"]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,6 +12,20 @@ export default defineConfig({
     // The Vue app is archived (OP-10), so this takes the default port back.
     port: 5173,
     strictPort: true,
+    proxy: {
+      // Everything under /api goes to the API service, so the browser only ever talks to one
+      // origin. That is what removes CORS from this project entirely: no preflight, no CORS
+      // middleware to misconfigure, no credentialed-request cookie subtleties, and — the part
+      // that bit the original — no per-environment API base URL. `HelloWorld.tsx` hardcoded
+      // `http://127.0.0.1:5000/`, which works on exactly one machine.
+      //
+      // The target is read from the environment so the same config serves both cases: `api:8000`
+      // over the compose network, and `localhost:8000` when the API is run directly on the host.
+      '/api': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8000',
+        changeOrigin: true,
+      },
+    },
   },
   resolve: {
     alias: {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,9 @@ services:
       # works from a clean clone with nothing to download and no API key — which is the whole
       # promise of the quickstart. CI overrides it to `fake` for speed.
       OPENPOSTURE_POSE_BACKEND: ${OPENPOSTURE_POSE_BACKEND:-mediapipe}
+      # Which scenario the fake backend returns. Ignored by mediapipe; the container smoke
+      # test sets it so the numbers it asserts on are deterministic.
+      OPENPOSTURE_POSE_BACKEND_PRESET: ${OPENPOSTURE_POSE_BACKEND_PRESET:-straight}
       OPENPOSTURE_ENVIRONMENT: ${OPENPOSTURE_ENVIRONMENT:-development}
       OPENPOSTURE_LOG_LEVEL: ${OPENPOSTURE_LOG_LEVEL:-info}
       # Local disk rather than MinIO: one fewer service until Epic E needs it, and the Protocol

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,8 +26,13 @@ services:
       OPENPOSTURE_ENVIRONMENT: ${OPENPOSTURE_ENVIRONMENT:-development}
       OPENPOSTURE_LOG_LEVEL: ${OPENPOSTURE_LOG_LEVEL:-info}
       # Local disk rather than MinIO: one fewer service until Epic E needs it, and the Protocol
-      # means switching is configuration rather than code.
-      OPENPOSTURE_STORAGE_BACKEND: local
+      # means switching is configuration rather than code. Expanded like everything else here,
+      # so `.env` can override it — a value documented as configurable in `.env.example` and
+      # then hardcoded here would be a setting that silently does nothing.
+      OPENPOSTURE_STORAGE_BACKEND: ${OPENPOSTURE_STORAGE_BACKEND:-local}
+      # Defaults to the named volume's mount point rather than to the image's own default,
+      # so uploads survive a restart. Overridable for the same reason as the rest.
+      OPENPOSTURE_STORAGE_ROOT: ${OPENPOSTURE_STORAGE_ROOT:-/app/var/storage}
     volumes:
       # Bind-mounted so a code edit is picked up by `--reload` without a rebuild. Source only —
       # the virtualenv and the model stay in the image, which is why this does not shadow them.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,97 @@
+# The development stack: `git clone && docker compose up`, and the app works.
+#
+# Two services for now. Postgres and MinIO arrive in Epic E; the production overlay arrives in
+# Epic H. Nothing here is a deployment — these are images built for reproducible local use.
+#
+# **The Vite proxy is the load-bearing piece.** The browser talks to one origin, `localhost:5173`,
+# and Vite forwards `/api` to `api:8000` over the compose network. That removes an entire
+# category of bug at once: no CORS preflight, no CORS middleware to misconfigure, no
+# credentialed-request cookie subtleties, and no per-environment API base URL threaded through
+# builds. The original fell into exactly that category with `axios.get('http://127.0.0.1:5000/')`
+# hardcoded into a component.
+
+services:
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
+    environment:
+      # Real inference by default. The model ships in the image with its hash pinned, so this
+      # works from a clean clone with nothing to download and no API key — which is the whole
+      # promise of the quickstart. CI overrides it to `fake` for speed.
+      OPENPOSTURE_POSE_BACKEND: ${OPENPOSTURE_POSE_BACKEND:-mediapipe}
+      OPENPOSTURE_ENVIRONMENT: ${OPENPOSTURE_ENVIRONMENT:-development}
+      OPENPOSTURE_LOG_LEVEL: ${OPENPOSTURE_LOG_LEVEL:-info}
+      # Local disk rather than MinIO: one fewer service until Epic E needs it, and the Protocol
+      # means switching is configuration rather than code.
+      OPENPOSTURE_STORAGE_BACKEND: local
+    volumes:
+      # Bind-mounted so a code edit is picked up by `--reload` without a rebuild. Source only —
+      # the virtualenv and the model stay in the image, which is why this does not shadow them.
+      - ./apps/api/src:/app/apps/api/src:ro
+      - ./packages/posture-core/src:/app/packages/posture-core/src:ro
+      - ./packages/posture-spec/src:/app/packages/posture-spec/src:ro
+      - ./packages/pose-backends/src:/app/packages/pose-backends/src:ro
+      # Named volume so uploaded images survive a restart without landing in the host checkout.
+      - api-storage:/app/var/storage
+    ports:
+      # Published for `curl` and for the OpenAPI schema generation in OP-45. The browser does not
+      # use this port — it goes through the Vite proxy.
+      - "8000:8000"
+    command:
+      - uvicorn
+      - openposture_api.main:app
+      - --host
+      - 0.0.0.0
+      - --port
+      - "8000"
+      - --reload
+      - --reload-dir
+      - /app/apps/api/src
+      - --reload-dir
+      - /app/packages
+    healthcheck:
+      # Readiness, not liveness — deliberately different from the image's own HEALTHCHECK.
+      # Compose uses this to gate `depends_on`, and the question there is "can it serve", not
+      # "is the process alive". Gating on liveness lets the frontend start while the model is
+      # still loading, and the first upload then fails for a reason that looks like a bug.
+      test:
+        - CMD
+        - python
+        - -c
+        - import urllib.request; urllib.request.urlopen('http://127.0.0.1:8000/health/ready').read()
+      interval: 5s
+      timeout: 3s
+      # Generous: loading and warming the pose model takes tens of seconds on a cold start, and
+      # a start period shorter than that restarts the container for being slow to start —
+      # repeatedly, since the restart takes just as long.
+      start_period: 60s
+      retries: 5
+
+  web:
+    build:
+      context: .
+      dockerfile: apps/web/Dockerfile
+    environment:
+      # Vite's file watcher does not see inotify events through some bind-mount implementations.
+      # Polling is slower but works everywhere, and a dev server that silently stops reloading is
+      # worse than one that costs a little CPU.
+      CHOKIDAR_USEPOLLING: "true"
+      # The proxy target on the compose network. Read by vite.config.ts, which falls back to
+      # localhost:8000 when the API runs directly on the host.
+      VITE_API_PROXY_TARGET: http://api:8000
+    volumes:
+      - ./apps/web/src:/app/src:ro
+      - ./apps/web/public:/app/public:ro
+      - ./apps/web/index.html:/app/index.html:ro
+      - ./apps/web/vite.config.ts:/app/vite.config.ts:ro
+    ports:
+      - "5173:5173"
+    depends_on:
+      api:
+        # Not merely `started`. Without this the frontend can come up while the API is still
+        # loading its model, and the first upload fails for a reason that looks like a bug.
+        condition: service_healthy
+
+volumes:
+  api-storage:

--- a/uv.lock
+++ b/uv.lock
@@ -1401,6 +1401,9 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+inference = [
+    { name = "pose-backends", extra = ["mediapipe"] },
+]
 serve = [
     { name = "uvicorn", extra = ["standard"] },
 ]
@@ -1417,13 +1420,14 @@ requires-dist = [
     { name = "fastapi", specifier = ">=0.115" },
     { name = "pillow", specifier = ">=11.0" },
     { name = "pose-backends", editable = "packages/pose-backends" },
+    { name = "pose-backends", extras = ["mediapipe"], marker = "extra == 'inference'", editable = "packages/pose-backends" },
     { name = "posture-core", editable = "packages/posture-core" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.34" },
 ]
-provides-extras = ["serve"]
+provides-extras = ["serve", "inference"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This pull request introduces full Docker Compose support for local development and CI, including new Dockerfiles for both the API and frontend, a Compose configuration, and a comprehensive container validation workflow. The stack is designed for reproducible, out-of-the-box startup with no manual setup, and includes robust health checks, volume management, and a proxy configuration that eliminates CORS issues. The CI now validates not just code but the entire containerized stack, ensuring that both images build and work together as promised in the quickstart.

**Containerization & Compose Integration**
- Added `docker-compose.yml` defining a two-service development stack (`api` and `web`), with health checks, bind mounts for source code, named volumes for persistent storage, and a Vite proxy setup to eliminate CORS and per-environment API URL issues.
- Created `apps/api/Dockerfile` and `apps/web/Dockerfile` for building minimal, reproducible images for the API and frontend, respectively, with non-root users, pinned dependencies, and explicit model hash verification for the API. [[1]](diffhunk://#diff-9ada278a9adf2846ef744063b304ed43826d904a8e1729669a1035ee26e036c6R1-R108) [[2]](diffhunk://#diff-4eb403c1470ca34300aea23c38f170d0e8b3c16932a5af4c99da390622d3db4eR1-R30)

**CI/CD Workflow Enhancements**
- Introduced `.github/workflows/containers.yml`, a new workflow that validates the Compose file, ensures model hash consistency, builds both images, runs smoke tests (including real API calls through the proxy), and aggregates results into a `containers-ok` status.
- Updated `.github/main-ruleset.md` to document the new `containers-ok` status check and clarify that both `scientific-ok` and `containers-ok` are conventionally required for merges, even before being enforced in the ruleset.

**Configuration & Environment**
- Added `.env.example` to document all configurable environment variables, their defaults, and the strict namespacing that prevents accidental misconfiguration.
- Updated `apps/api/pyproject.toml` to add an `inference` extra for clean dependency management of the real pose backend.

**Frontend Development Experience**
- Enhanced `apps/web/vite.config.ts` to read the API proxy target from the environment, supporting both Compose and direct-hosted API setups, and ensuring all API calls are proxied to avoid CORS.

These changes collectively ensure that `docker compose up` from a clean clone reliably starts a working stack, and that CI enforces this promise end-to-end.