### PR TITLE
OP-46: Client-side skeleton overlay on canvas

### DIFF
--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -34,15 +34,22 @@ from openposture_api.images import (
     decode_upload,
 )
 from openposture_api.pose import get_pose_backend
-from openposture_api.schemas import AnalysisResponse, ImageSize, PostureReportModel
+from openposture_api.schemas import (
+    AnalysisResponse,
+    DetectedLandmark,
+    ImageSize,
+    PostureReportModel,
+)
 from openposture_api.storage import StorageBackend, StorageError, get_storage
 from pose_backends.base import PoseBackend
 from pose_backends.errors import PoseBackendError
-from posture_core import build_report
+from posture_core import KeypointStatus, build_report
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
     from starlette.responses import JSONResponse
+
+    from posture_core import PoseFrame, PostureReport
 
 __all__ = ["API_PREFIX", "build_analyses_router", "register_analysis_error_handlers"]
 
@@ -106,6 +113,7 @@ def build_analyses_router() -> APIRouter:
                 object_key=stored.key,
                 pose_detected=False,
                 report=None,
+                landmarks=[],
                 image=ImageSize(width=decoded.width, height=decoded.height),
             )
 
@@ -124,6 +132,7 @@ def build_analyses_router() -> APIRouter:
         return AnalysisResponse(
             object_key=stored.key,
             pose_detected=True,
+            landmarks=_landmarks_for(frame, report),
             # Validated from `to_dict()` rather than rebuilt from the dataclass. `to_dict` stays
             # the engine's only serialiser — shared with the CLI and the golden corpus, and
             # depended on by the cross-language parity check in Epic G — while the model gives
@@ -134,6 +143,31 @@ def build_analyses_router() -> APIRouter:
         )
 
     return router
+
+
+def _landmarks_for(frame: PoseFrame, report: PostureReport) -> list[DetectedLandmark]:
+    """Pair each measured point with the status the resolver gave it.
+
+    The coordinates come from the frame and the status from the report, because they answer
+    different questions: the frame says *where* the model thinks a point is, and the resolver says
+    whether that belief is good enough to act on. A client needs both — drawing a
+    `low_confidence` elbow identically to a measured one presents a guess as a measurement, which
+    is the failure this project exists to remove.
+    """
+    statuses = report.quality.keypoints
+    return [
+        DetectedLandmark(
+            name=str(name),
+            x=landmark.x,
+            y=landmark.y,
+            # `NOT_DETECTED` is the honest default: the resolver reports on canonical keypoints,
+            # and a landmark it has no opinion about is one nothing has vouched for.
+            status=str(statuses.get(name, KeypointStatus.NOT_DETECTED)),  # type: ignore[arg-type]
+            visibility=landmark.visibility,
+            presence=landmark.presence,
+        )
+        for name, landmark in frame.landmarks.items()
+    ]
 
 
 async def _read_within_limit(upload: UploadFile) -> bytes:

--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -43,7 +43,7 @@ from openposture_api.schemas import (
 from openposture_api.storage import StorageBackend, StorageError, get_storage
 from pose_backends.base import PoseBackend
 from pose_backends.errors import PoseBackendError
-from posture_core import KeypointStatus, build_report
+from posture_core import build_report
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -159,15 +159,18 @@ def _landmarks_for(frame: PoseFrame, report: PostureReport) -> list[DetectedLand
     `low_confidence` elbow identically to a measured one presents a guess as a measurement, which
     is the failure this project exists to remove.
     """
+    # Indexed, not `.get(...)` with a default. `KeypointResolver` classifies *every* member of
+    # `KeypointName`, and `frame.landmarks` is keyed by that same enum, so a miss here is not a
+    # missing status — it is a broken invariant, and a default would hide it behind a plausible
+    # value. `not_detected` in particular would be a lie: the resolver only assigns it when the
+    # frame has no landmark at all, which cannot be true of one we are iterating over.
     statuses = report.quality.keypoints
     return [
         DetectedLandmark(
             name=str(name),
             x=landmark.x,
             y=landmark.y,
-            # `NOT_DETECTED` is the honest default: the resolver reports on canonical keypoints,
-            # and a landmark it has no opinion about is one nothing has vouched for.
-            status=str(statuses.get(name, KeypointStatus.NOT_DETECTED)),  # type: ignore[arg-type]
+            status=str(statuses[name]),  # type: ignore[arg-type]
             visibility=landmark.visibility,
             presence=landmark.presence,
         )

--- a/apps/api/src/openposture_api/schemas.py
+++ b/apps/api/src/openposture_api/schemas.py
@@ -21,6 +21,7 @@ from pydantic import BaseModel, Field
 
 __all__ = [
     "AnalysisResponse",
+    "DetectedLandmark",
     "Finding",
     "Gap",
     "ImageSize",
@@ -100,6 +101,32 @@ class PostureReportModel(BaseModel):
     quality: Quality
 
 
+class DetectedLandmark(BaseModel):
+    """One measured point, in the form a client needs to draw it.
+
+    **Normalised to the image, not in pixels.** The frontend renders the photo at whatever size
+    the viewport allows, so a pixel coordinate would be wrong the moment the layout changed. `x`
+    and `y` are fractions of width and height, which stay correct under any scale — the same
+    reasoning as the world-space metrics, applied to presentation.
+
+    World coordinates are deliberately absent: they are metres from the hip and mean nothing on
+    a 2D canvas.
+    """
+
+    name: str
+    x: float = Field(description="Fraction of image width. May fall outside [0, 1].")
+    y: float = Field(description="Fraction of image height, origin top-left.")
+    status: KeypointStatus = Field(
+        description=(
+            "How usable this point is. A client must render anything other than `ok` distinctly "
+            "or not at all — drawing a guessed position as though it were measured is the "
+            "confident-wrong-answer failure this project exists to remove."
+        )
+    )
+    visibility: float = Field(description="[0, 1] — confidence the point is not occluded.")
+    presence: float = Field(description="[0, 1] — confidence the point is in frame at all.")
+
+
 class AnalysisResponse(BaseModel):
     """What `POST /api/v1/analyses` returns on success."""
 
@@ -112,5 +139,17 @@ class AnalysisResponse(BaseModel):
     pose_detected: bool
     report: PostureReportModel | None = Field(
         description="`null` exactly when `pose_detected` is false."
+    )
+    # Required rather than defaulted. A field with a default is *optional* in the OpenAPI
+    # document, so the generated TypeScript types it `| undefined` and every consumer has to
+    # narrow a case the server never produces. Always sending it — empty when there is no pose —
+    # is both the simpler contract and the more honest one.
+    landmarks: list[DetectedLandmark] = Field(
+        description=(
+            "Every landmark the backend returned, for drawing a skeleton over the photo. Empty "
+            "when no pose was detected. The overlay is drawn client-side from these — the server "
+            "never writes an annotated image, which would cost a round trip, storage for a "
+            "derived artifact, and a cache-invalidation question every time the rules change."
+        ),
     )
     image: ImageSize

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -7,6 +7,14 @@
           "image": {
             "$ref": "#/components/schemas/ImageSize"
           },
+          "landmarks": {
+            "description": "Every landmark the backend returned, for drawing a skeleton over the photo. Empty when no pose was detected. The overlay is drawn client-side from these \u2014 the server never writes an annotated image, which would cost a round trip, storage for a derived artifact, and a cache-invalidation question every time the rules change.",
+            "items": {
+              "$ref": "#/components/schemas/DetectedLandmark"
+            },
+            "title": "Landmarks",
+            "type": "array"
+          },
           "object_key": {
             "description": "Where the uploaded image was stored. A key, never a URL \u2014 a URL embeds a host and an expiry, and persisting one means a hostname change invalidates it.",
             "title": "Object Key",
@@ -32,6 +40,7 @@
           "object_key",
           "pose_detected",
           "report",
+          "landmarks",
           "image"
         ],
         "title": "AnalysisResponse",
@@ -50,6 +59,56 @@
           "image"
         ],
         "title": "Body_create_analysis_api_v1_analyses_post",
+        "type": "object"
+      },
+      "DetectedLandmark": {
+        "description": "One measured point, in the form a client needs to draw it.\n\n**Normalised to the image, not in pixels.** The frontend renders the photo at whatever size\nthe viewport allows, so a pixel coordinate would be wrong the moment the layout changed. `x`\nand `y` are fractions of width and height, which stay correct under any scale \u2014 the same\nreasoning as the world-space metrics, applied to presentation.\n\nWorld coordinates are deliberately absent: they are metres from the hip and mean nothing on\na 2D canvas.",
+        "properties": {
+          "name": {
+            "title": "Name",
+            "type": "string"
+          },
+          "presence": {
+            "description": "[0, 1] \u2014 confidence the point is in frame at all.",
+            "title": "Presence",
+            "type": "number"
+          },
+          "status": {
+            "description": "How usable this point is. A client must render anything other than `ok` distinctly or not at all \u2014 drawing a guessed position as though it were measured is the confident-wrong-answer failure this project exists to remove.",
+            "enum": [
+              "ok",
+              "low_confidence",
+              "not_detected",
+              "out_of_frame"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "visibility": {
+            "description": "[0, 1] \u2014 confidence the point is not occluded.",
+            "title": "Visibility",
+            "type": "number"
+          },
+          "x": {
+            "description": "Fraction of image width. May fall outside [0, 1].",
+            "title": "X",
+            "type": "number"
+          },
+          "y": {
+            "description": "Fraction of image height, origin top-left.",
+            "title": "Y",
+            "type": "number"
+          }
+        },
+        "required": [
+          "name",
+          "x",
+          "y",
+          "status",
+          "visibility",
+          "presence"
+        ],
+        "title": "DetectedLandmark",
         "type": "object"
       },
       "Finding": {

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -75,6 +75,11 @@ export interface components {
         AnalysisResponse: {
             image: components["schemas"]["ImageSize"];
             /**
+             * Landmarks
+             * @description Every landmark the backend returned, for drawing a skeleton over the photo. Empty when no pose was detected. The overlay is drawn client-side from these — the server never writes an annotated image, which would cost a round trip, storage for a derived artifact, and a cache-invalidation question every time the rules change.
+             */
+            landmarks: components["schemas"]["DetectedLandmark"][];
+            /**
              * Object Key
              * @description Where the uploaded image was stored. A key, never a URL — a URL embeds a host and an expiry, and persisting one means a hostname change invalidates it.
              */
@@ -91,6 +96,48 @@ export interface components {
              * @description The photograph to analyse.
              */
             image: string;
+        };
+        /**
+         * DetectedLandmark
+         * @description One measured point, in the form a client needs to draw it.
+         *
+         *     **Normalised to the image, not in pixels.** The frontend renders the photo at whatever size
+         *     the viewport allows, so a pixel coordinate would be wrong the moment the layout changed. `x`
+         *     and `y` are fractions of width and height, which stay correct under any scale — the same
+         *     reasoning as the world-space metrics, applied to presentation.
+         *
+         *     World coordinates are deliberately absent: they are metres from the hip and mean nothing on
+         *     a 2D canvas.
+         */
+        DetectedLandmark: {
+            /** Name */
+            name: string;
+            /**
+             * Presence
+             * @description [0, 1] — confidence the point is in frame at all.
+             */
+            presence: number;
+            /**
+             * Status
+             * @description How usable this point is. A client must render anything other than `ok` distinctly or not at all — drawing a guessed position as though it were measured is the confident-wrong-answer failure this project exists to remove.
+             * @enum {string}
+             */
+            status: "ok" | "low_confidence" | "not_detected" | "out_of_frame";
+            /**
+             * Visibility
+             * @description [0, 1] — confidence the point is not occluded.
+             */
+            visibility: number;
+            /**
+             * X
+             * @description Fraction of image width. May fall outside [0, 1].
+             */
+            x: number;
+            /**
+             * Y
+             * @description Fraction of image height, origin top-left.
+             */
+            y: number;
         };
         /**
          * Finding

--- a/apps/web/src/setupTests.ts
+++ b/apps/web/src/setupTests.ts
@@ -23,3 +23,21 @@ afterEach(() => {
 afterAll(() => {
   server.close()
 })
+
+/**
+ * jsdom implements neither `ResizeObserver` nor a canvas 2D context.
+ *
+ * Both are stubbed rather than pulled in as dependencies, because what the tests need is the
+ * *ability to observe calls*, not a real rendering engine. A component that measures its own
+ * layout has nothing to measure in jsdom anyway — the overlay's own tests drive the box size
+ * explicitly, which is more deterministic than hoping jsdom reports one.
+ */
+class ResizeObserverStub implements ResizeObserver {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (!('ResizeObserver' in globalThis)) {
+  globalThis.ResizeObserver = ResizeObserverStub
+}

--- a/apps/web/src/test/reports.ts
+++ b/apps/web/src/test/reports.ts
@@ -8,6 +8,8 @@
 
 import type { AnalysisResponse, Metric, PostureReport } from '../api/types'
 
+type Landmark = AnalysisResponse['landmarks'][number]
+
 function ok(value: number, unit: string, detail: string): Metric {
   return { value, unit, status: 'ok', detail, confidence: 0.95 }
 }
@@ -119,11 +121,46 @@ export function frontalViewReport(): PostureReport {
   return report
 }
 
-export function analysisOf(report: PostureReport | null): AnalysisResponse {
+function point(name: string, x: number, y: number, status: Landmark['status'] = 'ok'): Landmark {
+  return {
+    name,
+    x,
+    y,
+    status,
+    visibility: status === 'ok' ? 0.95 : 0.2,
+    presence: status === 'out_of_frame' ? 0.1 : 0.98,
+  }
+}
+
+/**
+ * A skeleton with a deliberate mix of statuses.
+ *
+ * Six `ok`, one `low_confidence`, one `not_detected` — so a test can assert exactly how many
+ * points are drawn and how many are drawn *differently*, which is the whole contract of the
+ * overlay. A fixture where everything is `ok` would pass against a component that ignored status.
+ */
+export function landmarksWithGaps(): Landmark[] {
+  return [
+    point('left_shoulder', 0.4, 0.3),
+    point('right_shoulder', 0.5, 0.3),
+    point('left_hip', 0.4, 0.6),
+    point('right_hip', 0.5, 0.6),
+    point('left_knee', 0.42, 0.8),
+    point('left_ankle', 0.44, 0.95),
+    point('left_elbow', 0.35, 0.45, 'low_confidence'),
+    point('left_wrist', 0.3, 0.55, 'not_detected'),
+  ]
+}
+
+export function analysisOf(
+  report: PostureReport | null,
+  landmarks: Landmark[] = report ? landmarksWithGaps() : [],
+): AnalysisResponse {
   return {
     object_key: 'analyses/0123456789abcdef0123456789abcdef.jpg',
     pose_detected: report !== null,
     report,
+    landmarks,
     image: { width: 640, height: 480 },
   }
 }

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -172,7 +172,11 @@ export default function Dashboard() {
       )}
 
       {status === 'done' && analysis?.report && (
-        <PostureResult report={analysis.report} imageUrl={imageUrl} />
+        <PostureResult
+          report={analysis.report}
+          imageUrl={imageUrl}
+          landmarks={analysis.landmarks}
+        />
       )}
     </div>
   )

--- a/apps/web/src/views/PostureResult.tsx
+++ b/apps/web/src/views/PostureResult.tsx
@@ -16,7 +16,8 @@
  * than being presented as fact.
  */
 
-import type { PostureReport } from '../api/types'
+import type { AnalysisResponse, PostureReport } from '../api/types'
+import SkeletonOverlay from './SkeletonOverlay'
 import styles from './PostureResult.module.css'
 
 /**
@@ -34,9 +35,10 @@ const FRONTAL_VIEW_CODE = 'frontal_view'
 interface Props {
   report: PostureReport
   imageUrl: string | null
+  landmarks: AnalysisResponse['landmarks']
 }
 
-export default function PostureResult({ report, imageUrl }: Props) {
+export default function PostureResult({ report, imageUrl, landmarks }: Props) {
   const measured = Object.entries(report.metrics).filter(([, metric]) => metric.status === 'ok')
   const viewCaveat = report.findings.find((finding) => finding.code === FRONTAL_VIEW_CODE)
   // Rendered as a caveat above the results rather than as one finding among many, and therefore
@@ -74,9 +76,14 @@ export default function PostureResult({ report, imageUrl }: Props) {
         Assessed {report.quality.assessed} of {report.quality.total} measurements.
       </p>
 
-      {imageUrl && (
-        <img src={imageUrl} alt="The photo you uploaded" className={styles.uploadedImage} />
-      )}
+      {imageUrl &&
+        (landmarks.length > 0 ? (
+          <SkeletonOverlay imageUrl={imageUrl} landmarks={landmarks} />
+        ) : (
+          // No landmarks means nothing to draw. Showing a bare canvas would suggest the overlay
+          // failed rather than that there was nothing to overlay.
+          <img src={imageUrl} alt="The photo you uploaded" className={styles.uploadedImage} />
+        ))}
 
       {findings.length > 0 ? (
         <section aria-labelledby="findings-heading">

--- a/apps/web/src/views/SkeletonOverlay.module.css
+++ b/apps/web/src/views/SkeletonOverlay.module.css
@@ -1,0 +1,23 @@
+/* The canvas sits exactly on top of the image, so `position: relative` on the figure is what the
+   absolute positioning below is measured against. */
+
+.figure {
+  position: relative;
+  display: inline-block;
+  margin: 1rem 0;
+  max-width: 100%;
+}
+
+.image {
+  display: block;
+  max-width: 100%;
+  height: auto;
+  border-radius: 8px;
+}
+
+.canvas {
+  position: absolute;
+  inset: 0;
+  /* The photo underneath stays selectable and right-clickable; the overlay is decoration. */
+  pointer-events: none;
+}

--- a/apps/web/src/views/SkeletonOverlay.test.tsx
+++ b/apps/web/src/views/SkeletonOverlay.test.tsx
@@ -58,12 +58,10 @@ beforeEach(() => {
   vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
     recorder.context as unknown as CanvasRenderingContext2D,
   )
-  // The overlay measures the rendered image, which jsdom lays out at 0x0. Reporting a real box
-  // is what makes the scaling assertions meaningful rather than all-zero.
-  vi.spyOn(HTMLImageElement.prototype, 'getBoundingClientRect').mockReturnValue({
-    ...new DOMRect(0, 0, BOX.width, BOX.height),
-    toJSON: () => ({}),
-  })
+  // The box comes from the ResizeObserver stub below, which is the only thing the component reads
+  // — there is deliberately no `getBoundingClientRect` spy here. An unused DOM spy would mask a
+  // regression: if the component started measuring layout directly, this suite would keep passing
+  // on the spy's answer instead of failing on jsdom's 0x0.
   stubResizeObserver()
 })
 

--- a/apps/web/src/views/SkeletonOverlay.test.tsx
+++ b/apps/web/src/views/SkeletonOverlay.test.tsx
@@ -1,0 +1,206 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import SkeletonOverlay from './SkeletonOverlay'
+import { landmarksWithGaps } from '../test/reports'
+import type { AnalysisResponse } from '../api/types'
+
+type Landmark = AnalysisResponse['landmarks'][number]
+
+/**
+ * A recording 2D context.
+ *
+ * jsdom has no canvas implementation, so this stands in for one — and it is better than a real
+ * one for these assertions anyway. What matters is *which* primitives were issued and at what
+ * coordinates, and a recorder answers that directly where a rendered bitmap would have to be
+ * pixel-diffed.
+ */
+function recordingContext() {
+  const arcs: Array<{ x: number; y: number; radius: number }> = []
+  const lines: Array<{ from: [number, number]; to: [number, number] }> = []
+  const transforms: number[][] = []
+  let pen: [number, number] = [0, 0]
+  const fills: string[] = []
+
+  const context = {
+    canvas: null as unknown as HTMLCanvasElement,
+    lineWidth: 1,
+    strokeStyle: '',
+    fillStyle: '',
+    setTransform(a: number, b: number, c: number, d: number, e: number, f: number) {
+      transforms.push([a, b, c, d, e, f])
+    },
+    clearRect() {},
+    beginPath() {},
+    moveTo(x: number, y: number) {
+      pen = [x, y]
+    },
+    lineTo(x: number, y: number) {
+      lines.push({ from: pen, to: [x, y] })
+    },
+    stroke() {},
+    arc(x: number, y: number, radius: number) {
+      arcs.push({ x, y, radius })
+    },
+    fill() {
+      fills.push(String(context.fillStyle))
+    },
+  }
+
+  return { context, arcs, lines, transforms, fills }
+}
+
+const BOX = { width: 400, height: 300 }
+
+let recorder: ReturnType<typeof recordingContext>
+
+beforeEach(() => {
+  recorder = recordingContext()
+  vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue(
+    recorder.context as unknown as CanvasRenderingContext2D,
+  )
+  // The overlay measures the rendered image, which jsdom lays out at 0x0. Reporting a real box
+  // is what makes the scaling assertions meaningful rather than all-zero.
+  vi.spyOn(HTMLImageElement.prototype, 'getBoundingClientRect').mockReturnValue({
+    ...new DOMRect(0, 0, BOX.width, BOX.height),
+    toJSON: () => ({}),
+  })
+  stubResizeObserver()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+})
+
+/** Fire the observer immediately with a known box, so the component has a size to draw against. */
+function stubResizeObserver() {
+  class ImmediateResizeObserver {
+    // A plain field, not a parameter property: `erasableSyntaxOnly` rejects the shorthand
+    // because it emits runtime code rather than erasing to nothing.
+    private readonly callback: ResizeObserverCallback
+
+    constructor(callback: ResizeObserverCallback) {
+      this.callback = callback
+    }
+
+    observe() {
+      this.callback(
+        [{ contentRect: { width: BOX.width, height: BOX.height } } as ResizeObserverEntry],
+        this as unknown as ResizeObserver,
+      )
+    }
+    unobserve() {}
+    disconnect() {}
+  }
+  vi.stubGlobal('ResizeObserver', ImmediateResizeObserver)
+}
+
+function renderOverlay(landmarks: Landmark[] = landmarksWithGaps()) {
+  return render(<SkeletonOverlay imageUrl="blob:photo" landmarks={landmarks} />)
+}
+
+describe('SkeletonOverlay', () => {
+  it('draws one point per landmark that has a position worth drawing', () => {
+    // The fixture is six `ok`, one `low_confidence`, one `not_detected`. The last has no measured
+    // position, so drawing it would mean inventing one.
+    renderOverlay()
+
+    expect(recorder.arcs).toHaveLength(7)
+  })
+
+  it('draws nothing for a keypoint the model never found', () => {
+    const landmarks = landmarksWithGaps()
+    const missing = landmarks.filter((landmark) => landmark.status === 'not_detected')
+    expect(missing).toHaveLength(1)
+
+    renderOverlay()
+
+    const drawnAt = recorder.arcs.map((arc) => `${arc.x},${arc.y}`)
+    const wouldBe = `${missing[0]!.x * BOX.width},${missing[0]!.y * BOX.height}`
+    expect(drawnAt).not.toContain(wouldBe)
+  })
+
+  it('renders an uncertain point differently from a measured one', () => {
+    // Presenting a guess identically to a measurement is the confident-wrong-answer failure this
+    // project exists to remove. Size *and* colour differ, so it does not rest on colour alone.
+    renderOverlay()
+
+    const radii = new Set(recorder.arcs.map((arc) => arc.radius))
+    expect(radii.size).toBe(2)
+    expect(new Set(recorder.fills).size).toBe(2)
+  })
+
+  it('scales normalised coordinates onto the rendered box', () => {
+    // Landmarks are fractions of the image; the image is laid out by CSS. A point at x=0.4 in a
+    // 400px-wide box belongs at 160px, whatever the photo's intrinsic size.
+    renderOverlay([
+      {
+        name: 'left_shoulder',
+        x: 0.4,
+        y: 0.3,
+        status: 'ok',
+        visibility: 0.9,
+        presence: 0.9,
+      },
+    ])
+
+    expect(recorder.arcs[0]).toMatchObject({ x: 0.4 * BOX.width, y: 0.3 * BOX.height })
+  })
+
+  it('scales correctly at a different aspect ratio', () => {
+    // The same fraction maps to different pixels in a different box, which is the property that
+    // keeps the overlay on the body when the layout changes.
+    const landmark: Landmark = {
+      name: 'left_hip',
+      x: 0.25,
+      y: 0.75,
+      status: 'ok',
+      visibility: 0.9,
+      presence: 0.9,
+    }
+
+    renderOverlay([landmark])
+
+    expect(recorder.arcs[0]?.x).toBeCloseTo(0.25 * BOX.width)
+    expect(recorder.arcs[0]?.y).toBeCloseTo(0.75 * BOX.height)
+  })
+
+  it('accounts for device pixel ratio', () => {
+    // A canvas has a backing store and a CSS box. On a high-DPI display they differ, and ignoring
+    // that draws a blurry skeleton at half scale in the corner.
+    vi.stubGlobal('devicePixelRatio', 2)
+
+    renderOverlay()
+
+    const canvas = screen.getByTestId('skeleton') as HTMLCanvasElement
+    expect(canvas.width).toBe(BOX.width * 2)
+    expect(canvas.height).toBe(BOX.height * 2)
+    expect(canvas.style.width).toBe(`${BOX.width}px`)
+    // The transform is what keeps drawing coordinates in CSS pixels despite the larger store.
+    expect(recorder.transforms.at(-1)).toEqual([2, 0, 0, 2, 0, 0])
+  })
+
+  it('draws a bone only when both of its ends are measured', () => {
+    // A line between a measured shoulder and a guessed elbow looks exactly like a measured one,
+    // and there is no way to caveat a line.
+    renderOverlay()
+
+    const uncertain = landmarksWithGaps().find((landmark) => landmark.status !== 'ok')!
+    const endpoint = `${uncertain.x * BOX.width},${uncertain.y * BOX.height}`
+    const touched = recorder.lines.some(
+      ({ from, to }) => from.join(',') === endpoint || to.join(',') === endpoint,
+    )
+
+    expect(touched).toBe(false)
+    // Sanity: bones between confident points *are* drawn, so the assertion above is not vacuous.
+    expect(recorder.lines.length).toBeGreaterThan(0)
+  })
+
+  it('is hidden from assistive technology', () => {
+    // Decoration over a photo that already has alt text. The measurements are the accessible
+    // content and they are rendered as text beside this.
+    renderOverlay()
+
+    expect(screen.getByTestId('skeleton')).toHaveAttribute('aria-hidden', 'true')
+    expect(screen.getByRole('img')).toHaveAccessibleName('The photo you uploaded')
+  })
+})

--- a/apps/web/src/views/SkeletonOverlay.tsx
+++ b/apps/web/src/views/SkeletonOverlay.tsx
@@ -1,0 +1,179 @@
+/**
+ * The detected skeleton, drawn over the photo on a canvas.
+ *
+ * **Client-side, deliberately.** The alternative — the server drawing on the image and returning
+ * a second file — costs an extra round trip, server-side encoding, storage for a derived
+ * artifact, and a cache-invalidation question every time the rules change. The landmarks are
+ * already in the response; drawing them is a rendering concern. The legacy `draw()` did the
+ * opposite, calling `cv2.imread` a second time on an image it had already loaded and writing an
+ * annotated copy to disk.
+ *
+ * Two things are easy to get wrong here and both are handled explicitly:
+ *
+ * **Scaling.** Landmarks are fractions of the image, and the image is laid out by CSS at
+ * whatever size the viewport allows. The canvas is sized from the *rendered* box, measured after
+ * layout, so the overlay tracks the photo through any aspect ratio and any resize.
+ *
+ * **Device pixel ratio.** A canvas has two sizes: its backing store (`width`/`height`) and its
+ * CSS box. On a high-DPI display they differ by `devicePixelRatio`, and ignoring that draws a
+ * blurry skeleton at half scale in the top-left corner.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type { AnalysisResponse } from '../api/types'
+import styles from './SkeletonOverlay.module.css'
+
+type Landmark = AnalysisResponse['landmarks'][number]
+
+/**
+ * The bones, as pairs of landmark names.
+ *
+ * A segment is drawn only when *both* of its ends are `ok`. A line between a measured shoulder
+ * and a guessed elbow looks exactly like a measured one, and there is no way to caveat a line.
+ */
+const SEGMENTS: ReadonlyArray<readonly [string, string]> = [
+  ['left_shoulder', 'right_shoulder'],
+  ['left_shoulder', 'left_elbow'],
+  ['left_elbow', 'left_wrist'],
+  ['right_shoulder', 'right_elbow'],
+  ['right_elbow', 'right_wrist'],
+  ['left_shoulder', 'left_hip'],
+  ['right_shoulder', 'right_hip'],
+  ['left_hip', 'right_hip'],
+  ['left_hip', 'left_knee'],
+  ['left_knee', 'left_ankle'],
+  ['right_hip', 'right_knee'],
+  ['right_knee', 'right_ankle'],
+  ['left_ankle', 'left_heel'],
+  ['left_heel', 'left_foot_index'],
+  ['right_ankle', 'right_heel'],
+  ['right_heel', 'right_foot_index'],
+  ['nose', 'neck'],
+  ['neck', 'left_shoulder'],
+  ['neck', 'right_shoulder'],
+]
+
+const CONFIDENT_COLOUR = '#2ec4b6'
+const UNCERTAIN_COLOUR = '#f4a261'
+const CONFIDENT_RADIUS = 4
+const UNCERTAIN_RADIUS = 3
+
+interface Props {
+  imageUrl: string
+  landmarks: Landmark[]
+  /** Alt text for the photo underneath. */
+  alt?: string
+}
+
+export default function SkeletonOverlay({
+  imageUrl,
+  landmarks,
+  alt = 'The photo you uploaded',
+}: Props) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null)
+  const imageRef = useRef<HTMLImageElement | null>(null)
+  const [box, setBox] = useState<{ width: number; height: number } | null>(null)
+
+  // Measured after layout rather than taken from the natural image size, because CSS decides how
+  // big the photo actually is. `ResizeObserver` rather than a window `resize` listener: the image
+  // can change size without the window doing so — a sidebar opening, a font loading, a flex
+  // container reflowing — and a window listener misses all of those.
+  useEffect(() => {
+    const image = imageRef.current
+    if (!image) return
+
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[0]
+      if (!entry) return
+      const { width, height } = entry.contentRect
+      if (width > 0 && height > 0) setBox({ width, height })
+    })
+    observer.observe(image)
+    return () => observer.disconnect()
+  }, [imageUrl])
+
+  const draw = useCallback(() => {
+    const canvas = canvasRef.current
+    if (!canvas || !box) return
+
+    const context = canvas.getContext('2d')
+    if (!context) return
+
+    // The backing store is in device pixels; everything drawn afterwards is in CSS pixels because
+    // of the transform below. Without this the skeleton renders at 1/dpr scale on a Retina
+    // display — correct maths, wrong coordinate space.
+    const ratio = window.devicePixelRatio || 1
+    canvas.width = Math.round(box.width * ratio)
+    canvas.height = Math.round(box.height * ratio)
+    canvas.style.width = `${box.width}px`
+    canvas.style.height = `${box.height}px`
+
+    context.setTransform(ratio, 0, 0, ratio, 0, 0)
+    context.clearRect(0, 0, box.width, box.height)
+
+    const byName = new Map(landmarks.map((landmark) => [landmark.name, landmark]))
+    const at = (landmark: Landmark) => ({
+      x: landmark.x * box.width,
+      y: landmark.y * box.height,
+    })
+
+    context.lineWidth = 2
+    context.strokeStyle = CONFIDENT_COLOUR
+    for (const [from, to] of SEGMENTS) {
+      const start = byName.get(from)
+      const end = byName.get(to)
+      // Both ends measured, or no line. See the SEGMENTS comment.
+      if (!start || !end || start.status !== 'ok' || end.status !== 'ok') continue
+
+      const a = at(start)
+      const b = at(end)
+      context.beginPath()
+      context.moveTo(a.x, a.y)
+      context.lineTo(b.x, b.y)
+      context.stroke()
+    }
+
+    for (const landmark of landmarks) {
+      // Not drawn at all. A point the model never found has no position to draw, and inventing
+      // one is the whole class of error this project is about.
+      if (landmark.status === 'not_detected' || landmark.status === 'out_of_frame') continue
+
+      const confident = landmark.status === 'ok'
+      const { x, y } = at(landmark)
+
+      context.beginPath()
+      context.arc(x, y, confident ? CONFIDENT_RADIUS : UNCERTAIN_RADIUS, 0, Math.PI * 2)
+      context.fillStyle = confident ? CONFIDENT_COLOUR : UNCERTAIN_COLOUR
+      context.fill()
+
+      if (!confident) {
+        // Hollow, so an uncertain point is distinguishable without relying on colour alone.
+        context.strokeStyle = UNCERTAIN_COLOUR
+        context.lineWidth = 1.5
+        context.stroke()
+        context.strokeStyle = CONFIDENT_COLOUR
+        context.lineWidth = 2
+      }
+    }
+  }, [box, landmarks])
+
+  useEffect(draw, [draw])
+
+  return (
+    <figure className={styles.figure}>
+      <img
+        ref={imageRef}
+        src={imageUrl}
+        alt={alt}
+        className={styles.image}
+        // Redraw once the bitmap is decoded: before that the element has no intrinsic size, so
+        // the observed box would be the CSS box of an empty image.
+        onLoad={draw}
+      />
+      {/* `aria-hidden`: the skeleton is decoration over a photo that already has alt text, and a
+          canvas has nothing meaningful to announce. The measurements are the accessible content
+          and they are rendered as text beside this. */}
+      <canvas ref={canvasRef} className={styles.canvas} aria-hidden="true" data-testid="skeleton" />
+    </figure>
+  )
+}


### PR DESCRIPTION
This pull request introduces a new API contract and frontend support for returning and rendering pose landmarks as part of the analysis response. The backend now includes detailed landmark data in every analysis result, and the frontend consumes and displays this data as a skeleton overlay on the uploaded image. Additionally, the test fixtures and OpenAPI schema are updated to support and validate this new feature.

**API & Data Model Enhancements:**

- Added a new `DetectedLandmark` schema to the API, representing each measured point with coordinates, status, visibility, and presence, normalized to image size for consistent rendering. This is included as a required `landmarks` field in the `AnalysisResponse`, always present (empty when no pose is detected). [[1]](diffhunk://#diff-6afc742c42926dc0ebfddff517fe6d9290b8f0d77bc3d9267d50ca412fa43736R122-R147) [[2]](diffhunk://#diff-6afc742c42926dc0ebfddff517fe6d9290b8f0d77bc3d9267d50ca412fa43736R161-R172) [[3]](diffhunk://#diff-7d90a59e8c5c2f69d48484d02896327c228cd1dfa528790c1c4c638c987c51f6L37-R53)
- Implemented `_landmarks_for` function to pair each landmark's coordinates with its detection status, ensuring clients can distinguish between confidently detected, low-confidence, and missing points. [[1]](diffhunk://#diff-7d90a59e8c5c2f69d48484d02896327c228cd1dfa528790c1c4c638c987c51f6R153-R177) [[2]](diffhunk://#diff-7d90a59e8c5c2f69d48484d02896327c228cd1dfa528790c1c4c638c987c51f6R135) [[3]](diffhunk://#diff-7d90a59e8c5c2f69d48484d02896327c228cd1dfa528790c1c4c638c987c51f6R116)

**OpenAPI & TypeScript Types:**

- Updated the OpenAPI schema (`openapi.json`) to document the new `DetectedLandmark` type and require the `landmarks` field in `AnalysisResponse`, ensuring generated TypeScript types reflect the new contract. [[1]](diffhunk://#diff-2aaf30d48fff5616caa85da437280cec3a35b80dd6414e9d1bb534f9868cc330R11-R18) [[2]](diffhunk://#diff-2aaf30d48fff5616caa85da437280cec3a35b80dd6414e9d1bb534f9868cc330R44) [[3]](diffhunk://#diff-2aaf30d48fff5616caa85da437280cec3a35b80dd6414e9d1bb534f9868cc330R65-R115)

**Frontend Integration:**

- Modified the dashboard and result components to accept and pass `landmarks` data, rendering a `SkeletonOverlay` when landmarks are present and falling back to a plain image otherwise. [[1]](diffhunk://#diff-d8571d73660459febeb88f2c82592baa29fdfa556e1985c468492729420d6cc5L175-R179) [[2]](diffhunk://#diff-974a0d44cb03b2ade887ea5a8141372283efea00a6e09dfd7caf06c7bea1e809L19-R20) [[3]](diffhunk://#diff-974a0d44cb03b2ade887ea5a8141372283efea00a6e09dfd7caf06c7bea1e809R38-R41) [[4]](diffhunk://#diff-974a0d44cb03b2ade887ea5a8141372283efea00a6e09dfd7caf06c7bea1e809L77-R86)
- Added CSS for precise overlay positioning and appearance of the skeleton overlay on top of the uploaded image.

**Testing & Fixtures:**

- Enhanced test fixtures to provide landmark data with a variety of statuses, supporting robust frontend tests that verify correct rendering for each case. [[1]](diffhunk://#diff-8683854ae403a95ddb93325a1335cb61ef4c32b734877c2957d7cd5601650102R11-R12) [[2]](diffhunk://#diff-8683854ae403a95ddb93325a1335cb61ef4c32b734877c2957d7cd5601650102L122-R163)
- Stubbed `ResizeObserver` in test setup to avoid dependency on browser APIs not implemented in jsdom, improving test reliability.