### PR TITLE
OP-47: First Playwright end-to-end journey and the e2e.yml workflow

### DIFF
--- a/.github/main-ruleset.md
+++ b/.github/main-ruleset.md
@@ -58,20 +58,21 @@ them individually would make merging depend on how GitHub treats skipped checks.
 aggregator also means a job can be renamed or split without silently dropping protection. See the
 header comment in [`.github/workflows/pr.yml`](workflows/pr.yml).
 
-**`scientific-ok` and `containers-ok` are not required yet.** `scientific-validation.yml` arrived
-with the shared threshold spec and `containers.yml` with the first Compose commit (OP-43). Both
-run their own aggregator on every pull request, but the ruleset has not been updated to require
-them, so a red gate in either does not currently block a merge. Adding them is a ruleset change,
-not a workflow change:
+**`scientific-ok`, `containers-ok` and `e2e-ok` are not required yet.** `scientific-validation.yml`
+arrived with the shared threshold spec, `containers.yml` with the first Compose commit (OP-43), and
+`e2e.yml` with the first full-stack journey (OP-47). Each runs its own aggregator on every pull
+request, but the ruleset has not been updated to require them, so a red gate in any of them does
+not currently block a merge. Adding them is a ruleset change, not a workflow change:
 
 ```bash
 gh api -X PUT repos/{owner}/{repo}/rulesets/<id> --input .github/main-ruleset.json
 ```
 
-after adding `scientific-ok` and `containers-ok` to `required_status_checks` in the JSON. Until
-then, treat a failure in either as blocking by convention. `scientific-ok` failing means a metric
-moved, which should never merge unreviewed; `containers-ok` failing means `docker compose up`
-does not work from a clean clone, which is the quickstart the README promises.
+after adding `scientific-ok`, `containers-ok` and `e2e-ok` to `required_status_checks` in the JSON.
+Until then, treat a failure in any of them as blocking by convention. `scientific-ok` failing means
+a metric moved, which should never merge unreviewed; `containers-ok` failing means `docker compose
+up` does not work from a clean clone, which is the quickstart the README promises; `e2e-ok` failing
+means a person cannot complete the one journey the application exists for.
 
 ## Two rules from the OP-15 ticket that are deliberately absent
 

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,122 @@
+# The full-stack journey.
+#
+# `pr.yml` proves each layer is correct in isolation and `containers.yml` proves the stack starts
+# and answers. This proves a *person* can use it: a browser uploads a photograph and a measured
+# number appears on screen, through the Vite proxy, the API, the pose backend, the rules engine and
+# the React render.
+#
+# The assertion is an exact value, and that is the whole point. Asserting that a results panel
+# appeared would have passed against the hardcoded constants OP-44 deleted — they rendered after a
+# five-second timer and looked like a working app. `32°` proves a specific number was computed and
+# travelled the full chain.
+#
+# **Fake backend, so the number is exact rather than approximate.** The `hunchback` preset is an
+# analytic stick figure built at 32°, so the engine measures 32° every time. A real model would
+# force a tolerance, and a tolerance is where flake starts — and a flaky end-to-end test is worse
+# than none, because people learn to re-run it. Real-model validation lives in the
+# `workflow_dispatch` job from OP-21.
+
+name: e2e
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  NODE_VERSION: "22"
+
+jobs:
+  journey:
+    name: full-stack journey
+    runs-on: ubuntu-latest
+    env:
+      OPENPOSTURE_POSE_BACKEND: fake
+      # The spec asserts 32°, which is this preset's trunk inclination. Changing it here without
+      # changing the spec is a deliberate failure rather than a silent one.
+      OPENPOSTURE_POSE_BACKEND_PRESET: hunchback
+      OPENPOSTURE_ENVIRONMENT: test
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: apps/web/package-lock.json
+
+      - name: Install frontend dependencies
+        working-directory: apps/web
+        run: npm ci
+
+      - uses: docker/setup-buildx-action@e468171a9de216ec08956ac3ada2f0791b6bd435 # v3.11.1
+
+      - name: Build images
+        uses: docker/bake-action@37816e747588cb137173af99ab33873600c46ea8 # v6.9.0
+        with:
+          files: docker-compose.yml
+          load: true
+          set: |
+            *.cache-from=type=gha
+            *.cache-to=type=gha,mode=max
+
+      - name: Start the stack
+        run: docker compose up -d --wait --wait-timeout 240
+
+      - name: Install the Playwright browser
+        working-directory: apps/web
+        # Chromium only, and only after the stack is up — the download is the slow part and there
+        # is no reason to pay for it before knowing the stack starts.
+        run: npx playwright install --with-deps chromium
+
+      - name: Run the journey
+        working-directory: apps/web
+        run: npm run test:e2e:stack
+
+      - name: Capture service logs
+        # On failure only. A green run's logs are noise; a red run without them is undebuggable.
+        if: failure()
+        run: docker compose logs --no-color > /tmp/compose-logs.txt 2>&1 || true
+
+      - name: Upload diagnostics
+        if: failure()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: e2e-diagnostics
+          path: |
+            apps/web/test-results/
+            apps/web/playwright-report/
+            /tmp/compose-logs.txt
+          retention-days: 7
+          if-no-files-found: ignore
+
+      - name: Shut down cleanly
+        # `always()` so a failed assertion still tears down, and `-v` so an uploaded image from
+        # this run cannot be mistaken for a fresh one in the next.
+        if: always()
+        run: docker compose down -v --remove-orphans
+
+  e2e-ok:
+    name: e2e-ok
+    if: always()
+    needs: [journey]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Report
+        run: |
+          echo "journey ${{ needs.journey.result }}"
+
+      - name: Fail if the journey did not succeed
+        # Skipped counts as failure: nothing path-filters this workflow, so a skip means something
+        # went wrong rather than "not relevant to this change".
+        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped')
+        run: exit 1

--- a/apps/web/e2e-stack/analysis.spec.ts
+++ b/apps/web/e2e-stack/analysis.spec.ts
@@ -11,7 +11,7 @@ import { expect, test } from '@playwright/test'
  * Asserting that `32°` is on screen proves a specific number travelled the full chain and was
  * computed, not typed.
  *
- * That number is exact rather than approximate because the fake backend'"'"'s `hunchback` preset is
+ * That number is exact rather than approximate because the fake backend's `hunchback` preset is
  * an analytic stick figure: the trunk is built at 32° and the engine measures 32°. A real model
  * would force a tolerance, and a tolerance is where flake starts.
  *

--- a/apps/web/e2e-stack/analysis.spec.ts
+++ b/apps/web/e2e-stack/analysis.spec.ts
@@ -1,0 +1,97 @@
+import { fileURLToPath } from 'node:url'
+import { expect, test } from '@playwright/test'
+
+/**
+ * One journey through the entire application: browser, Vite proxy, API, pose backend, rules
+ * engine, response, render.
+ *
+ * **The assertion is an exact measured value, and that is the whole point.** Asserting that a
+ * results panel appeared would have passed against the hardcoded constants OP-44 deleted —
+ * `POSTURE_DETECTION_RESULT` rendered after a five-second timer and looked like a working app.
+ * Asserting that `32°` is on screen proves a specific number travelled the full chain and was
+ * computed, not typed.
+ *
+ * That number is exact rather than approximate because the fake backend'"'"'s `hunchback` preset is
+ * an analytic stick figure: the trunk is built at 32° and the engine measures 32°. A real model
+ * would force a tolerance, and a tolerance is where flake starts.
+ *
+ * Fake backend for the same reason `containers.yml` uses one: the job proves the layers are
+ * wired together, and real inference would make it slow and its failures about something else.
+ * Real-model validation lives in the `workflow_dispatch` job from OP-21.
+ */
+
+const FIXTURE = fileURLToPath(new URL('../../../fixtures/images/desk_hunch.jpeg', import.meta.url))
+
+/** The dashboard is behind `ProtectedRoute`, so every journey starts by making an account. */
+async function register(page: import('@playwright/test').Page, name: string) {
+  await page.goto('/register')
+  await page.getByLabel('Name:').fill(name)
+  await page.getByLabel('Email:').fill(`${name.toLowerCase().replace(/\s+/g, '.')}@example.com`)
+  await page.getByLabel('Password:').fill('correct-horse-battery')
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await expect(page.getByRole('heading', { name: `Hello, ${name}` })).toBeVisible()
+}
+
+test('a photograph produces a real, measured result on screen', async ({ page }) => {
+  await register(page, 'Ada Lovelace')
+
+  await page.getByLabel(/Input an image of you sitting/).setInputFiles(FIXTURE)
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  await expect(page.getByRole('heading', { name: 'Your results' })).toBeVisible()
+
+  // The exact value. 32° is the trunk inclination the `hunchback` preset is built at, so this
+  // fails if any link in the chain is broken *or* if the engine's answer changes.
+  //
+  // `exact: true` matters: "32°" also appears inside the finding's sentence, and a substring
+  // match resolves to several elements — which Playwright treats as an error rather than picking
+  // one, so the assertion would fail for the wrong reason.
+  await expect(page.getByText('32°', { exact: true })).toBeVisible()
+  await expect(page.getByText(/Your torso is leaning 32° forward/)).toBeVisible()
+
+  // The score is derived from the findings, so it is a second independent value off the same
+  // pipeline rather than a restatement of the first.
+  await expect(page.getByText('70', { exact: true })).toBeVisible()
+})
+
+test('the skeleton overlay is drawn over the uploaded photo', async ({ page }) => {
+  await register(page, 'Grace Hopper')
+
+  await page.getByLabel(/Input an image of you sitting/).setInputFiles(FIXTURE)
+  await page.getByRole('button', { name: 'Submit' }).click()
+  await expect(page.getByRole('heading', { name: 'Your results' })).toBeVisible()
+
+  const canvas = page.getByTestId('skeleton')
+  await expect(canvas).toBeVisible()
+
+  // Sized to the photo rather than left at the HTML default of 300x150, which is what an overlay
+  // that never measured its box would be. Checked in the real browser because the sizing depends
+  // on layout and `devicePixelRatio` — the things jsdom cannot tell us about.
+  const box = await canvas.boundingBox()
+  expect(box).not.toBeNull()
+  expect(box!.width).toBeGreaterThan(0)
+
+  const image = page.getByRole('img', { name: 'The photo you uploaded' })
+  const imageBox = await image.boundingBox()
+  expect(imageBox).not.toBeNull()
+  // The overlay sits on the photo. A few pixels of tolerance for sub-pixel layout rounding.
+  expect(Math.abs(box!.x - imageBox!.x)).toBeLessThan(2)
+  expect(Math.abs(box!.width - imageBox!.width)).toBeLessThan(2)
+})
+
+test('an unreadable file is refused with a message the user can act on', async ({ page }) => {
+  await register(page, 'Alan Turing')
+
+  await page.getByLabel(/Input an image of you sitting/).setInputFiles({
+    name: 'notes.txt',
+    mimeType: 'text/plain',
+    buffer: Buffer.from('this is not an image, it is a sentence'),
+  })
+  await page.getByRole('button', { name: 'Submit' }).click()
+
+  const alert = page.getByRole('alert')
+  await expect(alert).toBeVisible()
+  await expect(alert).toContainText(/could not be decoded as an image/)
+  // No half-rendered results beside the error.
+  await expect(page.getByRole('heading', { name: 'Your results' })).toBeHidden()
+})

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -17,7 +17,8 @@
     "preview": "vite preview",
     "codegen": "npm run codegen:schema && npm run codegen:types",
     "codegen:schema": "cd ../.. && uv run python scripts/dump_openapi.py apps/web/src/api/openapi.json",
-    "codegen:types": "npx --yes openapi-typescript@7.13.0 src/api/openapi.json -o src/api/schema.d.ts"
+    "codegen:types": "npx --yes openapi-typescript@7.13.0 src/api/openapi.json -o src/api/schema.d.ts",
+    "test:e2e:stack": "playwright test --config playwright.stack.config.ts"
   },
   "dependencies": {
     "react": "^19.2.8",

--- a/apps/web/playwright.stack.config.ts
+++ b/apps/web/playwright.stack.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig, devices } from '@playwright/test'
+
+/**
+ * End-to-end config for the journey that needs a real API behind it.
+ *
+ * Separate from `playwright.config.ts`, which serves a static production bundle at :4173 and can
+ * therefore test everything except the one thing this suite is for. The difference is not a
+ * preference:
+ *
+ * - `vite preview` applies `preview.proxy`, not `server.proxy`, so the production-bundle server
+ *   does not forward `/api` at all. A spec run there would exercise a frontend talking to
+ *   nothing.
+ * - This suite is meaningless without the API, so it must not run in the `web-e2e` job that has
+ *   no stack. Two configs keep "can this run here" a property of the config rather than of a
+ *   skip inside a spec.
+ *
+ * No `webServer`. The stack is started by `docker compose` — by `e2e.yml` in CI, or by hand
+ * locally — because starting it from Playwright would mean Playwright owning image builds and
+ * healthchecks, which Compose already does properly.
+ */
+export default defineConfig({
+  testDir: './e2e-stack',
+  fullyParallel: true,
+  // A test that only passes on retry is flaky, and the ticket asks for ten consecutive green
+  // runs before merge. Retries would hide exactly what that check is looking for.
+  retries: 0,
+  forbidOnly: Boolean(process.env.CI),
+  reporter: process.env.CI ? 'github' : 'list',
+  use: {
+    // The web service, which proxies /api to the api service. Deliberately *not* :8000 — going
+    // straight to the API would skip the proxy, and the proxy is half of what this proves.
+    baseURL: process.env.E2E_BASE_URL ?? 'http://localhost:5173',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -39,9 +39,12 @@ export default defineConfig({
     environment: 'jsdom',
     setupFiles: ['./src/setupTests.ts'],
     css: true,
-    // Playwright owns e2e/. Without this, `vitest run` collects those specs, fails to resolve
-    // @playwright/test's runner and reports errors that look like broken tests.
-    exclude: ['node_modules/**', 'dist/**', 'e2e/**'],
+    // Playwright owns both e2e directories. Without this, `vitest run` collects those specs,
+    // fails to resolve @playwright/test's runner and reports errors that look like broken
+    // tests — which is exactly what happened when `e2e-stack/` was added and this list was
+    // not: the spec parsed under Vitest, called `fileURLToPath` on a non-file URL and failed
+    // a job that had nothing to do with it.
+    exclude: ['node_modules/**', 'dist/**', 'e2e/**', 'e2e-stack/**'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'lcov'],

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -100,6 +100,26 @@ services:
         # Not merely `started`. Without this the frontend can come up while the API is still
         # loading its model, and the first upload fails for a reason that looks like a bug.
         condition: service_healthy
+    healthcheck:
+      # Without this, `docker compose up --wait` treats the container as ready the moment the
+      # process starts — which is before Vite has bound its port. Anything that navigates
+      # immediately afterwards races the dev server, and the symptom is an intermittent
+      # connection refused in a job that otherwise looks correct.
+      #
+      # `node -e` rather than curl or wget: this image is `node:22-bookworm-slim`, which ships
+      # neither. Node is the one thing guaranteed to be present, and its global `fetch` makes the
+      # check a one-liner.
+      test:
+        - CMD
+        - node
+        - -e
+        # Quoted: the ternary contains a colon-space, which YAML would otherwise read as a
+        # mapping key rather than as part of the command.
+        - "fetch('http://127.0.0.1:5173/').then((r) => process.exit(r.ok ? 0 : 1)).catch(() => process.exit(1))"
+      interval: 3s
+      timeout: 3s
+      start_period: 30s
+      retries: 10
 
 volumes:
   api-storage:


### PR DESCRIPTION
This pull request introduces a comprehensive end-to-end (E2E) test suite that validates the application's full-stack journey, ensuring a real user can successfully upload a photo and receive a computed result through all layers of the stack. It adds a new GitHub Actions workflow to automate this test, updates project configuration to support the new tests, and clarifies documentation regarding required status checks.

**End-to-end testing infrastructure:**

* Added a new Playwright E2E test suite in `apps/web/e2e-stack/analysis.spec.ts` that simulates a user registering, uploading a photo, and validating that a precise, computed result appears on screen, as well as verifying error handling and overlay rendering.
* Introduced a dedicated Playwright configuration file `apps/web/playwright.stack.config.ts` to run these full-stack tests against a live backend, ensuring the frontend, API, and backend are wired together correctly.
* Updated `apps/web/package.json` to add the `test:e2e:stack` script for running the new E2E test suite.
* Modified the Vitest configuration in `apps/web/vite.config.ts` to exclude the new E2E test directory, preventing test runner conflicts.

**CI/CD and documentation updates:**

* Added a new GitHub Actions workflow `.github/workflows/e2e.yml` that builds the stack, runs the E2E journey, and reports status via an `e2e-ok` aggregator job. The documentation `.github/main-ruleset.md` is updated to reflect the addition of `e2e-ok` as a conventionally blocking check, clarifying its purpose and integration with other required checks. [[1]](diffhunk://#diff-3e103440521ada06efd263ae09b259e5507e4b8f7408308dc227621ad9efa31eR1-R122) [[2]](diffhunk://#diff-b5945d91adde8af79aaba6b0e492fe847ec003fbd14977ab3958e9be221bafaeL61-R75)