### PR TITLE
Epic D review follow-ups: a cancelled upload is not a failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![PR](https://github.com/m-nweke/OpenPosture/actions/workflows/pr.yml/badge.svg?branch=main)](https://github.com/m-nweke/OpenPosture/actions/workflows/pr.yml)
 [![containers](https://github.com/m-nweke/OpenPosture/actions/workflows/containers.yml/badge.svg?branch=main)](https://github.com/m-nweke/OpenPosture/actions/workflows/containers.yml)
 [![scientific-validation](https://github.com/m-nweke/OpenPosture/actions/workflows/scientific-validation.yml/badge.svg?branch=main)](https://github.com/m-nweke/OpenPosture/actions/workflows/scientific-validation.yml)
+[![e2e](https://github.com/m-nweke/OpenPosture/actions/workflows/e2e.yml/badge.svg?branch=main)](https://github.com/m-nweke/OpenPosture/actions/workflows/e2e.yml)
 
 **Upload a photograph of yourself sitting. Get back angles measured from your own body, and an
 honest account of what could not be measured.**

--- a/apps/api/src/openposture_api/schemas.py
+++ b/apps/api/src/openposture_api/schemas.py
@@ -107,7 +107,15 @@ class PostureReportModel(ContractModel):
     rules_version: str
     backend: str
     inference_ms: float
-    image: ImageSize
+    image: ImageSize = Field(
+        description=(
+            "The frame the *backend* measured, which is not always the frame that was uploaded. "
+            "`FakePoseBackend` ignores the image entirely and reports its preset's own size, so "
+            "this can differ from `AnalysisResponse.image` whenever the fake backend is in use. "
+            "For anything to do with the uploaded photograph — scaling an overlay, for instance — "
+            "use `AnalysisResponse.image`."
+        )
+    )
     overall_score: float | None = Field(
         description=(
             "0 to 100, or `null` when nothing could be measured. Null rather than 0 or 100: both "
@@ -170,4 +178,10 @@ class AnalysisResponse(ContractModel):
             "derived artifact, and a cache-invalidation question every time the rules change."
         ),
     )
-    image: ImageSize
+    image: ImageSize = Field(
+        description=(
+            "The uploaded photograph's dimensions after EXIF rotation is applied — what the user "
+            "actually sees. This is the authoritative size for a client; see the note on "
+            "`PostureReportModel.image` for why the two can differ."
+        )
+    )

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -6,7 +6,8 @@
         "description": "What `POST /api/v1/analyses` returns on success.",
         "properties": {
           "image": {
-            "$ref": "#/components/schemas/ImageSize"
+            "$ref": "#/components/schemas/ImageSize",
+            "description": "The uploaded photograph's dimensions after EXIF rotation is applied \u2014 what the user actually sees. This is the authoritative size for a client; see the note on `PostureReportModel.image` for why the two can differ."
           },
           "landmarks": {
             "description": "Every landmark the backend returned, for drawing a skeleton over the photo. Empty when no pose was detected. The overlay is drawn client-side from these \u2014 the server never writes an annotated image, which would cost a round trip, storage for a derived artifact, and a cache-invalidation question every time the rules change.",
@@ -328,7 +329,8 @@
             "type": "array"
           },
           "image": {
-            "$ref": "#/components/schemas/ImageSize"
+            "$ref": "#/components/schemas/ImageSize",
+            "description": "The frame the *backend* measured, which is not always the frame that was uploaded. `FakePoseBackend` ignores the image entirely and reports its preset's own size, so this can differ from `AnalysisResponse.image` whenever the fake backend is in use. For anything to do with the uploaded photograph \u2014 scaling an overlay, for instance \u2014 use `AnalysisResponse.image`."
           },
           "inference_ms": {
             "title": "Inference Ms",

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -73,6 +73,7 @@ export interface components {
          * @description What `POST /api/v1/analyses` returns on success.
          */
         AnalysisResponse: {
+            /** @description The uploaded photograph's dimensions after EXIF rotation is applied — what the user actually sees. This is the authoritative size for a client; see the note on `PostureReportModel.image` for why the two can differ. */
             image: components["schemas"]["ImageSize"];
             /**
              * Landmarks
@@ -245,6 +246,7 @@ export interface components {
             backend: string;
             /** Findings */
             findings: components["schemas"]["Finding"][];
+            /** @description The frame the *backend* measured, which is not always the frame that was uploaded. `FakePoseBackend` ignores the image entirely and reports its preset's own size, so this can differ from `AnalysisResponse.image` whenever the fake backend is in use. For anything to do with the uploaded photograph — scaling an overlay, for instance — use `AnalysisResponse.image`. */
             image: components["schemas"]["ImageSize"];
             /** Inference Ms */
             inference_ms: number;

--- a/apps/web/src/views/Dashboard.test.tsx
+++ b/apps/web/src/views/Dashboard.test.tsx
@@ -343,6 +343,40 @@ describe('Dashboard', () => {
     })
   })
 
+  describe('cancelling', () => {
+    it('clearing mid-upload does not report a failure', async () => {
+      // Aborting rejects the request, and an unfiltered catch turns that into a red alert saying
+      // "The upload was cancelled." on a form the user has just deliberately cleared — telling
+      // them something went wrong when nothing did.
+      signedInAs('Ada')
+      const release = heldResponse()
+      renderWithProviders(<Dashboard />)
+      const user = await upload()
+      await screen.findByRole('progressbar')
+
+      await user.click(screen.getByRole('button', { name: 'Clear' }))
+      release()
+
+      await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+    })
+
+    it('choosing another file mid-upload does not report a failure', async () => {
+      signedInAs('Ada')
+      const release = heldResponse()
+      renderWithProviders(<Dashboard />)
+      const user = await upload()
+      await screen.findByRole('progressbar')
+
+      await user.upload(fileInput(), pngFile())
+      release()
+
+      await waitFor(() => expect(screen.queryByRole('progressbar')).not.toBeInTheDocument())
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument()
+      expect(screen.queryByRole('heading', { name: 'Your results' })).not.toBeInTheDocument()
+    })
+  })
+
   describe('clearing', () => {
     it('removes the result and re-disables submit', async () => {
       signedInAs('Ada')

--- a/apps/web/src/views/Dashboard.tsx
+++ b/apps/web/src/views/Dashboard.tsx
@@ -82,9 +82,18 @@ export default function Dashboard() {
         onProgress: setProgress,
         signal: controller.signal,
       })
+      // Superseded while in flight. Writing the result now would put this report beside whatever
+      // the screen has moved on to — a cleared form, or a different photo's preview.
+      if (controller.signal.aborted) return
       setAnalysis(result)
       setStatus('done')
     } catch (caught) {
+      // A cancelled upload is not a failure to report. Clearing the form and choosing a second
+      // file both abort the request, and both already put the screen where the user asked for
+      // it; surfacing "The upload was cancelled." as a red alert on top of that tells them
+      // something went wrong when nothing did.
+      if (controller.signal.aborted) return
+
       setError(
         caught instanceof ApiError
           ? caught
@@ -92,7 +101,9 @@ export default function Dashboard() {
       )
       setStatus('error')
     } finally {
-      abortRef.current = null
+      // Only if this request still owns the ref. A superseded request finishing later would
+      // otherwise clear the *current* one's controller, leaving it with no way to be aborted.
+      if (abortRef.current === controller) abortRef.current = null
     }
   }, [file, status])
 


### PR DESCRIPTION
This pull request improves both the backend and frontend user experience by clarifying the meaning of image dimensions in API responses and by refining the upload cancellation behavior in the Dashboard. The backend API schemas and documentation now provide clear descriptions distinguishing between the image as uploaded and as measured by the backend, while the Dashboard no longer displays misleading error alerts when an upload is cancelled or superseded.

**API Schema and Documentation Improvements:**
- Clarified the meaning of the `image` field in both `PostureReportModel` and `AnalysisResponse` in the backend schema, explaining when and why their values may differ. This helps clients understand which image dimensions to use for overlays and UI scaling. [[1]](diffhunk://#diff-6afc742c42926dc0ebfddff517fe6d9290b8f0d77bc3d9267d50ca412fa43736L110-R118) [[2]](diffhunk://#diff-6afc742c42926dc0ebfddff517fe6d9290b8f0d77bc3d9267d50ca412fa43736L173-R187)
- Updated the OpenAPI documentation (`openapi.json`) to include these new descriptions, ensuring the API contract is clear for frontend and external consumers. [[1]](diffhunk://#diff-2aaf30d48fff5616caa85da437280cec3a35b80dd6414e9d1bb534f9868cc330L9-R10) [[2]](diffhunk://#diff-2aaf30d48fff5616caa85da437280cec3a35b80dd6414e9d1bb534f9868cc330L331-R333)

**Frontend User Experience Improvements:**
- Modified the Dashboard so that cancelling an upload or selecting a new file mid-upload does not display a failure alert, preventing confusion for users who intentionally interrupt the upload process.
- Added tests to verify that cancelling or superseding an upload does not show error alerts or stale results.

**Other:**
- Added a badge for end-to-end (e2e) tests to the `README.md` for improved project status visibility.