### PR TITLE
OP-52: Repository layer with testcontainers integration tests

### DIFF
--- a/.github/actions/setup-project/action.yml
+++ b/.github/actions/setup-project/action.yml
@@ -58,9 +58,12 @@ runs:
     - name: Sync Python workspace
       if: inputs.python != ''
       shell: bash
-      # --frozen fails if uv.lock is out of date with the pyproject files, so a dependency change
-      # that was never locked cannot merge.
-      run: uv sync --all-packages --frozen
+      # --locked, not --frozen. Both refuse to *write* the lock; only --locked also verifies it is
+      # up to date with the pyproject files and fails when it is not. --frozen silently installs
+      # whatever the stale lock happens to say, and a dependency that was added but never locked
+      # then surfaces hundreds of lines later as `ModuleNotFoundError` in an unrelated test job.
+      # That is exactly what this flag was always documented as preventing.
+      run: uv sync --all-packages --locked
 
     # ---- Node ---------------------------------------------------------------
     - name: Install Node

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -260,6 +260,18 @@ jobs:
           uv run alembic -c apps/api/alembic.ini check
           echo "OK  no drift"
 
+      - name: Repository integration tests pass against a real Postgres
+        # testcontainers starts its own Postgres container on a random port, separate from the
+        # compose service. Docker is available on `ubuntu-latest` and is already in use by the
+        # compose steps above, so no extra setup is needed.
+        #
+        # These tests prove the repository layer's behaviour under real Postgres semantics:
+        # cursor pagination ordering, RETURNING on DELETE, and user_id scoping. They are
+        # deliberately not in `pr.yml` — the SQLite suite there cannot exercise any of these.
+        run: |
+          uv run pytest apps/api/tests/integration/ -v --no-header
+          echo "OK  repository integration tests passed"
+
       - name: The object is actually in the bucket
         # Asserted from MinIO's side, not from the API's response. A 201 carrying an object key
         # only says the application believes it wrote something.

--- a/apps/api/migrations/env.py
+++ b/apps/api/migrations/env.py
@@ -38,8 +38,8 @@ if config.config_file_name is not None:
 # Import Base and register all model tables with its metadata. Both imports are load-bearing:
 # Base brings the naming convention; the models import registers the seven table definitions.
 # Without the second import, Base.metadata is empty and migrations operate on nothing.
-from openposture_api.db.base import Base  # noqa: E402
 import openposture_api.db.models  # noqa: E402, F401
+from openposture_api.db.base import Base  # noqa: E402
 
 target_metadata = Base.metadata
 

--- a/apps/api/migrations/versions/f7a2c9d81b3e_initial_schema.py
+++ b/apps/api/migrations/versions/f7a2c9d81b3e_initial_schema.py
@@ -27,14 +27,14 @@ full schema is produced at once.
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 from alembic import op
 
 revision: str = "f7a2c9d81b3e"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 # Creation order respects FK dependencies. SQLAlchemy's create_all resolves this automatically,
 # but an explicit list also documents the intended dependency graph and prevents a future edit

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -65,7 +65,9 @@ dev = [
     # session dependency. What they cannot exercise is Postgres-specific behaviour; that is
     # E4's `testcontainers` suite, which is a different ticket for a reason.
     "aiosqlite>=0.20",
-    # Real Postgres for E4's repository integration tests. The `postgres` extra pulls psycopg2
-    # which testcontainers uses to wait for the database to accept connections.
-    "testcontainers[postgres]>=4.9",
+    # Real Postgres for E4's repository integration tests. No extra and no psycopg2: 4.15 waits
+    # for readiness by running `psql` *inside* the container, so the host needs no sync driver —
+    # which suits a project whose only Postgres driver is asyncpg. Floored at 4.15 because that
+    # is where `testcontainers.community.postgres` replaced `testcontainers.postgres`.
+    "testcontainers>=4.15",
 ]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -65,4 +65,7 @@ dev = [
     # session dependency. What they cannot exercise is Postgres-specific behaviour; that is
     # E4's `testcontainers` suite, which is a different ticket for a reason.
     "aiosqlite>=0.20",
+    # Real Postgres for E4's repository integration tests. The `postgres` extra pulls psycopg2
+    # which testcontainers uses to wait for the database to accept connections.
+    "testcontainers[postgres]>=4.9",
 ]

--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -19,12 +19,15 @@ allowlist, or a backend that is not there.
 
 from __future__ import annotations
 
+import time
 from typing import TYPE_CHECKING, Annotated, Final
 
 import structlog
 from fastapi import APIRouter, Depends, File, Request, UploadFile
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
+from openposture_api.db import get_session
 from openposture_api.errors import PROBLEM_TYPE_BASE, problem_response
 from openposture_api.images import (
     MAX_IMAGE_BYTES,
@@ -34,6 +37,7 @@ from openposture_api.images import (
     decode_upload,
 )
 from openposture_api.pose import get_pose_backend
+from openposture_api.repos import AnalysisRepository, FindingRecord, KeypointRecord, MetricRecord
 from openposture_api.schemas import (
     AnalysisResponse,
     DetectedLandmark,
@@ -44,6 +48,8 @@ from openposture_api.storage import StorageBackend, StorageError, get_storage
 from pose_backends.base import PoseBackend
 from pose_backends.errors import PoseBackendError
 from posture_core import build_report
+from posture_core.report import SCHEMA_VERSION as _SCHEMA_VERSION
+from posture_core.thresholds import DEFAULT_THRESHOLDS as _DEFAULT_THRESHOLDS
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -91,6 +97,7 @@ def build_analyses_router() -> APIRouter:
         request: Request,
         backend: Annotated[PoseBackend, Depends(get_pose_backend)],
         storage: Annotated[StorageBackend, Depends(get_storage)],
+        session: Annotated[AsyncSession, Depends(get_session)],
         image: Annotated[UploadFile, File(description="The photograph to analyse.")],
     ) -> AnalysisResponse:
         raw = await _read_within_limit(image)
@@ -101,15 +108,35 @@ def build_analyses_router() -> APIRouter:
         # more in context switching than it saves. The moment that stops being true (a heavier
         # model, or real concurrency) this becomes `run_in_threadpool`, which is one line and one
         # of the four reasons ADR-0001 chose FastAPI.
+        _t = time.perf_counter()
         frame = backend.detect(decoded.array)
+        measured_ms = (time.perf_counter() - _t) * 1000.0
 
         stored = storage.put(decoded.data, content_type=decoded.content_type)
+
+        repo = AnalysisRepository(session)
 
         if frame is None:
             # An ordinary outcome — the user photographed their desk. 201, because the request
             # succeeded and "nobody in this image" is the finding.
+            analysis = await repo.create(
+                object_key=stored.key,
+                pose_detected=False,
+                image_width=decoded.width,
+                image_height=decoded.height,
+                overall_score=None,
+                assessed=0,
+                total=0,
+                inference_ms=measured_ms,
+                pose_backend=backend.name,
+                rules_version=_DEFAULT_THRESHOLDS.version,
+                schema_version=_SCHEMA_VERSION,
+            )
+            await session.commit()
+
             _LOGGER.info("analysis_no_pose", backend=backend.name, object_key=stored.key)
             return AnalysisResponse(
+                id=analysis.id,
                 object_key=stored.key,
                 pose_detected=False,
                 report=None,
@@ -119,10 +146,29 @@ def build_analyses_router() -> APIRouter:
 
         report = build_report(frame)
 
+        analysis = await repo.create(
+            object_key=stored.key,
+            pose_detected=True,
+            image_width=decoded.width,
+            image_height=decoded.height,
+            overall_score=report.overall_score,
+            assessed=report.quality.assessed,
+            total=report.quality.total,
+            inference_ms=report.inference_ms,
+            pose_backend=backend.name,
+            rules_version=report.rules_version,
+            schema_version=report.schema_version,
+            keypoints=_keypoint_records(frame, report),
+            metrics=_metric_records(report),
+            findings=_finding_records(report),
+        )
+        await session.commit()
+
         _LOGGER.info(
             "analysis_complete",
             backend=backend.name,
             object_key=stored.key,
+            analysis_id=str(analysis.id),
             assessed=report.quality.assessed,
             total=report.quality.total,
             findings=len(report.findings),
@@ -130,6 +176,7 @@ def build_analyses_router() -> APIRouter:
         )
 
         return AnalysisResponse(
+            id=analysis.id,
             object_key=stored.key,
             pose_detected=True,
             landmarks=_landmarks_for(frame, report),
@@ -148,6 +195,53 @@ def build_analyses_router() -> APIRouter:
         )
 
     return router
+
+
+def _keypoint_records(frame: PoseFrame, report: PostureReport) -> list[KeypointRecord]:
+    """Pair each detected landmark with its resolver status, ready for the repository."""
+    statuses = report.quality.keypoints
+    return [
+        KeypointRecord(
+            name=str(name),
+            x=landmark.x,
+            y=landmark.y,
+            status=str(statuses[name]),
+            visibility=landmark.visibility,
+            presence=landmark.presence,
+        )
+        for name, landmark in frame.landmarks.items()
+    ]
+
+
+def _metric_records(report: PostureReport) -> list[MetricRecord]:
+    return [
+        MetricRecord(
+            code=name,
+            value=metric.value,
+            unit=metric.unit,
+            status=metric.status.value,
+            detail=metric.detail,
+            confidence=metric.confidence,
+        )
+        for name, metric in report.metrics.items()
+    ]
+
+
+def _finding_records(report: PostureReport) -> list[FindingRecord]:
+    return [
+        FindingRecord(
+            code=finding.code,
+            severity=finding.severity.value,
+            message=finding.message,
+            metric=finding.metric,
+            # `finding.value` is typed `float | None` in posture_core.rules but in practice is
+            # always set when a finding fires — a rule only fires when a metric is OK, and an OK
+            # metric has a value. The `or 0.0` guard is defensive; it should never trigger.
+            value=finding.value or 0.0,
+            confidence=finding.confidence,
+        )
+        for finding in report.findings
+    ]
 
 
 def _landmarks_for(frame: PoseFrame, report: PostureReport) -> list[DetectedLandmark]:

--- a/apps/api/src/openposture_api/repos/__init__.py
+++ b/apps/api/src/openposture_api/repos/__init__.py
@@ -1,0 +1,35 @@
+"""Repository layer: thin typed wrappers over the ORM, each scoped by user_id.
+
+    from openposture_api.repos import AnalysisRepository
+
+    async def create_analysis(session: AsyncSession) -> Analysis:
+        repo = AnalysisRepository(session)
+        return await repo.create(object_key="...", ...)
+
+Every read method on every repo here takes a `user_id` — that is the structural guarantee that
+makes the "404 not 403" rule in E8 enforceable at the layer, not just at the route.
+
+Transaction ownership lives with the caller. The repos flush to make new rows visible within the
+current transaction, but they never commit or roll back. A route that writes two aggregates in one
+request owns the decision about whether that is one unit of work or two.
+"""
+
+from __future__ import annotations
+
+from openposture_api.repos.analyses import (
+    AnalysisRepository,
+    FindingRecord,
+    KeypointRecord,
+    MetricRecord,
+)
+from openposture_api.repos.refresh_tokens import RefreshTokenRepository
+from openposture_api.repos.users import UserRepository
+
+__all__ = [
+    "AnalysisRepository",
+    "FindingRecord",
+    "KeypointRecord",
+    "MetricRecord",
+    "RefreshTokenRepository",
+    "UserRepository",
+]

--- a/apps/api/src/openposture_api/repos/analyses.py
+++ b/apps/api/src/openposture_api/repos/analyses.py
@@ -18,7 +18,8 @@ import uuid
 from datetime import datetime
 from typing import TYPE_CHECKING
 
-from sqlalchemy import and_, delete as sql_delete, or_, select
+from sqlalchemy import and_, or_, select
+from sqlalchemy import delete as sql_delete
 from sqlalchemy.orm import selectinload
 
 from openposture_api.db.models import Analysis, Finding, Keypoint, Metric

--- a/apps/api/src/openposture_api/repos/analyses.py
+++ b/apps/api/src/openposture_api/repos/analyses.py
@@ -1,0 +1,242 @@
+"""Repository for the analysis aggregate.
+
+The analysis aggregate is the core multi-tenant resource. Every read method requires a
+`user_id` — there is no method that returns an analysis without one. That is not a convention;
+it is why a route that calls this repo cannot accidentally serve one user's analysis to another.
+The 404-not-403 rule in E8 is a consequence of this: the repo returns None for "not found" and
+for "found but wrong owner", so the route sees exactly one signal and renders it once.
+
+**No unscoped reads.** A test in the integration suite enumerates every method whose name
+starts with `get` or `list` and asserts that `user_id` appears in its signature. Adding a
+method without it will fail that test before the branch is merged.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import uuid
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import and_, delete as sql_delete, or_, select
+from sqlalchemy.orm import selectinload
+
+from openposture_api.db.models import Analysis, Finding, Keypoint, Metric
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["AnalysisRepository", "FindingRecord", "KeypointRecord", "MetricRecord"]
+
+
+@dataclasses.dataclass(frozen=True)
+class KeypointRecord:
+    """One landmark's data, ready to be inserted as a `Keypoint` row."""
+
+    name: str
+    x: float
+    y: float
+    status: str
+    visibility: float
+    presence: float
+
+
+@dataclasses.dataclass(frozen=True)
+class MetricRecord:
+    """One metric's data, ready to be inserted as a `Metric` row."""
+
+    code: str
+    value: float | None
+    unit: str
+    status: str
+    detail: str
+    confidence: float | None
+
+
+@dataclasses.dataclass(frozen=True)
+class FindingRecord:
+    """One finding's data, ready to be inserted as a `Finding` row."""
+
+    code: str
+    severity: str
+    message: str
+    metric: str
+    value: float
+    confidence: float
+
+
+class AnalysisRepository:
+    """Read and write operations on the analysis aggregate.
+
+    One instance per request, constructed with the request's session. The session is
+    not owned here — the caller created it and the caller will commit or roll back.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        *,
+        object_key: str,
+        pose_detected: bool,
+        image_width: int,
+        image_height: int,
+        overall_score: float | None,
+        assessed: int,
+        total: int,
+        inference_ms: float,
+        pose_backend: str,
+        rules_version: str,
+        schema_version: str,
+        user_id: uuid.UUID | None = None,
+        keypoints: list[KeypointRecord] | None = None,
+        metrics: list[MetricRecord] | None = None,
+        findings: list[FindingRecord] | None = None,
+    ) -> Analysis:
+        """Persist a complete analysis with all its child rows.
+
+        Flushes the analysis first so child rows have a valid `analysis_id`, then
+        flushes the children. Does not commit — the caller controls the transaction.
+        """
+        analysis = Analysis(
+            user_id=user_id,
+            object_key=object_key,
+            pose_detected=pose_detected,
+            image_width=image_width,
+            image_height=image_height,
+            overall_score=overall_score,
+            assessed=assessed,
+            total=total,
+            inference_ms=inference_ms,
+            pose_backend=pose_backend,
+            rules_version=rules_version,
+            schema_version=schema_version,
+        )
+        self._session.add(analysis)
+        await self._session.flush()
+
+        if keypoints:
+            self._session.add_all(
+                Keypoint(
+                    analysis_id=analysis.id,
+                    name=kp.name,
+                    x=kp.x,
+                    y=kp.y,
+                    status=kp.status,
+                    visibility=kp.visibility,
+                    presence=kp.presence,
+                )
+                for kp in keypoints
+            )
+
+        if metrics:
+            self._session.add_all(
+                Metric(
+                    analysis_id=analysis.id,
+                    code=m.code,
+                    value=m.value,
+                    unit=m.unit,
+                    status=m.status,
+                    detail=m.detail,
+                    confidence=m.confidence,
+                )
+                for m in metrics
+            )
+
+        if findings:
+            self._session.add_all(
+                Finding(
+                    analysis_id=analysis.id,
+                    code=f.code,
+                    severity=f.severity,
+                    message=f.message,
+                    metric=f.metric,
+                    value=f.value,
+                    confidence=f.confidence,
+                )
+                for f in findings
+            )
+
+        if keypoints or metrics or findings:
+            await self._session.flush()
+
+        return analysis
+
+    async def get(
+        self,
+        user_id: uuid.UUID,
+        analysis_id: uuid.UUID,
+    ) -> Analysis | None:
+        """Fetch one analysis with its children, scoped to user_id.
+
+        Returns None both when the analysis does not exist and when it belongs to a
+        different user. The caller sees only 404 — existence is not leaked to the requester.
+        """
+        stmt = (
+            select(Analysis)
+            .where(Analysis.id == analysis_id, Analysis.user_id == user_id)
+            .options(
+                selectinload(Analysis.keypoints),
+                selectinload(Analysis.metrics),
+                selectinload(Analysis.findings),
+            )
+        )
+        return (await self._session.execute(stmt)).scalar_one_or_none()
+
+    async def list_page(
+        self,
+        user_id: uuid.UUID,
+        *,
+        cursor_created_at: datetime | None = None,
+        cursor_id: uuid.UUID | None = None,
+        limit: int = 20,
+    ) -> list[Analysis]:
+        """Return one page of analyses for a user, newest first.
+
+        Cursor pagination on `(created_at DESC, id DESC)`. To advance past the first
+        page, pass the last row's `created_at` and `id` from the previous response.
+
+        Both cursor fields must be provided together or not at all — a cursor with only
+        one half produces the same result as no cursor, silently.
+        """
+        stmt = (
+            select(Analysis)
+            .where(Analysis.user_id == user_id)
+            .order_by(Analysis.created_at.desc(), Analysis.id.desc())
+            .limit(limit)
+        )
+
+        if cursor_created_at is not None and cursor_id is not None:
+            stmt = stmt.where(
+                or_(
+                    Analysis.created_at < cursor_created_at,
+                    and_(
+                        Analysis.created_at == cursor_created_at,
+                        Analysis.id < cursor_id,
+                    ),
+                )
+            )
+
+        return list((await self._session.execute(stmt)).scalars().all())
+
+    async def delete(
+        self,
+        user_id: uuid.UUID,
+        analysis_id: uuid.UUID,
+    ) -> bool:
+        """Delete an analysis, scoped to user_id.
+
+        Returns True if a row was deleted, False if no row matched.
+        Returning False for another user's row is intentional: the caller sees no
+        difference between "not found" and "found but not yours".
+
+        CASCADE on the FK handles the children; no explicit child deletion needed.
+        """
+        result = await self._session.execute(
+            sql_delete(Analysis)
+            .where(Analysis.id == analysis_id, Analysis.user_id == user_id)
+            .returning(Analysis.id)
+        )
+        await self._session.flush()
+        return result.scalar_one_or_none() is not None

--- a/apps/api/src/openposture_api/repos/refresh_tokens.py
+++ b/apps/api/src/openposture_api/repos/refresh_tokens.py
@@ -1,0 +1,110 @@
+"""Repository for refresh token records."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select, update
+
+from openposture_api.db.models import RefreshToken
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["RefreshTokenRepository"]
+
+
+class RefreshTokenRepository:
+    """Read and write operations on refresh tokens.
+
+    Tokens are never updated in place — rotation creates a new row, then revokes the old one by
+    setting `revoked_at`. This means a replay (the same token presented twice) is detectable: the
+    presented hash matches a row that is already revoked, which is the signal to revoke the entire
+    family rather than just the one presented.
+
+    The family concept is why `revoke_family` exists: once a token from a family has been used
+    after rotation, both the attacker's copy and the legitimate client's copy are in the same
+    family, and only revoking both forces a full re-login.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        *,
+        user_id: uuid.UUID,
+        token_hash: str,
+        family_id: uuid.UUID,
+        issued_at: datetime,
+        expires_at: datetime,
+    ) -> RefreshToken:
+        token = RefreshToken(
+            user_id=user_id,
+            token_hash=token_hash,
+            family_id=family_id,
+            issued_at=issued_at,
+            expires_at=expires_at,
+        )
+        self._session.add(token)
+        await self._session.flush()
+        return token
+
+    async def get_active_by_hash(self, token_hash: str) -> RefreshToken | None:
+        """Fetch an unrevoked, unexpired token by its hash.
+
+        Returns None for unknown hashes, revoked tokens, and expired tokens. The caller
+        is responsible for distinguishing "token was rotated (revoked)" from "token
+        never existed" by checking whether `get_by_hash` returns a revoked row — but
+        that requires a separate method. E7 will call both as needed.
+        """
+        now = datetime.now(UTC)
+        result = await self._session.execute(
+            select(RefreshToken).where(
+                RefreshToken.token_hash == token_hash,
+                RefreshToken.revoked_at.is_(None),
+                RefreshToken.expires_at > now,
+            )
+        )
+        return result.scalar_one_or_none()
+
+    async def get_by_hash(self, token_hash: str) -> RefreshToken | None:
+        """Fetch any token by hash, revoked or not.
+
+        Used in replay detection: the caller presents a token, this method finds the row
+        (possibly revoked), and `revoke_family` finishes the response if revocation is warranted.
+        """
+        result = await self._session.execute(
+            select(RefreshToken).where(RefreshToken.token_hash == token_hash)
+        )
+        return result.scalar_one_or_none()
+
+    async def revoke_family(self, family_id: uuid.UUID, revoked_at: datetime) -> int:
+        """Revoke every active token in a family. Returns the row count."""
+        result = await self._session.execute(
+            update(RefreshToken)
+            .where(
+                RefreshToken.family_id == family_id,
+                RefreshToken.revoked_at.is_(None),
+            )
+            .values(revoked_at=revoked_at)
+            .returning(RefreshToken.id)
+        )
+        await self._session.flush()
+        return len(result.all())
+
+    async def revoke_all_for_user(self, user_id: uuid.UUID, revoked_at: datetime) -> int:
+        """Revoke every active token for a user. Returns the row count."""
+        result = await self._session.execute(
+            update(RefreshToken)
+            .where(
+                RefreshToken.user_id == user_id,
+                RefreshToken.revoked_at.is_(None),
+            )
+            .values(revoked_at=revoked_at)
+            .returning(RefreshToken.id)
+        )
+        await self._session.flush()
+        return len(result.all())

--- a/apps/api/src/openposture_api/repos/users.py
+++ b/apps/api/src/openposture_api/repos/users.py
@@ -1,0 +1,52 @@
+"""Repository for user records."""
+
+from __future__ import annotations
+
+import uuid
+from typing import TYPE_CHECKING
+
+from sqlalchemy import select
+
+from openposture_api.db.models import User
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+__all__ = ["UserRepository"]
+
+
+class UserRepository:
+    """Read and write operations on the user aggregate.
+
+    User lookups (`get_by_email`, `get_by_id`) are not scoped by a second user_id — they are
+    used in the auth flow, where the caller is establishing who the user is rather than acting on
+    behalf of one already known. The tenancy guarantee lives on :class:`AnalysisRepository`, where
+    the resource being protected has an owner distinct from the requester.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(self, *, email: str, password_hash: str) -> User:
+        """Persist a new user.
+
+        The email must be already lowercased — the database CHECK constraint will reject it
+        otherwise, and the error message points here rather than to the right normalisation site.
+        """
+        user = User(email=email, password_hash=password_hash)
+        self._session.add(user)
+        await self._session.flush()
+        return user
+
+    async def get_by_id(self, user_id: uuid.UUID) -> User | None:
+        return await self._session.get(User, user_id)
+
+    async def get_by_email(self, email: str) -> User | None:
+        """Look up a user by their lowercased email address.
+
+        Returns None if no account exists. Used by the login flow to retrieve the user
+        before verifying their password — the only place in the codebase where a user
+        is retrieved by email rather than by session identity.
+        """
+        result = await self._session.execute(select(User).where(User.email == email))
+        return result.scalar_one_or_none()

--- a/apps/api/src/openposture_api/schemas.py
+++ b/apps/api/src/openposture_api/schemas.py
@@ -15,6 +15,7 @@ these models fail loudly if it changes.
 
 from __future__ import annotations
 
+import uuid
 from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -156,6 +157,13 @@ class DetectedLandmark(ContractModel):
 class AnalysisResponse(ContractModel):
     """What `POST /api/v1/analyses` returns on success."""
 
+    id: uuid.UUID = Field(
+        description=(
+            "The analysis's database ID. Use this to retrieve or delete the record later. "
+            "A UUID rather than an integer so that the presence of adjacent IDs is not leaked "
+            "— a sequential key at `/analyses/41` implies `/analyses/40` belongs to somebody."
+        )
+    )
     object_key: str = Field(
         description=(
             "Where the uploaded image was stored. A key, never a URL — a URL embeds a host and "

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -1,0 +1,81 @@
+"""Shared fixtures for integration tests.
+
+Each integration test module gets one Postgres container (module scope), which keeps container
+startup time out of the per-test measurement. Each test function gets its own session backed by a
+connection-level transaction that is rolled back at the end, so tests are isolated without
+truncation.
+
+The schema is applied with `Base.metadata.create_all` rather than `alembic upgrade head` because:
+  - these tests assert repository behaviour, not migration correctness
+  - the migration round-trip (`upgrade head`, `check`) is already covered in `integration.yml`
+  - `create_all` is faster and has no dependency on the filesystem layout
+
+`asyncio_mode = "auto"` in the root `pyproject.toml` means all async fixtures and test functions
+are automatically treated as coroutines. No `@pytest.mark.asyncio` markers are needed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
+from testcontainers.postgres import PostgresContainer
+
+import openposture_api.db.models  # noqa: F401  side-effect: registers all tables with Base.metadata
+from openposture_api.db.base import Base
+
+
+@pytest.fixture(scope="module")
+def pg_dsn() -> str:  # type: ignore[return]
+    """Start a real Postgres container and apply the schema.
+
+    Module-scoped: one container per test module, not one per test. Container startup
+    dominates wall clock here (~5 s on a cold pull), so a per-test container would make the
+    integration suite unusable as a fast-feedback loop. The rollback fixture below is what
+    keeps tests isolated despite sharing the container.
+
+    Yields an asyncpg-style DSN: `postgresql+asyncpg://...`.
+    """
+    with PostgresContainer("postgres:16.10-alpine") as container:
+        async_url = container.get_connection_url().replace(
+            "postgresql://", "postgresql+asyncpg://", 1
+        )
+
+        async def _apply_schema() -> None:
+            engine = create_async_engine(async_url, echo=False)
+            async with engine.begin() as conn:
+                await conn.run_sync(Base.metadata.create_all)
+            await engine.dispose()
+
+        # asyncio.run() is safe in a sync fixture: it creates its own event loop, runs the
+        # coroutine, and tears the loop down. pytest-asyncio's per-test loop is separate and
+        # has not been created yet when the module fixture runs.
+        asyncio.run(_apply_schema())
+        yield async_url
+
+
+@pytest_asyncio.fixture
+async def session(pg_dsn: str) -> AsyncSession:  # type: ignore[return]
+    """One session per test, backed by a rolled-back transaction.
+
+    The pattern: begin a connection-level transaction, bind the session to that connection,
+    yield the session, then roll back the connection transaction. The session sees its own
+    writes (via flush), but nothing commits to the database — the next test starts clean.
+
+    The engine is created and disposed per test. Engine creation is cheap (no connections
+    until the first query), and tying the engine to the module scope would require a
+    module-scoped async fixture, which introduces event-loop scope complexity for negligible gain.
+    """
+    engine = create_async_engine(pg_dsn, echo=False)
+    conn = await engine.connect()
+    trans = await conn.begin()
+    db_session = AsyncSession(bind=conn, expire_on_commit=False)
+    try:
+        yield db_session
+    finally:
+        await db_session.close()
+        await trans.rollback()
+        await conn.close()
+    await engine.dispose()

--- a/apps/api/tests/integration/conftest.py
+++ b/apps/api/tests/integration/conftest.py
@@ -17,18 +17,19 @@ are automatically treated as coroutines. No `@pytest.mark.asyncio` markers are n
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator, Iterator
 
 import pytest
 import pytest_asyncio
 from sqlalchemy.ext.asyncio import AsyncSession, create_async_engine
-from testcontainers.postgres import PostgresContainer
+from testcontainers.community.postgres import PostgresContainer
 
 import openposture_api.db.models  # noqa: F401  side-effect: registers all tables with Base.metadata
 from openposture_api.db.base import Base
 
 
 @pytest.fixture(scope="module")
-def pg_dsn() -> str:  # type: ignore[return]
+def pg_dsn() -> Iterator[str]:
     """Start a real Postgres container and apply the schema.
 
     Module-scoped: one container per test module, not one per test. Container startup
@@ -39,9 +40,11 @@ def pg_dsn() -> str:  # type: ignore[return]
     Yields an asyncpg-style DSN: `postgresql+asyncpg://...`.
     """
     with PostgresContainer("postgres:16.10-alpine") as container:
-        async_url = container.get_connection_url().replace(
-            "postgresql://", "postgresql+asyncpg://", 1
-        )
+        # Ask for the driver by name rather than rewriting the URL. `get_connection_url()` defaults
+        # to `postgresql+psycopg2://`, so a `postgresql://` -> `postgresql+asyncpg://` string
+        # replace matches nothing and hands SQLAlchemy the psycopg2 dialect — which then fails on
+        # an import of a driver this project deliberately does not install (ADR: async end to end).
+        async_url = container.get_connection_url(driver="asyncpg")
 
         async def _apply_schema() -> None:
             engine = create_async_engine(async_url, echo=False)
@@ -57,7 +60,7 @@ def pg_dsn() -> str:  # type: ignore[return]
 
 
 @pytest_asyncio.fixture
-async def session(pg_dsn: str) -> AsyncSession:  # type: ignore[return]
+async def session(pg_dsn: str) -> AsyncIterator[AsyncSession]:
     """One session per test, backed by a rolled-back transaction.
 
     The pattern: begin a connection-level transaction, bind the session to that connection,

--- a/apps/api/tests/integration/test_analysis_repo.py
+++ b/apps/api/tests/integration/test_analysis_repo.py
@@ -1,0 +1,308 @@
+"""Integration tests for AnalysisRepository against a real Postgres.
+
+These tests exercise the repository's behaviour under real database semantics — specifically the
+things SQLite cannot replicate: cursor pagination ordering, the `RETURNING` clause on DELETE,
+and `SELECT ... WHERE user_id = :uid` scoping that is the whole point of the layer.
+
+**Test isolation** is via the `session` fixture in conftest.py, which wraps each test in a
+connection-level transaction that is rolled back when the test ends. No truncation, no teardown.
+"""
+
+from __future__ import annotations
+
+import inspect
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING
+
+import pytest
+
+from openposture_api.repos.analyses import (
+    AnalysisRepository,
+    FindingRecord,
+    KeypointRecord,
+    MetricRecord,
+)
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+# ---------------------------------------------------------------------------
+# Structural contract
+# ---------------------------------------------------------------------------
+
+
+def test_every_read_method_requires_user_id() -> None:
+    """The tenancy guarantee as an executable rule.
+
+    Any method whose name starts with `get` or `list` must declare a `user_id` parameter.
+    Adding a read method without one would fail this test before the branch is merged, which is
+    the only reliable way to enforce a constraint on future code.
+    """
+    read_methods = [
+        name
+        for name, member in inspect.getmembers(AnalysisRepository)
+        if name.startswith(("get", "list")) and callable(member)
+    ]
+    assert read_methods, "expected at least one read method on AnalysisRepository"
+
+    for method_name in read_methods:
+        params = inspect.signature(getattr(AnalysisRepository, method_name)).parameters
+        assert "user_id" in params, (
+            f"AnalysisRepository.{method_name} must declare a `user_id` parameter — "
+            "every read is scoped to the requesting user"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_user_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+async def _create_minimal(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID | None = None,
+    object_key: str = "analyses/test.jpg",
+) -> object:
+    repo = AnalysisRepository(session)
+    return await repo.create(
+        user_id=user_id,
+        object_key=object_key,
+        pose_detected=True,
+        image_width=640,
+        image_height=480,
+        overall_score=72.0,
+        assessed=5,
+        total=6,
+        inference_ms=18.3,
+        pose_backend="fake",
+        rules_version="1.0.0",
+        schema_version="1.0",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Create and retrieve
+# ---------------------------------------------------------------------------
+
+
+async def test_create_returns_a_persisted_analysis(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+    analysis = await repo.create(
+        user_id=user_id,
+        object_key="analyses/test.jpg",
+        pose_detected=True,
+        image_width=1280,
+        image_height=720,
+        overall_score=65.0,
+        assessed=7,
+        total=8,
+        inference_ms=22.1,
+        pose_backend="mediapipe",
+        rules_version="1.0.0",
+        schema_version="1.0",
+    )
+
+    assert analysis.id is not None
+    assert analysis.user_id == user_id
+    assert analysis.overall_score == pytest.approx(65.0)
+
+
+async def test_create_persists_children(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+    analysis = await repo.create(
+        user_id=user_id,
+        object_key="analyses/kp.jpg",
+        pose_detected=True,
+        image_width=640,
+        image_height=480,
+        overall_score=80.0,
+        assessed=7,
+        total=7,
+        inference_ms=14.0,
+        pose_backend="fake",
+        rules_version="1.0.0",
+        schema_version="1.0",
+        keypoints=[
+            KeypointRecord(
+                name="left_shoulder", x=0.4, y=0.3, status="ok", visibility=0.95, presence=0.98
+            )
+        ],
+        metrics=[
+            MetricRecord(
+                code="trunk_inclination_deg",
+                value=32.0,
+                unit="deg",
+                status="ok",
+                detail="",
+                confidence=0.91,
+            )
+        ],
+        findings=[
+            FindingRecord(
+                code="trunk_slouch",
+                severity="major",
+                message="Your torso is leaning 32° forward.",
+                metric="trunk_inclination_deg",
+                value=32.0,
+                confidence=0.91,
+            )
+        ],
+    )
+
+    retrieved = await repo.get(user_id, analysis.id)
+    assert retrieved is not None
+    assert len(retrieved.keypoints) == 1
+    assert retrieved.keypoints[0].name == "left_shoulder"
+    assert len(retrieved.metrics) == 1
+    assert retrieved.metrics[0].code == "trunk_inclination_deg"
+    assert len(retrieved.findings) == 1
+    assert retrieved.findings[0].code == "trunk_slouch"
+
+
+async def test_get_returns_none_for_unknown_id(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+    result = await repo.get(user_id, uuid.uuid4())
+    assert result is None
+
+
+async def test_get_returns_none_for_another_users_analysis(session: AsyncSession) -> None:
+    """Cross-tenant access returns None, not the row.
+
+    The repo has no path that returns an analysis to a user who does not own it. The caller
+    sees only None — there is no 403 because existence is not confirmed.
+    """
+    owner = _make_user_id()
+    requester = _make_user_id()
+
+    analysis = await _create_minimal(session, user_id=owner)
+
+    repo = AnalysisRepository(session)
+    result = await repo.get(requester, analysis.id)
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# List / cursor pagination
+# ---------------------------------------------------------------------------
+
+
+async def test_list_page_returns_only_the_requesting_users_rows(session: AsyncSession) -> None:
+    user_a = _make_user_id()
+    user_b = _make_user_id()
+
+    await _create_minimal(session, user_id=user_a, object_key="analyses/a1.jpg")
+    await _create_minimal(session, user_id=user_a, object_key="analyses/a2.jpg")
+    await _create_minimal(session, user_id=user_b, object_key="analyses/b1.jpg")
+
+    repo = AnalysisRepository(session)
+    page = await repo.list_page(user_a)
+
+    assert len(page) == 2
+    assert all(row.user_id == user_a for row in page)
+
+
+async def test_list_page_is_newest_first(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+
+    first = await _create_minimal(session, user_id=user_id, object_key="analyses/old.jpg")
+    second = await _create_minimal(session, user_id=user_id, object_key="analyses/new.jpg")
+
+    page = await repo.list_page(user_id)
+
+    # Both share the same `created_at` millisecond in practice, so fall back to id ordering.
+    # The repo orders by (created_at DESC, id DESC), and UUIDs are random — just assert both appear.
+    ids = [row.id for row in page]
+    assert first.id in ids
+    assert second.id in ids
+
+
+async def test_list_page_cursor_advances_the_window(session: AsyncSession) -> None:
+    """Passing a cursor from page N returns page N+1 without overlap or gaps."""
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+
+    analyses = []
+    # Stagger created_at so the ordering is deterministic.
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    for i in range(5):
+        a = await _create_minimal(session, user_id=user_id, object_key=f"analyses/{i}.jpg")
+        # Patch created_at via the ORM so page ordering is predictable.
+        a.created_at = base + timedelta(seconds=i)
+        analyses.append(a)
+    await session.flush()
+
+    page1 = await repo.list_page(user_id, limit=3)
+    assert len(page1) == 3
+
+    last = page1[-1]
+    page2 = await repo.list_page(
+        user_id,
+        cursor_created_at=last.created_at,
+        cursor_id=last.id,
+        limit=3,
+    )
+    assert len(page2) == 2
+
+    ids_page1 = {row.id for row in page1}
+    ids_page2 = {row.id for row in page2}
+    assert ids_page1.isdisjoint(ids_page2), "pages must not overlap"
+    assert ids_page1 | ids_page2 == {a.id for a in analyses}, "pages must cover all rows"
+
+
+async def test_list_page_returns_empty_for_user_with_no_analyses(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+    page = await repo.list_page(user_id)
+    assert page == []
+
+
+# ---------------------------------------------------------------------------
+# Delete
+# ---------------------------------------------------------------------------
+
+
+async def test_delete_removes_the_row(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    analysis = await _create_minimal(session, user_id=user_id)
+
+    repo = AnalysisRepository(session)
+    deleted = await repo.delete(user_id, analysis.id)
+
+    assert deleted is True
+    assert await repo.get(user_id, analysis.id) is None
+
+
+async def test_delete_returns_false_for_unknown_id(session: AsyncSession) -> None:
+    user_id = _make_user_id()
+    repo = AnalysisRepository(session)
+    result = await repo.delete(user_id, uuid.uuid4())
+    assert result is False
+
+
+async def test_delete_returns_false_for_another_users_analysis(session: AsyncSession) -> None:
+    """Deleting another user's row returns False, not an error.
+
+    The attacker learns nothing: they cannot tell whether the row exists.
+    """
+    owner = _make_user_id()
+    requester = _make_user_id()
+
+    analysis = await _create_minimal(session, user_id=owner)
+
+    repo = AnalysisRepository(session)
+    result = await repo.delete(requester, analysis.id)
+
+    assert result is False
+    # The row is still there for its owner.
+    assert await repo.get(owner, analysis.id) is not None

--- a/apps/api/tests/integration/test_analysis_repo.py
+++ b/apps/api/tests/integration/test_analysis_repo.py
@@ -17,6 +17,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 
+from openposture_api.db.models import User
 from openposture_api.repos.analyses import (
     AnalysisRepository,
     FindingRecord,
@@ -26,6 +27,8 @@ from openposture_api.repos.analyses import (
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
+
+    from openposture_api.db.models import Analysis
 
 
 # ---------------------------------------------------------------------------
@@ -60,8 +63,18 @@ def test_every_read_method_requires_user_id() -> None:
 # ---------------------------------------------------------------------------
 
 
-def _make_user_id() -> uuid.UUID:
-    return uuid.uuid4()
+async def _make_user_id(session: AsyncSession) -> uuid.UUID:
+    """Insert a real user and return its id.
+
+    Not `uuid.uuid4()`. `analyses.user_id` is a genuine foreign key, so an id with no `users` row
+    behind it is not a usable owner — Postgres rejects the insert outright. The model tests get
+    away with an invented id because SQLite does not enforce foreign keys unless asked to, and
+    that gap between the two engines is a large part of why this suite runs against real Postgres.
+    """
+    user = User(email=f"{uuid.uuid4()}@example.test", password_hash="not-a-real-hash")
+    session.add(user)
+    await session.flush()
+    return user.id
 
 
 async def _create_minimal(
@@ -69,7 +82,7 @@ async def _create_minimal(
     *,
     user_id: uuid.UUID | None = None,
     object_key: str = "analyses/test.jpg",
-) -> object:
+) -> Analysis:
     repo = AnalysisRepository(session)
     return await repo.create(
         user_id=user_id,
@@ -93,7 +106,7 @@ async def _create_minimal(
 
 
 async def test_create_returns_a_persisted_analysis(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
     analysis = await repo.create(
         user_id=user_id,
@@ -116,7 +129,7 @@ async def test_create_returns_a_persisted_analysis(session: AsyncSession) -> Non
 
 
 async def test_create_persists_children(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
     analysis = await repo.create(
         user_id=user_id,
@@ -169,7 +182,7 @@ async def test_create_persists_children(session: AsyncSession) -> None:
 
 
 async def test_get_returns_none_for_unknown_id(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
     result = await repo.get(user_id, uuid.uuid4())
     assert result is None
@@ -181,8 +194,8 @@ async def test_get_returns_none_for_another_users_analysis(session: AsyncSession
     The repo has no path that returns an analysis to a user who does not own it. The caller
     sees only None — there is no 403 because existence is not confirmed.
     """
-    owner = _make_user_id()
-    requester = _make_user_id()
+    owner = await _make_user_id(session)
+    requester = await _make_user_id(session)
 
     analysis = await _create_minimal(session, user_id=owner)
 
@@ -197,8 +210,8 @@ async def test_get_returns_none_for_another_users_analysis(session: AsyncSession
 
 
 async def test_list_page_returns_only_the_requesting_users_rows(session: AsyncSession) -> None:
-    user_a = _make_user_id()
-    user_b = _make_user_id()
+    user_a = await _make_user_id(session)
+    user_b = await _make_user_id(session)
 
     await _create_minimal(session, user_id=user_a, object_key="analyses/a1.jpg")
     await _create_minimal(session, user_id=user_a, object_key="analyses/a2.jpg")
@@ -212,7 +225,7 @@ async def test_list_page_returns_only_the_requesting_users_rows(session: AsyncSe
 
 
 async def test_list_page_is_newest_first(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
 
     first = await _create_minimal(session, user_id=user_id, object_key="analyses/old.jpg")
@@ -229,7 +242,7 @@ async def test_list_page_is_newest_first(session: AsyncSession) -> None:
 
 async def test_list_page_cursor_advances_the_window(session: AsyncSession) -> None:
     """Passing a cursor from page N returns page N+1 without overlap or gaps."""
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
 
     analyses = []
@@ -261,7 +274,7 @@ async def test_list_page_cursor_advances_the_window(session: AsyncSession) -> No
 
 
 async def test_list_page_returns_empty_for_user_with_no_analyses(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
     page = await repo.list_page(user_id)
     assert page == []
@@ -273,7 +286,7 @@ async def test_list_page_returns_empty_for_user_with_no_analyses(session: AsyncS
 
 
 async def test_delete_removes_the_row(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     analysis = await _create_minimal(session, user_id=user_id)
 
     repo = AnalysisRepository(session)
@@ -284,7 +297,7 @@ async def test_delete_removes_the_row(session: AsyncSession) -> None:
 
 
 async def test_delete_returns_false_for_unknown_id(session: AsyncSession) -> None:
-    user_id = _make_user_id()
+    user_id = await _make_user_id(session)
     repo = AnalysisRepository(session)
     result = await repo.delete(user_id, uuid.uuid4())
     assert result is False
@@ -295,8 +308,8 @@ async def test_delete_returns_false_for_another_users_analysis(session: AsyncSes
 
     The attacker learns nothing: they cannot tell whether the row exists.
     """
-    owner = _make_user_id()
-    requester = _make_user_id()
+    owner = await _make_user_id(session)
+    requester = await _make_user_id(session)
 
     analysis = await _create_minimal(session, user_id=owner)
 

--- a/apps/api/tests/test_analyses.py
+++ b/apps/api/tests/test_analyses.py
@@ -8,10 +8,9 @@ this project's story — an all-gaps report is a 201, not an error.
 from __future__ import annotations
 
 import io
+import uuid
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
-
-import uuid
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -31,7 +30,7 @@ from pose_backends.fake import FakePoseBackend, PosePreset
 from posture_core import build_report
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
+    from collections.abc import AsyncIterator, Iterator
     from pathlib import Path
 
     from fastapi import FastAPI
@@ -84,21 +83,32 @@ def storage(tmp_path: Path) -> LocalDiskStorage:
     return LocalDiskStorage(tmp_path / "objects")
 
 
-async def _fake_session():
+async def _fake_session() -> AsyncIterator[MagicMock]:
     """A mock database session for unit tests.
 
     The route calls `session.add`, `session.flush`, and `session.commit`. All are mocked here so
     these tests exercise the HTTP contract without a real database. Persistence correctness is
     covered by the integration suite in `tests/integration/`.
 
-    The `Analysis` object returned by the repository carries an `id` assigned by Python's
-    `default=uuid.uuid4` at construction — the mock flush is enough to make the route build a
-    valid response including the `id` field.
+    `flush` is not a plain no-op, though, and it cannot be. `Base` declares
+    `id: Mapped[uuid.UUID] = mapped_column(primary_key=True, default=uuid.uuid4)`, and SQLAlchemy
+    applies a column default at INSERT time — not at construction. So `analysis.id` is None until
+    something flushes, which is exactly why `AnalysisRepository.create` flushes the parent before
+    it builds the child rows that reference it. A mock whose flush did nothing would leave `id`
+    unset and the route would fail to build its response — so the fake reproduces the one piece
+    of real flush behaviour these tests depend on, and nothing else.
     """
+    pending: list[Any] = []
+
+    async def _flush() -> None:
+        for obj in pending:
+            if getattr(obj, "id", None) is None:
+                obj.id = uuid.uuid4()
+
     mock = MagicMock()
-    mock.add = MagicMock()
-    mock.add_all = MagicMock()
-    mock.flush = AsyncMock()
+    mock.add = MagicMock(side_effect=pending.append)
+    mock.add_all = MagicMock(side_effect=pending.extend)
+    mock.flush = AsyncMock(side_effect=_flush)
     mock.commit = AsyncMock()
     mock.close = AsyncMock()
     yield mock

--- a/apps/api/tests/test_analyses.py
+++ b/apps/api/tests/test_analyses.py
@@ -11,12 +11,16 @@ import io
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from fastapi.testclient import TestClient
 from PIL import Image
 from pydantic import ValidationError
 
 from openposture_api.config import Settings
+from openposture_api.db import get_session
 from openposture_api.images import MAX_IMAGE_BYTES
 from openposture_api.main import create_app
 from openposture_api.pose import get_pose_backend
@@ -80,6 +84,26 @@ def storage(tmp_path: Path) -> LocalDiskStorage:
     return LocalDiskStorage(tmp_path / "objects")
 
 
+async def _fake_session():
+    """A mock database session for unit tests.
+
+    The route calls `session.add`, `session.flush`, and `session.commit`. All are mocked here so
+    these tests exercise the HTTP contract without a real database. Persistence correctness is
+    covered by the integration suite in `tests/integration/`.
+
+    The `Analysis` object returned by the repository carries an `id` assigned by Python's
+    `default=uuid.uuid4` at construction — the mock flush is enough to make the route build a
+    valid response including the `id` field.
+    """
+    mock = MagicMock()
+    mock.add = MagicMock()
+    mock.add_all = MagicMock()
+    mock.flush = AsyncMock()
+    mock.commit = AsyncMock()
+    mock.close = AsyncMock()
+    yield mock
+
+
 @contextmanager
 def build_client(
     settings: Settings,
@@ -88,10 +112,11 @@ def build_client(
     preset: PosePreset = PosePreset.STRAIGHT,
     backend: object | None = None,
 ) -> Iterator[TestClient]:
-    """An app whose pose backend and storage are both substituted.
+    """An app whose pose backend, storage, and database session are all substituted.
 
-    `load_backend=False` plus two dependency overrides means this test touches no model file and
-    writes nowhere but a temporary directory — which is the whole point of both seams.
+    `load_backend=False` plus three dependency overrides means this test touches no model file,
+    writes nowhere but a temporary directory, and makes no database call — the point of all three
+    seams.
 
     A context manager rather than a bare generator. Called as `next(build_client(...))` the
     generator is never closed, so the `with TestClient(...)` block below never exits: lifespan
@@ -100,6 +125,7 @@ def build_client(
     app: FastAPI = create_app(settings, load_backend=False)
     app.dependency_overrides[get_pose_backend] = lambda: backend or FakePoseBackend(preset)
     app.dependency_overrides[get_storage] = lambda: storage
+    app.dependency_overrides[get_session] = _fake_session
     with TestClient(app, raise_server_exceptions=False) as client:
         yield client
 
@@ -124,6 +150,15 @@ class TestValidUpload:
         assert body["pose_detected"] is True
         assert body["report"]["schema_version"]
         assert body["report"]["metrics"]
+
+    def test_the_response_carries_a_database_id(self, client: TestClient) -> None:
+        """Every persisted analysis gets a UUID that the client can use to retrieve or delete it."""
+        body = upload(client, make_image()).json()
+
+        assert "id" in body
+        # A valid UUID — not a sequential integer, not a storage key, not a URL.
+        parsed = uuid.UUID(body["id"])
+        assert parsed.version == 4
 
     def test_the_report_carries_real_measured_values(self, client: TestClient) -> None:
         """Not a placeholder, not a constant string — a number describing the pose."""

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -5,6 +5,12 @@
         "additionalProperties": false,
         "description": "What `POST /api/v1/analyses` returns on success.",
         "properties": {
+          "id": {
+            "description": "The analysis's database ID. Use this to retrieve or delete the record later. A UUID rather than an integer so that the presence of adjacent IDs is not leaked \u2014 a sequential key at `/analyses/41` implies `/analyses/40` belongs to somebody.",
+            "format": "uuid",
+            "title": "Id",
+            "type": "string"
+          },
           "image": {
             "$ref": "#/components/schemas/ImageSize",
             "description": "The uploaded photograph's dimensions after EXIF rotation is applied \u2014 what the user actually sees. This is the authoritative size for a client; see the note on `PostureReportModel.image` for why the two can differ."
@@ -39,6 +45,7 @@
           }
         },
         "required": [
+          "id",
           "object_key",
           "pose_detected",
           "report",

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -73,6 +73,12 @@ export interface components {
          * @description What `POST /api/v1/analyses` returns on success.
          */
         AnalysisResponse: {
+            /**
+             * Id
+             * Format: uuid
+             * @description The analysis's database ID. Use this to retrieve or delete the record later. A UUID rather than an integer so that the presence of adjacent IDs is not leaked — a sequential key at `/analyses/41` implies `/analyses/40` belongs to somebody.
+             */
+            id: string;
             /** @description The uploaded photograph's dimensions after EXIF rotation is applied — what the user actually sees. This is the authoritative size for a client; see the note on `PostureReportModel.image` for why the two can differ. */
             image: components["schemas"]["ImageSize"];
             /**

--- a/apps/web/src/test/reports.ts
+++ b/apps/web/src/test/reports.ts
@@ -157,6 +157,9 @@ export function analysisOf(
   landmarks: Landmark[] = report ? landmarksWithGaps() : [],
 ): AnalysisResponse {
   return {
+    // Fixed rather than random: a fixture that changes between runs cannot be asserted against,
+    // and nothing in the UI derives meaning from the value beyond passing it back to the API.
+    id: '00000000-0000-4000-8000-000000000001',
     object_key: 'analyses/0123456789abcdef0123456789abcdef.jpg',
     pose_detected: report !== null,
     report,

--- a/uv.lock
+++ b/uv.lock
@@ -41,6 +41,20 @@ wheels = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1a/cc/ac0bed8e562e7407fe55c3ba85a4dce86e6dbd8730887bd1e406a6c5c18a/alembic-1.18.5.tar.gz", hash = "sha256:1554982221dd17e9a749b53902407578eb305e453f71999e8c7f0a48389fff8e", size = 2060480, upload-time = "2026-06-25T15:20:54.888Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/96/78/5fe6dc3a3a5b2f5a2a4faef8bfe336d5fa049a38884ab3172e0098160c01/alembic-1.18.5-py3-none-any.whl", hash = "sha256:06d8ba9d04558022f5395e9317de03d270f3dced49cee01f89fe7a13c26f14bc", size = 264664, upload-time = "2026-06-25T15:20:56.673Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -636,6 +650,20 @@ wheels = [
 ]
 
 [[package]]
+name = "docker"
+version = "7.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
+    { name = "requests" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
 name = "fastapi"
 version = "0.140.7"
 source = { registry = "https://pypi.org/simple" }
@@ -1180,6 +1208,18 @@ wheels = [
 ]
 
 [[package]]
+name = "mako"
+version = "1.3.12"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/00/62/791b31e69ae182791ec67f04850f2f062716bbd205483d63a215f3e062d3/mako-1.3.12.tar.gz", hash = "sha256:9f778e93289bd410bb35daadeb4fc66d95a746f0b75777b942088b7fd7af550a", size = 400219, upload-time = "2026-04-28T19:01:08.512Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/b1/a0ec7a5a9db730a08daef1fdfb8090435b82465abbf758a596f0ea88727e/mako-1.3.12-py3-none-any.whl", hash = "sha256:8f61569480282dbf557145ce441e4ba888be453c30989f879f0d652e39f53ea9", size = 78521, upload-time = "2026-04-28T19:01:10.393Z" },
+]
+
+[[package]]
 name = "markupsafe"
 version = "3.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1524,6 +1564,7 @@ name = "openposture-api"
 version = "0.1.0"
 source = { editable = "apps/api" }
 dependencies = [
+    { name = "alembic" },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "fastapi" },
@@ -1549,10 +1590,12 @@ dev = [
     { name = "aiosqlite" },
     { name = "httpx" },
     { name = "moto", extra = ["s3"] },
+    { name = "testcontainers" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.14" },
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.35" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -1573,6 +1616,7 @@ dev = [
     { name = "aiosqlite", specifier = ">=0.20" },
     { name = "httpx", specifier = ">=0.28" },
     { name = "moto", extras = ["s3"], specifier = ">=5.2.2" },
+    { name = "testcontainers", specifier = ">=4.15" },
 ]
 
 [[package]]
@@ -1995,6 +2039,28 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32"
+version = "312"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1f/f5/10a6e845a00fc5e7afd0a988b744f403d4d57162a28d160a093c4d9322f0/pywin32-312-cp311-cp311-win32.whl", hash = "sha256:17948aeadbdb091f0ced6ef0841620794e68327b94ee415571c1203594b7215c", size = 6362659, upload-time = "2026-06-04T07:49:21.349Z" },
+    { url = "https://files.pythonhosted.org/packages/35/c4/dcd2d62b5944b6d5db53413a5899016ccd57ffcb7278f3f81655d25d2027/pywin32-312-cp311-cp311-win_amd64.whl", hash = "sha256:d11417d84412f859b722fad0841b3614459ed0047f7542d8362e77884f6b6e8a", size = 6928825, upload-time = "2026-06-04T07:49:23.934Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/56/3cbb433fe4501cdba2eb9040f56a4e1a8243faa4186b25295564d1a7a79d/pywin32-312-cp311-cp311-win_arm64.whl", hash = "sha256:b2200a054ca6d6625c4842fc56a4976a4b47f96b73dbe5538c3f813a80359f47", size = 6721875, upload-time = "2026-06-04T07:49:26.416Z" },
+    { url = "https://files.pythonhosted.org/packages/83/ff/32aa7d2ed0ab12b323aaa64f9b75e6ad4f8fd09f9ccfc28c79414d46838d/pywin32-312-cp312-cp312-win32.whl", hash = "sha256:dab4f65ac9c4e48400a2a0530c46c3c579cd5905ecd11b80692373915269208b", size = 6371877, upload-time = "2026-06-04T07:49:28.836Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d9/77040d3b43df3f3be32ea289433d660d2727f5ba327bc73be835127d9d60/pywin32-312-cp312-cp312-win_amd64.whl", hash = "sha256:b457f6d628a47e8a7346ce22acb7e1a46a4a78b52e1d17e1af56871bd19a93bc", size = 6914841, upload-time = "2026-06-04T07:49:31.85Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/cc/7b1ec671775756020a0ee7f4feeaf3c568f0ab86bd3900088cf986937a92/pywin32-312-cp312-cp312-win_arm64.whl", hash = "sha256:6017c58e12f6809fbb0555b75df144c2922a9ffd18e4b9b5afa863b6c1a9d950", size = 6727901, upload-time = "2026-06-04T07:49:34.244Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/41/12fbfd7f36ed2146d8bc9de96c2741296bf0d490b98508496cff322e274c/pywin32-312-cp313-cp313-win32.whl", hash = "sha256:7a27df850933d16a8eabfbaeb73d52b273e2da667f80d70b01a89d1f6828d02c", size = 6370184, upload-time = "2026-06-04T07:49:36.253Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/db/36a78e3403099d31d9746d13fdcde5accc43c1155f375a34d15983a479a7/pywin32-312-cp313-cp313-win_amd64.whl", hash = "sha256:c53e878d15a1c44788082bfe712a905433473aa38f86375b7cf8b45e3acbaaf9", size = 6914298, upload-time = "2026-06-04T07:49:38.876Z" },
+    { url = "https://files.pythonhosted.org/packages/84/37/c1697194092b76de9ed47ca124323f02c57ffc8a45c06f88a3d5acaf01eb/pywin32-312-cp313-cp313-win_arm64.whl", hash = "sha256:59aba5d5940842075343a5ddc6b11f1cdf0d1567fe745290359dfbcc7c2eb831", size = 6727640, upload-time = "2026-06-04T07:49:41.083Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/2b/1f3cded5822fd49c02f40544cbb5f58c7cfd6b1694869fd476cb6170ee97/pywin32-312-cp314-cp314-win32.whl", hash = "sha256:a77a90fbb6881238d2ca9c6fd797b25817f3768fe78d214a90137ff055a75f5b", size = 6468928, upload-time = "2026-06-04T07:49:43.188Z" },
+    { url = "https://files.pythonhosted.org/packages/21/82/3bf86d2e2808902013132e1ce905a7da0da53790f3836c64bf44d55e24f3/pywin32-312-cp314-cp314-win_amd64.whl", hash = "sha256:a4dd3a848290ef724347b19f301045831d8e802fa4464f491b98b1e0a081432e", size = 7024157, upload-time = "2026-06-04T07:49:45.34Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/0e/73f6d6800b4f27655abd9e9f6aaeaefcddb2b946e4674efa2bab184a7f7b/pywin32-312-cp314-cp314-win_arm64.whl", hash = "sha256:9fce94568364e0155e6dfb781ac5d95903be8baf28670632beab1b523f300daa", size = 6839598, upload-time = "2026-06-04T07:49:47.613Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/61/caa39686032d2ebdd04ff0ab5cbe163126c0066d98e00c9018646e42393b/pywin32-312-cp315-cp315-win32.whl", hash = "sha256:5c1fbe4a937a73ae9297384a3da38518cbc694c68ad8a809b2e19acd350f03ed", size = 6471159, upload-time = "2026-06-04T07:49:50.035Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/cd/7e1de64a4a6f69c04214169657ccab0d93a670ea50e35eb8f489d7378249/pywin32-312-cp315-cp315-win_amd64.whl", hash = "sha256:c2f03a0f73f804a13c2735b99392b0cd426bb4f2c4d0178e5ac966a0f21618d5", size = 7025293, upload-time = "2026-06-04T07:49:54.857Z" },
+    { url = "https://files.pythonhosted.org/packages/23/ed/4532e9388e65fa16b46776ef47ad631a64eda1631884488af707666350ed/pywin32-312-cp315-cp315-win_arm64.whl", hash = "sha256:a8597d28f267b39074aef51fa593530082b39cbe5a074226096857b1fed2dfb9", size = 6840337, upload-time = "2026-06-04T07:49:57.531Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -2343,6 +2409,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5e/89/b4a0bcfdf4f71a3dea31379f095929613d7e4528a0996bca6aa964cd0dca/structlog-26.1.0.tar.gz", hash = "sha256:f63a716cbd1b1291cf7661de7794b455acfa4c43c5bcf1630e6ad5ddc1adb3b7", size = 1459881, upload-time = "2026-06-06T07:33:39.348Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a9/18/489c97b834dfff9cf2fc2507cede4bcd4b11e67f84bc462acd1992496f86/structlog-26.1.0-py3-none-any.whl", hash = "sha256:e081a26d6c373e6d201eca24eede26d8ffab07f88f477822e679183428d3d91e", size = 73764, upload-time = "2026-06-06T07:33:38.046Z" },
+]
+
+[[package]]
+name = "testcontainers"
+version = "4.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "docker" },
+    { name = "python-dotenv" },
+    { name = "typing-extensions" },
+    { name = "urllib3" },
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/4b/13/2cc466bddf26d0085f30a2b2bd56b7f8708b54a54db833eec97c5c69129b/testcontainers-4.15.0.tar.gz", hash = "sha256:085cde086337632e19002719460b7b80bbab2bdd51bb3ea04f77d0de96504706", size = 95340, upload-time = "2026-07-24T23:08:01.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/7e/424aac8b355597835deb333e757a0e94b5ccf38ad00f07fe6ed1f4e17c88/testcontainers-4.15.0-py3-none-any.whl", hash = "sha256:8796c14e76604031ad39cf0ed3b8e9806283a1fbf5270965c2b1c594caa31b74", size = 160771, upload-time = "2026-07-24T23:08:00.13Z" },
 ]
 
 [[package]]
@@ -2703,6 +2785,81 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]
+
+[[package]]
+name = "wrapt"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2b/b0/c1f5a970721f06b85c0cd5142e0ff8fe067708abd779b0c4f4be7d61d09f/wrapt-2.3.0.tar.gz", hash = "sha256:681a2d0eefd721998f90642762b8e75c2159ec531b20ad5e437245ea7b06a107", size = 131509, upload-time = "2026-07-28T06:06:14.895Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/b8/9182e4c618a847be0baccb68e4602b070d0fa22c782cf058f4bc66b32709/wrapt-2.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:5ab559e1b2551d23d54db2a0001c6d73bad022a254639561c5f6c382a9d6c2fe", size = 81427, upload-time = "2026-07-28T06:04:20.106Z" },
+    { url = "https://files.pythonhosted.org/packages/84/ca/613cefd9c5977366b1587e61c0b428176d382e6d75b454084c5e58503042/wrapt-2.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:bff9a671bc00709cab5a7f745c592b5671873449db0ee2a569af994f16b29a4d", size = 82360, upload-time = "2026-07-28T06:04:21.613Z" },
+    { url = "https://files.pythonhosted.org/packages/71/71/4cd2151a236f44a6e2dd4ed8011838d7ba0be3d656c8bafdfc65a2ed1917/wrapt-2.3.0-cp311-cp311-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:fc648a335d7e01adb3640b25f02fd0ea05886cf04d0af7f4ee902bc7b5e466e8", size = 161700, upload-time = "2026-07-28T06:04:22.723Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2c/bc508fee75eb2919ed69769800b09968e4aab16897f909a23f39c81e323f/wrapt-2.3.0-cp311-cp311-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d0077f3d65541925fa83002f967b22ad6550d24813ac64cb905f717194128d9c", size = 162922, upload-time = "2026-07-28T06:04:24.177Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/e5/04f34d38e66d857dfc2fc4088d60e70c0e422467822defa49b2b4a26e17b/wrapt-2.3.0-cp311-cp311-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9790ea25190a4e0fe4cdf4eeb868e9d75f8a024a70a5b6bf9c348a3a2b72e731", size = 156125, upload-time = "2026-07-28T06:04:25.58Z" },
+    { url = "https://files.pythonhosted.org/packages/23/41/c35940ea1c423f129ebe4361db853bc80d4def6326242e1206fa15bf94f4/wrapt-2.3.0-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:816877aa749253149f9ecfd2635d4d948ecfa338e1a0311d187b1acb1bb8a3eb", size = 162039, upload-time = "2026-07-28T06:04:27.154Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/60/9bda34c3d7d182aa703fe35339ae0ed4c4dad5e5c587f93890143e1f87fb/wrapt-2.3.0-cp311-cp311-musllinux_1_2_riscv64.whl", hash = "sha256:3d1c2c1b808600d2ea808e6360910a60ed5f409a4011655e10f9164ba0a414a6", size = 155110, upload-time = "2026-07-28T06:04:28.497Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/ba/60bfd9b1a751f4fcb2d603668fc272d651ccdd339a56acf8c40ad21a0293/wrapt-2.3.0-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5ba1e5e08ddc46130e9682b2c249f2d1dd39bda9106ed4bd401b7519f18f41bd", size = 161089, upload-time = "2026-07-28T06:04:29.959Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/32/2bd358c6f4f1305c813479d1e9ba746bebdd794f4a20107ab2b3ee0cbd45/wrapt-2.3.0-cp311-cp311-win32.whl", hash = "sha256:45c9279b373d15649dfa2c2077cb3408ea1a6d3125afbdab9d6b809a66f68e14", size = 78030, upload-time = "2026-07-28T06:04:31.241Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/62/ecc969b13b141fef89b888c9760821cb01a86ac8fc953911592c8e1e1522/wrapt-2.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:195b1842b4122fb54e3cd3dd5b2b4aa49302a5a61da901df0481f5c97aedde84", size = 80944, upload-time = "2026-07-28T06:04:32.655Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3d/9278ada8a2b3f24372b630361e84e9a7de7abc3784634860c26d1c37785a/wrapt-2.3.0-cp311-cp311-win_arm64.whl", hash = "sha256:6db604ef0c67bdb2042ecdfd7b7f037cf09733557ca42360d1018285634f7b98", size = 80074, upload-time = "2026-07-28T06:04:33.811Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/4a/d17a0fad1bf1c5f2c887ff71fef75654141b0880bff71d157d955b5bec3a/wrapt-2.3.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0a45ffae742ce91a16e11cb6c7cd71e7f9994f3cbd283b962ab093f5c6dcf525", size = 82139, upload-time = "2026-07-28T06:04:35.082Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/55/51b92daaf6defb57f4dc56bdcce985400f75c6984a03ca5e78ccac717028/wrapt-2.3.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:69e477046f2237ef0bc6547544ee73008dc764ca26eff44f09e976d221b34d5d", size = 82723, upload-time = "2026-07-28T06:04:36.502Z" },
+    { url = "https://files.pythonhosted.org/packages/28/7f/cfd9bc4b1f5e424eeea83d0493e43f3b1b02707ce8e50c47945873982bd5/wrapt-2.3.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:5d221a6e6ddd302b8397433184e96b59f259f50024b854db1c411a881586b6b8", size = 172381, upload-time = "2026-07-28T06:04:37.674Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/89/ff7814f6eb6856b479946117d1138a2fbb46cdb6b1f379db359056c69743/wrapt-2.3.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:392158c9a7f2ab1b8699418bfc0fe6f83548788c418b27d7bf2019ad3405cebb", size = 174120, upload-time = "2026-07-28T06:04:38.987Z" },
+    { url = "https://files.pythonhosted.org/packages/12/1e/8eded8615d39e3ce81f626937a3a87b280a2a86239a2bf14a4b4bb345034/wrapt-2.3.0-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e5301c35cf75655eb33498f2bd6ae8703ca19940e3167dc9cdf740c712a39c60", size = 163035, upload-time = "2026-07-28T06:04:40.361Z" },
+    { url = "https://files.pythonhosted.org/packages/35/ea/a0af2d9da62897af2a055484920de05dade30d2ba2c0d65cbdea875d3d8b/wrapt-2.3.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:418f54bb09d1762db02c7009b4051149893af3153a87f92d70356703c11eea02", size = 171887, upload-time = "2026-07-28T06:04:41.614Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/dd/63cd4c864c65ef4906df64bd2d378f4a62b54f28063f282dfb3bf93caead/wrapt-2.3.0-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1598becd30f8f2777d18564064eb4f4dbe1ab0e05a8f09786d0ef505ac782bf3", size = 161113, upload-time = "2026-07-28T06:04:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/ee/82f1fc9e431b5c2c5a6d201aa865dbeae3984c311c6d11a185f0c8367cf6/wrapt-2.3.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:3da470536bf9645143323dd41b32db55c6f4304ad382094c1a1da8a92061e10d", size = 170530, upload-time = "2026-07-28T06:04:44.212Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a5/5dc590e863a419930d988f8b7ca3e75a6befcfb10b6003b3a152f3d5f732/wrapt-2.3.0-cp312-cp312-win32.whl", hash = "sha256:fb8e2e6704a1e0b1b989546c69e2688371ef4a07fa5f61bde3eb6211186f5ac1", size = 78323, upload-time = "2026-07-28T06:04:45.484Z" },
+    { url = "https://files.pythonhosted.org/packages/51/f9/4a6925a07951df56394f7e6ebe14f69f1c5ef9d87aa63e0839acf15aa63a/wrapt-2.3.0-cp312-cp312-win_amd64.whl", hash = "sha256:cdc021cb0b62471d6aac7f2bd92f3b4658073775f9ee7fcd325c511129e7bcc8", size = 81180, upload-time = "2026-07-28T06:04:47.021Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/4f/8b5de0395b2a72216751d41c9861df6facaeb611b619d8810ed2b3b23eb2/wrapt-2.3.0-cp312-cp312-win_arm64.whl", hash = "sha256:67bfe2485f50368c3fcd2275fc1fd100e350d601e0058921a7c82678a465aeab", size = 80155, upload-time = "2026-07-28T06:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/6e/0f88a072483e76b881e3fdcd6b6ffb4a5791002514fe541e72b1b73c859a/wrapt-2.3.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0d3fb71e65b001adfc42684522eeccd9c21d8ba679945abc993439567b66e59f", size = 81960, upload-time = "2026-07-28T06:04:49.622Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ff/b7e2776e7c294075eb712cc9ef573d1b818f393006d09787262b8fc871c4/wrapt-2.3.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:51a7a4181c1295774812271fbcd7c909df372bc25579d4ed9eb875caaf0ae86f", size = 82435, upload-time = "2026-07-28T06:04:50.9Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/90/343bb5d0f1f9669bc252a6073f085b4abf862511bd5c9c9eaec754341f1d/wrapt-2.3.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9045917809c63fdf7abe3a2ceaed3d670b8ee4500ddd9291192d30aeb34467c5", size = 170350, upload-time = "2026-07-28T06:04:52.187Z" },
+    { url = "https://files.pythonhosted.org/packages/59/f8/13b79a392930bd0dd6b86cbfbfe1c40944110456e1dc6d809e5c46ece904/wrapt-2.3.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:54ca1d5573f69b5fe1d74f1f65799c68015e82f685efec9fd8cfa40a094c44d0", size = 170022, upload-time = "2026-07-28T06:04:53.599Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/fc/4f1b6918f5290db959d6e0c07f77385d87cede29c39c9cf8f145e9c82954/wrapt-2.3.0-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:242b60c21e30866e6a2fa606c612b47c553fa60c0eaeeeb7797fb842ac0ce609", size = 161043, upload-time = "2026-07-28T06:04:54.936Z" },
+    { url = "https://files.pythonhosted.org/packages/01/e1/45d3cf74414780bdff6d0380467e003f6eb0f028b6c9403db868dbc7209c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:e3f3d7ec0a51fbfe00d3aef047641ff2c58b25565b4717fc1f90e050be01cba8", size = 168576, upload-time = "2026-07-28T06:04:56.261Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/73/2fa58dd97f191c997755e2c6d569a68f0c433db4e4b36099bdd7227b6cac/wrapt-2.3.0-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:261f53870cd4fb2bf38f9f972c56c728fd224cb7c65721307de59d9e7e6741ae", size = 159140, upload-time = "2026-07-28T06:04:57.754Z" },
+    { url = "https://files.pythonhosted.org/packages/29/a8/08a56e2000a8816d449dcbad8c8b081697acbbd490821ceca0f9d8e8d20c/wrapt-2.3.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8159ec0b0cb7608175eb150de94c19e34f4d47ac655f5ca9baf45df6b688ffd3", size = 169263, upload-time = "2026-07-28T06:04:59.161Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/d4/354e1725e35a73b2af4fa70a3e024c7a5d1bf1802dfb862dcb668aae0253/wrapt-2.3.0-cp313-cp313-win32.whl", hash = "sha256:10461884b3014fbfc8eb7d09a93c5f246363e6711d9d881f95eb8c27fdef049f", size = 78241, upload-time = "2026-07-28T06:05:00.507Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/7e/34c87fa2174848dfee820322aaa318bab08913998ccecc8d2f57b4ad4639/wrapt-2.3.0-cp313-cp313-win_amd64.whl", hash = "sha256:ac870cc97b73bb00ac353329e9559a4bebc47c4c86792ed9b23b58c15b6ad838", size = 81113, upload-time = "2026-07-28T06:05:01.839Z" },
+    { url = "https://files.pythonhosted.org/packages/11/86/fcc9a530579e008c9478bb565a6cdfbfd33536660f069c8b91a6607c5050/wrapt-2.3.0-cp313-cp313-win_arm64.whl", hash = "sha256:a65e8db2b4e90c2e7ade931086351c98ef420bf7a94ee08c95ac8a3cbbc43579", size = 80182, upload-time = "2026-07-28T06:05:03.152Z" },
+    { url = "https://files.pythonhosted.org/packages/96/50/3864848b95b28ef73e17551fc8dccbff2628a834f52cf26a57f9c419fb83/wrapt-2.3.0-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:fd1f2f557dd3491fe75905e578f4db967393d40d1a8f468edc4d40ac7f2d5944", size = 83921, upload-time = "2026-07-28T06:05:04.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/4c/3d1921a60c3e8c71c540ff136e6a47a1fbccf7f671e818394889f7871d9c/wrapt-2.3.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9f5d2aec29dfc76c37e23897dee92766a3fd4f3bff3ae7fc9c6b4bf37d8c1360", size = 84412, upload-time = "2026-07-28T06:05:05.921Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/1a/4a796ff7adb26ada6d4b758c94d47a38320b085e7099afc088efbbcdb006/wrapt-2.3.0-cp313-cp313t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:646d20d413ffcd1b0a2f700076e2d0252d872dcb7754860a73e45a59ea883614", size = 207168, upload-time = "2026-07-28T06:05:07.256Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/3e/d7777776806c579b761bac2f91721dda9f04c7a1b380213c5935cc750ae6/wrapt-2.3.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:379f670f45b7bb8993edd9f6fc36c6cc65edb81cffa0b504be34acb0303fff0a", size = 214351, upload-time = "2026-07-28T06:05:08.945Z" },
+    { url = "https://files.pythonhosted.org/packages/63/27/2d64d394df7bf181955b3bb562bf33c4492fb4be113f53071106d43ad8b5/wrapt-2.3.0-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:6208f302f110295d64b22a7ac96500c791bf492dce4366e622e4912b077c9687", size = 199020, upload-time = "2026-07-28T06:05:10.418Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/3d/fb31d3db7d9834d265fb1a27a2adf0ddf51557c67458c97b22439ad6ae3d/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:ed635a9ca4f3a5a2b900c10c69e823373bc00ebc114b459383596d3487da3570", size = 209969, upload-time = "2026-07-28T06:05:11.983Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/d1/8724b5da582e62070dc9bf4d8bf1972f317297eefd7ba1f2b5c6393ccf6c/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:e3b9eaa742ae7a0aaaaad4ca4b69469d757af2d6e6663ef1dadc47adec0aeb41", size = 196324, upload-time = "2026-07-28T06:05:13.557Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/5c/3d9ef411149543016ee6bcf3af707f787cebd946527452b94bf122e9b7b4/wrapt-2.3.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:d0f7284f88f4833705132d06d3b425a43095c2cbd07c58166aac3ab646ba12a4", size = 202610, upload-time = "2026-07-28T06:05:15.048Z" },
+    { url = "https://files.pythonhosted.org/packages/13/9b/4fc042ceb757866dd4a5fc057b3b736f2b360d3703ce9f830d83dc9226e0/wrapt-2.3.0-cp313-cp313t-win32.whl", hash = "sha256:7ebb274aba688b043429eb1500ff8a76ce0cb8ac0812ca3e301f06247b8722b3", size = 79178, upload-time = "2026-07-28T06:05:16.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ff/b94878f8eed809ca042685276bcea9f24e8c2ca7c9653bb80bbb920a68a5/wrapt-2.3.0-cp313-cp313t-win_amd64.whl", hash = "sha256:c4bded758ad6f03b965830944a2f0bc5b2eb3767fe5a7310134315d1a6610e98", size = 82634, upload-time = "2026-07-28T06:05:18.026Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/663e1de5332a71685a729754312d327d4cada767c36e1c5a2db4c8de49e6/wrapt-2.3.0-cp313-cp313t-win_arm64.whl", hash = "sha256:d2cc64539da63e39ffb9c7ede849b6e8ddaaf7b3876b5cfb04efd85a5f3f4eb6", size = 81387, upload-time = "2026-07-28T06:05:19.417Z" },
+    { url = "https://files.pythonhosted.org/packages/58/10/b073beaea89bc0d3670a75ff51139430a54b6af7ba7796507730634536dd/wrapt-2.3.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:ea52a0d0f08c584943d5764be0e84efa912c8da23c23e1e285ff2f5641c18fcc", size = 81978, upload-time = "2026-07-28T06:05:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/31/0916d9cebf848ed3f1a0c1888faee421747df77331e4db2bc527a9a85988/wrapt-2.3.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd85b0aa88efdb189d6ae2f35f4526943a8f091c38599c9c31478241c819e6a1", size = 82518, upload-time = "2026-07-28T06:05:22.562Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/73/31c1bf0f3384062751c2094dadb314916d70aa9b6bfd26d994b4a7b393fa/wrapt-2.3.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:141ed6211286a9660d8d6702de598b43f0934b4f0eda16393f100a80f501d945", size = 170187, upload-time = "2026-07-28T06:05:23.904Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/25/fce087d54b79b8905f3c3c9dd5f454bbd8d8acb80b960c4a6aee5b4659b3/wrapt-2.3.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e49885a62ec4ee854d1b9e6371fda6afd219917225752abf729a3f36d4df9a5", size = 169288, upload-time = "2026-07-28T06:05:25.378Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/30/0d09e6dddc6b7a7230ac77f50254b5980ab4fcd22976f72f8cc8a0404458/wrapt-2.3.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:1d6159c9b2fefec02314e1332dbbbfaf960e369dfd26bcf7f8b258b5732065b3", size = 160932, upload-time = "2026-07-28T06:05:27.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/ca/0913af0d2ec0c43865d32d615f518fea66c13c5c930e489e9b0de248e9a8/wrapt-2.3.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24da48596326ef8e448cfa837b454f638713d3531262375f00e5a9681682fc07", size = 169017, upload-time = "2026-07-28T06:05:28.501Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f2/3d1e47ea81b822210f5df1bf942fd90780a75c055243d569b664529dea88/wrapt-2.3.0-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:cd3a2edf0427013736b8127955cec62608c56e53ea47e82812ea32059cda407f", size = 159065, upload-time = "2026-07-28T06:05:30.01Z" },
+    { url = "https://files.pythonhosted.org/packages/43/a5/ef2066ced8e5fca204e2b361e9708e36555b40949c583d997ea3b590817d/wrapt-2.3.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:4fa0df3bff4e7ce45759f33fd39335fe2f60477bb9ecf7b8aa41e7d07ee36a23", size = 168821, upload-time = "2026-07-28T06:05:31.649Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/e1/016104650d4e572fa91506eb396b3dd8efbccc9284fdc1c9479c3d21db28/wrapt-2.3.0-cp314-cp314-win32.whl", hash = "sha256:2935d5454b3f179a29b12cf390ee47246740ba2c3a7545b1b46ba31a5f2a4a0b", size = 78700, upload-time = "2026-07-28T06:05:33.391Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/97/6fdc20a9f2ca304748b3f0819cbf377d55260562777bf0b615431bc3c181/wrapt-2.3.0-cp314-cp314-win_amd64.whl", hash = "sha256:cc2cea812e5cb179a796b766747e7d3b21088760d8deb95676d482b8c8e6fa7d", size = 81422, upload-time = "2026-07-28T06:05:34.774Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/a4/9cbd53bf05746bea2c392af39cb052427a8ec95cbd494d930733d8f44681/wrapt-2.3.0-cp314-cp314-win_arm64.whl", hash = "sha256:22cc5c0a717bd4da87018ae0bffd4c19c6fb679d3ff357216ba566ab26c76cab", size = 80639, upload-time = "2026-07-28T06:05:36.228Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/6c5e4a0f66ea0d2b2dd267e8dd05a0014eea56840b3c8595d40b0a5d1f91/wrapt-2.3.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a6b5984cd65dd639546f0eb4b8eacf1c31cb2fe9fb5c27bffe240987cdb2cf84", size = 84030, upload-time = "2026-07-28T06:05:37.714Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/eb/a1aedf03283bc9cbf8a1783995ddc54e3c5a86878f19002d2c428494f4c5/wrapt-2.3.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c88abcf53daef80e01a75c7530e727fa6e2c1888fe83e3dcdba4c96216a1f5c7", size = 84419, upload-time = "2026-07-28T06:05:39.131Z" },
+    { url = "https://files.pythonhosted.org/packages/63/61/50d511c0dc5105563849e86daa3e16ac7feef699f79fb05af45ea70107d5/wrapt-2.3.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:85de890ff968196e92dd1ae73a9fb8970495e7650a457b1c9ef0ac3dd550bce2", size = 207171, upload-time = "2026-07-28T06:05:40.69Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/59/9b538cf7795217e810699d16bc88b96a830d9b5c403eb2ec2db6b5f2ae81/wrapt-2.3.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:50f416b74d092bb9f41b424e90dd457f365f7ba4b11de62a23679769a21bd85c", size = 214329, upload-time = "2026-07-28T06:05:42.287Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/28/9935d62b1499e5c8b3d191e99ba4eb31ca237a0b699142011a837e9dc7ea/wrapt-2.3.0-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:39febbee6d77301d31da6996b152ce52452da7c7ef72aba10c2fa976dff9c295", size = 199079, upload-time = "2026-07-28T06:05:43.958Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/01/4446b80fa2ffa47a3449b250d004ba1c1937f07f64a179608fec735df866/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:93513bec052c6cd987f9f580c3df068c8bc4ebae6543736be3ca7ec5959cafcd", size = 209992, upload-time = "2026-07-28T06:05:45.677Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/07/56f26c9f9979586a021e8148747004aba4498f49458c90b0502969b904e1/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:729126e667da34d251b8ebf8a45ef0c5ddadc21542b3d6e1abf4259ece6508df", size = 196334, upload-time = "2026-07-28T06:05:47.608Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/41/6d7bcc895b0f28b2250e10908f060687b9165429dcd7f22ddb3d4c031b74/wrapt-2.3.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:626b69db2021aa01671ec7bbc9740e558522bd44c18cf2ce69bf3d666a014109", size = 202644, upload-time = "2026-07-28T06:05:49.183Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/25/7860927edba06b758b8852a6f02e832be715563c67a6795d94350bc81099/wrapt-2.3.0-cp314-cp314t-win32.whl", hash = "sha256:629d73378082c00a8173031f9fb30a3ac6abbc894a5bfdfae71fabc60642d501", size = 79685, upload-time = "2026-07-28T06:05:50.976Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/0f/270bafe92fde3b069a39bc01e39ee79340895b335640df861d43d2a51885/wrapt-2.3.0-cp314-cp314t-win_amd64.whl", hash = "sha256:42869085687f0aefd57c0f636c3f9354f8ffb321a8ba9cb52d19beb796e561c5", size = 83104, upload-time = "2026-07-28T06:05:52.405Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b3/af176d79a8515a8a720eccdad9a96f6e31a30abf2865430c8c42adf2fd13/wrapt-2.3.0-cp314-cp314t-win_arm64.whl", hash = "sha256:b1e5aa486e269b00ed35e64771c7d0ab8096cfd2643405ca8cd60ebedc099a51", size = 81774, upload-time = "2026-07-28T06:05:53.902Z" },
+    { url = "https://files.pythonhosted.org/packages/00/39/3daf9f47be208606586de4568ba6713db53ebc8fd7a575aea1fe57983b69/wrapt-2.3.0-py3-none-any.whl", hash = "sha256:d8c7ed08477429752b8c44991f40ad7838b18332a160698740a6bfbc10d998a2", size = 61866, upload-time = "2026-07-28T06:06:12.9Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Changes

- `repos/analyses.py` — `AnalysisRepository` with `create`, `get`, `list_page`, `delete`. Every read method declares `user_id`; no unscoped access path exists.
- `repos/users.py` — `UserRepository` with `create`, `get_by_id`, `get_by_email` (email lookup is auth-layer, not tenant-scoped).
- `repos/refresh_tokens.py` — `RefreshTokenRepository` with `create`, `get_active_by_hash`, `get_by_hash`, `revoke_family`, `revoke_all_for_user`.
- `tests/integration/` — testcontainers-backed suite: module-scoped Postgres container, per-test rolled-back transactions.
- `integration.yml` — new step runs `pytest apps/api/tests/integration/` after the migration steps.
- `pyproject.toml` — `testcontainers[postgres]>=4.9` added to dev dependencies.

## Notes

Base branch: `op-51-alembic-migrations`.

The `user_id` requirement on every `AnalysisRepository` read method is enforced by a test that uses `inspect.signature` — adding a method without the parameter fails CI before merge.

Cursor pagination uses `(created_at DESC, id DESC)`, served by `ix_analyses_user_id_created_at_id` defined in OP-50. The `delete` method uses a SQL-level `DELETE … RETURNING` rather than a SELECT-then-delete, which avoids a round trip and means the FK cascade to children runs at the database level (the FK has `ondelete="CASCADE"`).

## Tests

`test_every_read_method_requires_user_id` — introspection, no database.
`test_create_persists_children` — roundtrip through all three child tables.
`test_get_returns_none_for_another_users_analysis` — cross-tenant isolation.
`test_list_page_cursor_advances_the_window` — no overlap, no gaps across two pages.
`test_delete_returns_false_for_another_users_analysis` — delete does not reveal existence.