### PR TITLE
Give the MinIO storage step a database it can reach

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -135,39 +135,6 @@ jobs:
           echo "minio-init exited ${code} on a populated volume"
           test "${code}" = "0"
 
-      - name: The API can store an object in MinIO
-        # Run from the workspace rather than from the image, for the reason in the header. What
-        # this catches that the moto-backed unit tests cannot: a wrong endpoint URL, credentials
-        # that do not match the ones MinIO booted with, a bucket name that differs between the
-        # bootstrap and the application, and path-style addressing — moto accepts virtual-host
-        # style, a real MinIO on an IP address does not.
-        env:
-          OPENPOSTURE_POSE_BACKEND: fake
-          OPENPOSTURE_POSE_BACKEND_PRESET: hunchback
-          OPENPOSTURE_STORAGE_BACKEND: s3
-          OPENPOSTURE_S3_ENDPOINT_URL: http://127.0.0.1:9000
-          OPENPOSTURE_S3_ACCESS_KEY: openposture
-          OPENPOSTURE_S3_SECRET_KEY: openposture-dev-only
-        run: |
-          uv run python - <<'PY'
-          from fastapi.testclient import TestClient
-
-          from openposture_api.config import Settings
-          from openposture_api.main import create_app
-
-          with TestClient(create_app(Settings())) as client:
-              with open("fixtures/images/desk_hunch.jpeg", "rb") as image:
-                  response = client.post(
-                      "/api/v1/analyses",
-                      files={"image": ("desk_hunch.jpeg", image, "image/jpeg")},
-                  )
-
-          assert response.status_code == 201, (response.status_code, response.text)
-          key = response.json()["object_key"]
-          assert key.startswith("analyses/"), key
-          print("stored:", key)
-          PY
-
       - name: The API's own engine reaches Postgres
         # Through `create_engine(Settings())` rather than through psql, so what is exercised is
         # the configured URL, the asyncpg driver and the pool the application will actually use.
@@ -259,6 +226,49 @@ jobs:
         run: |
           uv run alembic -c apps/api/alembic.ini check
           echo "OK  no drift"
+
+      - name: The API can store an object in MinIO
+        # Run from the workspace rather than from the image, for the reason in the header. What
+        # this catches that the moto-backed unit tests cannot: a wrong endpoint URL, credentials
+        # that do not match the ones MinIO booted with, a bucket name that differs between the
+        # bootstrap and the application, and path-style addressing — moto accepts virtual-host
+        # style, a real MinIO on an IP address does not.
+        #
+        # **Placed after the migration steps, not with the other bucket checks.** This posts a
+        # real image to `/analyses`, and since E5 that endpoint writes rows as well as an object,
+        # so it needs a migrated schema. Run earlier it fails on the insert, and the failure
+        # reads as a storage problem because of what the step is called.
+        env:
+          OPENPOSTURE_POSE_BACKEND: fake
+          OPENPOSTURE_POSE_BACKEND_PRESET: hunchback
+          OPENPOSTURE_STORAGE_BACKEND: s3
+          OPENPOSTURE_S3_ENDPOINT_URL: http://127.0.0.1:9000
+          OPENPOSTURE_S3_ACCESS_KEY: openposture
+          OPENPOSTURE_S3_SECRET_KEY: openposture-dev-only
+          # Without this, `Settings()` falls back to its default of `@db:5432` — the Compose
+          # service name. That resolves inside the network and nowhere else, and this step runs
+          # on the runner, so the symptom is a `socket.gaierror` surfacing as a 500 from the
+          # endpoint rather than as anything that names the real problem.
+          OPENPOSTURE_DATABASE_URL: postgresql+asyncpg://openposture:openposture-dev-only@127.0.0.1:5432/openposture
+        run: |
+          uv run python - <<'PY'
+          from fastapi.testclient import TestClient
+
+          from openposture_api.config import Settings
+          from openposture_api.main import create_app
+
+          with TestClient(create_app(Settings())) as client:
+              with open("fixtures/images/desk_hunch.jpeg", "rb") as image:
+                  response = client.post(
+                      "/api/v1/analyses",
+                      files={"image": ("desk_hunch.jpeg", image, "image/jpeg")},
+                  )
+
+          assert response.status_code == 201, (response.status_code, response.text)
+          key = response.json()["object_key"]
+          assert key.startswith("analyses/"), key
+          print("stored:", key)
+          PY
 
       - name: Repository integration tests pass against a real Postgres
         # testcontainers starts its own Postgres container on a random port, separate from the


### PR DESCRIPTION
Stacked on #72. Merge this into `op-51-alembic-migrations`, and #72's next run is what actually proves it — see *How tested* for why this branch cannot prove it itself.

## What

One step in `integration.yml`, **"The API can store an object in MinIO"**, had two independent faults. Both are fixed here; nothing else changes.

1. **Missing `OPENPOSTURE_DATABASE_URL`.** Its `env:` block set the pose backend and all four S3 variables, but no database URL, so `Settings()` fell through to its default:

   ```python
   # config.py:166
   default="postgresql+asyncpg://openposture:openposture-dev-only@db:5432/openposture"
   ```

   `db` is the Compose *service name*. It resolves on the Compose network and nowhere else, and this step runs on the runner. The step immediately after it already got this right with `@127.0.0.1:5432`.

2. **Ran before the schema existed.** The step was at position 8; `alembic upgrade head` is at position 10. It is now at position 14, after the drift check — and still before "The object is actually in the bucket", which consumes what it writes.

## Why

The step was written in `d051135`, when `POST /analyses` was in-memory and touched no database at all. E5 made it persist rows, and the step was never revisited. It has failed on every run of this branch since `3d1d61f` (2026-07-29).

Worth noting what the failure *looked* like, because it is a good argument for keeping a step's name honest about its dependencies: a `socket.gaierror` deep inside `session.flush()` surfaced as a 500 from the endpoint, inside a step called "The API can store an object in MinIO". Every word in that name points at object storage. The actual fault was DNS, for Postgres.

`main` is unaffected — it does not yet have the persistence code, so the step passes there. The break exists only inside this stack.

## How tested

Reproduced and fixed against a live local stack, both directions:

```
OLD CONFIG (no DATABASE_URL) -> 500     socket.gaierror
NEW CONFIG                   -> 201     stored: analyses/8ea7b895fde24160887e5d974d6b0d46.jpg
```

Step ordering re-parsed from the YAML to confirm the move landed where intended:

```
13. No drift between models and the migrated schema
14. The API can store an object in MinIO          <- moved here
15. Repository integration tests pass against a real Postgres
16. The object is actually in the bucket
```

**Honest limitation:** the DNS half is proven by execution. The reordering half is proven by step order only — the local database already had the schema, so reproducing the missing-table failure would have meant dropping the tables.

**This PR will not run `integration.yml` itself.** The workflow triggers on `pull_request: branches: [main]`, and this targets `op-51-alembic-migrations`. Merging it into that branch and letting #72 re-run is the only way to see it go green in CI.