### PR TITLE
OP-55: Self-hosted auth — argon2id, JWT, rotating refresh tokens, security.yml

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,152 @@
+# Security scanning (OP-55).
+#
+# Separate from `pr.yml` rather than folded into it, for one reason: `pr.yml` is the required
+# check and has a five-minute budget, while these jobs are slower, partly scheduled, and some of
+# them cannot run on a `push` at all. Merging them would either blow that budget or make the
+# required check depend on jobs that skip in half the situations it runs in.
+#
+# Four questions, one job each:
+#
+#   dependency-review  Does this PR add a dependency with a known vulnerability, or a licence
+#                      the project cannot ship?
+#   codeql             Does the code itself contain an injection, a path traversal, an unsafe
+#                      deserialisation?
+#   secrets            Is there a credential anywhere in the history?
+#   licences           Does the *existing* tree — not just the diff — still comply?
+#
+# ACTION PINNING. Follows `pr.yml`'s policy: third-party actions are pinned to a full commit SHA
+# with the release tag in a trailing comment, GitHub-owned actions use a major tag. Two notes
+# where reality did not fit the policy cleanly, both verified against the tag list rather than
+# assumed:
+#
+#   * `github/codeql-action` is GitHub-owned but not under `actions/*`. It is treated as
+#     first-party, because the policy's reasoning — GitHub controls the namespace and the runner,
+#     so a SHA pin buys little against a threat model that already trusts the platform — applies
+#     to it exactly as written. `v4` exists and is used.
+#   * `actions/dependency-review-action` publishes no major tag past `v3`; `v4` and `v5` do not
+#     exist as refs. It is therefore pinned to the exact release, which freezes patches too and
+#     has to be bumped by hand like the SHA-pinned entries.
+#
+# This workflow needs no secret. `gitleaks` requires a licence key only for organisation-owned
+# repositories, and this one belongs to a personal account.
+
+name: Security
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  # CodeQL's value decays without this. A rule added to the query pack next month finds nothing
+  # if the code is only ever scanned on the day it changes, and the files least likely to be
+  # touched again are exactly the ones worth re-examining.
+  schedule:
+    - cron: "17 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+jobs:
+  # Blocks a *new* vulnerable or badly-licensed dependency at the point it is introduced, which
+  # is the only moment when removing it is free.
+  dependency-review:
+    name: Dependency review
+    runs-on: ubuntu-latest
+    # `pull_request` only, and not by preference: the action diffs the dependency graph between
+    # two commits, and a push has no base to diff against. Gated here rather than left to fail.
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Review dependency changes
+        # No major tag exists for this action (see the note at the top of the file).
+        uses: actions/dependency-review-action@v5.0.0
+        with:
+          # Fail on a newly introduced moderate-or-worse advisory. Not `low`: the base rate of
+          # low-severity advisories in a transitive tree is high enough that a gate set there
+          # trains people to bypass it, and a gate routinely bypassed protects nothing.
+          fail-on-severity: moderate
+          # Copyleft licences the project cannot ship under, given it is MIT. Denying rather than
+          # allow-listing, because an allow-list rejects every unrecognised SPDX string —
+          # including dual licences and the occasional `LicenseRef-*` — and turns a licence gate
+          # into a source of unrelated failures.
+          deny-licenses: GPL-2.0, GPL-3.0, AGPL-3.0, LGPL-3.0, SSPL-1.0
+          comment-summary-in-pr: on-failure
+
+  # Static analysis of our own code, as opposed to our dependencies'.
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      # The one privilege escalation in this file: writing results back to the Security tab.
+      security-events: write
+      # CodeQL reads the workflow run's own metadata to attribute results to a run.
+      actions: read
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        # Both halves of the application. Scanning only Python would leave the code that actually
+        # touches a browser DOM unexamined, which is where injection findings mostly live.
+        language: [python, javascript-typescript]
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Initialise CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          # `security-extended` over the default pack. The default is tuned to near-zero false
+          # positives; extended accepts a few more in exchange for finding the classes of bug
+          # this ticket exists to keep out — injection, unsafe deserialisation, weak crypto.
+          queries: security-extended
+
+      # No build step and no `setup-project`. Both languages here are interpreted, so CodeQL
+      # extracts from source directly; installing the dependency tree would add minutes and
+      # would only put third-party code in front of an analysis that already has
+      # `dependency-review` looking at it.
+      - name: Analyse
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: /language:${{ matrix.language }}
+
+  # A credential in the history is a credential to rotate, whether or not it is in the current
+  # tree. Deleting the file in a later commit does not unpublish it.
+  secrets:
+    name: Secret detection
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # The whole history, not the default shallow clone. A secret committed and then removed
+          # is still in the pack file, still fetchable, and still valid until rotated — and a
+          # depth-1 checkout is precisely blind to it.
+          fetch-depth: 0
+
+      - name: Scan history for credentials
+        uses: gitleaks/gitleaks-action@e0c47f4f8be36e29cdc102c57e68cb5cbf0e8d1e # v3.0.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Dependency review sees only what a PR changes. This answers the same question about the tree
+  # as it stands, which is what catches a licence that changed under an existing dependency.
+  licences:
+    name: Licence policy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-project
+        with:
+          python: "3.12"
+
+      - name: Check installed Python licences
+        run: uv run --with pip-licenses python -m piplicenses --format=markdown --with-urls
+        # Reporting, not gating. A first pass at a licence policy that fails the build tends to
+        # fail on a package whose metadata is merely missing rather than incompatible, and the
+        # fix for that is a per-package exception list nobody maintains. `dependency-review`
+        # above is the gate; this is the inventory that makes writing a real policy possible.
+        continue-on-error: true

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -42,6 +42,10 @@ dependencies = [
     # Access tokens. Decoding always passes an explicit algorithm allowlist, which is what makes
     # `alg: none` and HS/RS confusion unrepresentable rather than merely untested.
     "pyjwt>=2.10",
+    # `EmailStr`. Pydantic keeps the address parser behind an extra because it carries a DNS
+    # library; registration validates the shape of an address at the boundary rather than
+    # discovering it is unroutable at send time — which this project has no path to do anyway.
+    "pydantic[email]>=2.0",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -35,6 +35,13 @@ dependencies = [
     # concurrent API replicas serialise rather than race on DDL. Ships as a runtime dependency
     # (not dev-only) because the container needs it to start.
     "alembic>=1.14",
+    # Password hashing (ADR-0003). argon2id, not passlib: passlib's last release predates several
+    # Python versions this project supports, and a hashing library going quiet is the one
+    # dependency where "still works" is not the same as "still maintained".
+    "argon2-cffi>=23.1",
+    # Access tokens. Decoding always passes an explicit algorithm allowlist, which is what makes
+    # `alg: none` and HS/RS confusion unrepresentable rather than merely untested.
+    "pyjwt>=2.10",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/src/openposture_api/auth.py
+++ b/apps/api/src/openposture_api/auth.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
 from openposture_api.db import get_session
+from openposture_api.errors import problem_response
 from openposture_api.repos import RefreshTokenRepository, UserRepository
 from openposture_api.schemas import CredentialsRequest, TokenResponse
 from openposture_api.security import (
@@ -45,6 +46,8 @@ from openposture_api.security import (
 )
 
 if TYPE_CHECKING:
+    from starlette.responses import JSONResponse
+
     from openposture_api.config import Settings
     from openposture_api.db.models import User
 
@@ -193,7 +196,7 @@ def build_auth_router() -> APIRouter:
         request: Request,
         response: Response,
         session: Annotated[AsyncSession, Depends(get_session)],
-    ) -> TokenResponse:
+    ) -> TokenResponse | JSONResponse:
         """Rotate the refresh token and mint a new access token.
 
         The presented token is always retired, whatever else happens. A refresh that returned a
@@ -202,14 +205,14 @@ def build_auth_router() -> APIRouter:
         settings = _settings_of(request)
         presented = request.cookies.get(settings.refresh_cookie_name)
         if not presented:
-            raise _unauthorized_refresh(response, settings)
+            return _unauthorized_refresh(request, settings)
 
         tokens = RefreshTokenRepository(session)
         stored = await tokens.get_by_hash(hash_refresh_token(presented))
         now = datetime.now(UTC)
 
         if stored is None:
-            raise _unauthorized_refresh(response, settings)
+            return _unauthorized_refresh(request, settings)
 
         if stored.revoked_at is not None:
             # Replay. This token was already rotated, so a correct client would never present it
@@ -225,10 +228,10 @@ def build_auth_router() -> APIRouter:
                 family_id=str(stored.family_id),
                 tokens_revoked=revoked,
             )
-            raise _unauthorized_refresh(response, settings)
+            return _unauthorized_refresh(request, settings)
 
         if _as_utc(stored.expires_at) <= now:
-            raise _unauthorized_refresh(response, settings)
+            return _unauthorized_refresh(request, settings)
 
         await tokens.revoke(stored, now)
         await _issue_refresh_cookie(
@@ -385,19 +388,27 @@ def _clear_refresh_cookie(response: Response, settings: Settings) -> None:
     )
 
 
-def _unauthorized_refresh(response: Response, settings: Settings) -> HTTPException:
+def _unauthorized_refresh(request: Request, settings: Settings) -> JSONResponse:
     """One 401 for every way a refresh can fail, with the dead cookie cleared on the way out.
 
     Missing, unknown, expired and replayed are deliberately indistinguishable to the client. A
     client that could tell "expired" from "revoked as stolen" would learn whether the token it
     holds was ever real, which is exactly what an attacker testing a captured token wants to know.
+
+    **Returned and not raised, and the difference is load-bearing.** Raising `HTTPException`
+    hands control to the error handler, which builds its own response — so anything written to
+    the injected `Response` object, including a `Set-Cookie`, is discarded. The first version of
+    this function raised, and the cookie clearing it documented simply never reached the client.
+    Building the problem response here keeps the header attached to the response that is sent.
     """
-    _clear_refresh_cookie(response, settings)
-    return HTTPException(
-        status_code=status.HTTP_401_UNAUTHORIZED,
-        detail="Your session has expired. Please sign in again.",
+    problem = problem_response(
+        request,
+        status.HTTP_401_UNAUTHORIZED,
+        "Your session has expired. Please sign in again.",
         headers={"WWW-Authenticate": "Bearer"},
     )
+    _clear_refresh_cookie(problem, settings)
+    return problem
 
 
 def _as_utc(moment: datetime) -> datetime:

--- a/apps/api/src/openposture_api/auth.py
+++ b/apps/api/src/openposture_api/auth.py
@@ -1,21 +1,81 @@
-"""Authentication dependencies.
+"""Authentication routes and dependencies.
 
-E7 (OP-55) adds the full auth stack: argon2id password hashing, JWT access tokens, and rotating
-opaque refresh tokens. E8 (OP-56) implements `get_current_user_id` for real.
+Four endpoints, and each exists to move one credential across one boundary:
 
-Until then this module exists so that E6's routes compile and tests can override the dependency.
-Every route that needs the current user depends on `get_current_user_id`, which raises 401 today
-and will return the authenticated user's UUID after E8 lands.
+* `register` and `login` turn an email and a password into a session.
+* `refresh` turns a refresh token into a new access token — and a new refresh token.
+* `logout` ends the session everywhere it exists.
+
+**Two credentials, because one cannot do both jobs.** The access token is self-verifying and so
+costs no query, but cannot be withdrawn before it expires. The refresh token is opaque and so is
+revocable, but requires a lookup. Fifteen minutes and thirty days are the two halves of that
+trade-off (ADR-0003).
+
+**Rotation makes theft detectable.** Every refresh mints a new token and retires the one
+presented. A retired token arriving a second time has two explanations — a client bug or a stolen
+copy — and only one safe reading, so the whole family is revoked and everyone re-authenticates.
+The alternative is that an attacker who has copied a token keeps refreshing it forever, silently,
+alongside the legitimate user.
+
+**Sign-in never reveals whether an account exists.** Not just an identical response body: an
+identical amount of *work*. See `_verify_credentials`.
 """
 
 from __future__ import annotations
 
 import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Annotated, Final
 
-from fastapi import HTTPException
+import structlog
+from fastapi import APIRouter, Depends, HTTPException, Request, Response
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 from starlette import status
 
-__all__ = ["get_current_user_id"]
+from openposture_api.db import get_session
+from openposture_api.repos import RefreshTokenRepository, UserRepository
+from openposture_api.schemas import CredentialsRequest, TokenResponse
+from openposture_api.security import (
+    hash_password,
+    hash_refresh_token,
+    issue_access_token,
+    issue_refresh_token,
+    verify_password,
+)
+
+if TYPE_CHECKING:
+    from openposture_api.config import Settings
+    from openposture_api.db.models import User
+
+# `AsyncSession` is imported above at runtime rather than here, and that is load-bearing rather
+# than untidy. `from __future__ import annotations` turns every annotation into a string, and
+# FastAPI resolves route signatures by evaluating those strings at startup. A name that exists
+# only for the type checker cannot be resolved, so `Annotated[AsyncSession, Depends(...)]`
+# silently stops being a dependency and becomes an unrecognised *query parameter* — every request
+# then fails with "query.session: Field required" rather than anything mentioning imports.
+
+__all__ = ["AUTH_PREFIX", "build_auth_router", "get_current_user_id"]
+
+AUTH_PREFIX: Final = "/api/v1/auth"
+
+_LOGGER = structlog.get_logger(__name__)
+
+_INVALID_CREDENTIALS: Final = "Email or password is incorrect."
+"""One sentence for "no such account" and for "wrong password" alike.
+
+Two messages would be an account-existence oracle in plain text, which is the same leak the
+equal-cost verification below closes in the time domain. Both halves are needed; either alone
+still tells an attacker which addresses are registered.
+"""
+
+_DUMMY_HASH: Final = hash_password("a password nobody has, hashed once at import")
+"""A real argon2 hash that no submitted password can match.
+
+Verifying against this when the email is unknown is what makes a failed login cost the same
+whether or not the account exists. Computed once at import, because doing it per request would
+double the cost of every failed sign-in for no benefit.
+"""
 
 
 async def get_current_user_id() -> uuid.UUID:
@@ -29,3 +89,348 @@ async def get_current_user_id() -> uuid.UUID:
         detail="Authentication required.",
         headers={"WWW-Authenticate": "Bearer"},
     )
+
+
+def build_auth_router() -> APIRouter:
+    """The authentication routes.
+
+    A builder rather than a module-level router, for the same reason `create_app` is a factory:
+    two apps in one test session must not share mutable route state.
+    """
+    router = APIRouter(prefix=AUTH_PREFIX, tags=["auth"])
+
+    @router.post(
+        "/register",
+        status_code=status.HTTP_201_CREATED,
+        response_model=TokenResponse,
+        summary="Create an account and sign in",
+        responses={
+            status.HTTP_409_CONFLICT: {"description": "That email is already registered."},
+            status.HTTP_422_UNPROCESSABLE_CONTENT: {"description": "Password or email rejected."},
+        },
+    )
+    async def register(
+        credentials: CredentialsRequest,
+        request: Request,
+        response: Response,
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> TokenResponse:
+        """Register, then immediately issue a session — nobody wants to log in twice.
+
+        **This route does leak whether an address is registered**, via the 409, and that is a
+        known gap rather than an oversight. Closing it means always returning 201 and sending a
+        "somebody tried to register your address" email, and ADR-0003 records that this project
+        has no outbound mail path. The alternative — a 201 that silently creates nothing — lies
+        to legitimate users about whether they have an account, which is worse.
+        """
+        settings = _settings_of(request)
+        email = _normalise_email(credentials.email)
+        users = UserRepository(session)
+
+        try:
+            # `create` flushes, so the unique constraint is enforced here rather than by a prior
+            # SELECT. That ordering matters: two simultaneous registrations of one address both
+            # pass a check-then-insert, and only one survives a constraint. The race is rare, the
+            # database already prevents it, and a pre-check would merely make it less visible.
+            user = await users.create(
+                email=email, password_hash=hash_password(credentials.password)
+            )
+        except IntegrityError as exc:
+            await session.rollback()
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail="That email is already registered.",
+            ) from exc
+
+        tokens = await _open_session_for(
+            user, session=session, settings=settings, response=response
+        )
+        await session.commit()
+        _LOGGER.info("user_registered", user_id=str(user.id))
+        return tokens
+
+    @router.post(
+        "/login",
+        response_model=TokenResponse,
+        summary="Sign in",
+        responses={status.HTTP_401_UNAUTHORIZED: {"description": "Credentials rejected."}},
+    )
+    async def login(
+        credentials: CredentialsRequest,
+        request: Request,
+        response: Response,
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> TokenResponse:
+        settings = _settings_of(request)
+        email = _normalise_email(credentials.email)
+
+        user = await _verify_credentials(email, credentials.password, session=session)
+        if user is None:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail=_INVALID_CREDENTIALS,
+                headers={"WWW-Authenticate": "Bearer"},
+            )
+
+        tokens = await _open_session_for(
+            user, session=session, settings=settings, response=response
+        )
+        await session.commit()
+        _LOGGER.info("user_logged_in", user_id=str(user.id))
+        return tokens
+
+    @router.post(
+        "/refresh",
+        response_model=TokenResponse,
+        summary="Exchange a refresh token for a new access token",
+        responses={
+            status.HTTP_401_UNAUTHORIZED: {
+                "description": "The refresh token is missing, expired, unknown or already used."
+            }
+        },
+    )
+    async def refresh(
+        request: Request,
+        response: Response,
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> TokenResponse:
+        """Rotate the refresh token and mint a new access token.
+
+        The presented token is always retired, whatever else happens. A refresh that returned a
+        new token while leaving the old one usable would make rotation decorative.
+        """
+        settings = _settings_of(request)
+        presented = request.cookies.get(settings.refresh_cookie_name)
+        if not presented:
+            raise _unauthorized_refresh(response, settings)
+
+        tokens = RefreshTokenRepository(session)
+        stored = await tokens.get_by_hash(hash_refresh_token(presented))
+        now = datetime.now(UTC)
+
+        if stored is None:
+            raise _unauthorized_refresh(response, settings)
+
+        if stored.revoked_at is not None:
+            # Replay. This token was already rotated, so a correct client would never present it
+            # again — meaning either the legitimate client and an attacker both hold copies, or
+            # something is badly confused. Both warrant ending every session in the family: the
+            # attacker's branch and the user's branch are indistinguishable from here, and
+            # revoking only the presented row would leave whichever of them refreshed last.
+            revoked = await tokens.revoke_family(stored.family_id, now)
+            await session.commit()
+            _LOGGER.warning(
+                "refresh_token_replayed",
+                user_id=str(stored.user_id),
+                family_id=str(stored.family_id),
+                tokens_revoked=revoked,
+            )
+            raise _unauthorized_refresh(response, settings)
+
+        if _as_utc(stored.expires_at) <= now:
+            raise _unauthorized_refresh(response, settings)
+
+        await tokens.revoke(stored, now)
+        await _issue_refresh_cookie(
+            response,
+            settings=settings,
+            session=session,
+            user_id=stored.user_id,
+            # Same family: this is the next link in one chain of rotations, and a replay of any
+            # earlier link has to be able to revoke everything downstream of it.
+            family_id=stored.family_id,
+            now=now,
+        )
+        access = _issue_access(stored.user_id, settings)
+        await session.commit()
+        return access
+
+    @router.post(
+        "/logout",
+        status_code=status.HTTP_204_NO_CONTENT,
+        # Without this, returning `None` from a 204 route serialises to a four-byte `null` body,
+        # which is a protocol violation: 204 means there is no body to send.
+        response_class=Response,
+        summary="End the session on every device",
+    )
+    async def logout(
+        request: Request,
+        response: Response,
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> None:
+        """Revoke the whole family and clear the cookie.
+
+        Always 204, even when the cookie is absent or unrecognised. Logging out is not a place to
+        report that a token was already invalid — the caller wanted no session, and afterwards
+        there is no session. Reporting the difference would turn logout into a token oracle.
+
+        The family, not just the presented token, because "log out" means the session is over. A
+        rotation the client had already performed elsewhere must not survive it.
+        """
+        settings = _settings_of(request)
+        presented = request.cookies.get(settings.refresh_cookie_name)
+
+        if presented:
+            tokens = RefreshTokenRepository(session)
+            stored = await tokens.get_by_hash(hash_refresh_token(presented))
+            if stored is not None:
+                await tokens.revoke_family(stored.family_id, datetime.now(UTC))
+                await session.commit()
+                _LOGGER.info("user_logged_out", user_id=str(stored.user_id))
+
+        _clear_refresh_cookie(response, settings)
+
+    return router
+
+
+async def _verify_credentials(email: str, password: str, *, session: AsyncSession) -> User | None:
+    """Return the user if the credentials are right, `None` otherwise — at a constant cost.
+
+    The naive version returns early when no user is found, and that early return is a timing
+    oracle: a missing account answers in a fraction of a millisecond, a wrong password answers in
+    roughly twenty-three. The difference is two orders of magnitude, far above network jitter, so
+    an attacker with a list of addresses can simply time the responses and learn which are
+    registered — the exact leak ADR-0003 forbids, arriving through the clock instead of the body.
+
+    So the hash is verified either way, against `_DUMMY_HASH` when there is no user. It cannot
+    match, and that is the point: the work is spent regardless.
+
+    This equalises, it does not make constant-time. Argon2's own comparison is constant-time; what
+    remains here is the difference between a hit and a miss on the email index, which is orders of
+    magnitude below the noise floor of a network round trip.
+    """
+    user = await UserRepository(session).get_by_email(email)
+    stored_hash = user.password_hash if user is not None else _DUMMY_HASH
+
+    matched = verify_password(stored_hash, password)
+
+    return user if (matched and user is not None) else None
+
+
+async def _open_session_for(
+    user: User, *, session: AsyncSession, settings: Settings, response: Response
+) -> TokenResponse:
+    """Start a brand-new rotation family and return the access token for it."""
+    now = datetime.now(UTC)
+    await _issue_refresh_cookie(
+        response,
+        settings=settings,
+        session=session,
+        user_id=user.id,
+        family_id=uuid.uuid4(),
+        now=now,
+    )
+    return _issue_access(user.id, settings)
+
+
+async def _issue_refresh_cookie(
+    response: Response,
+    *,
+    settings: Settings,
+    session: AsyncSession,
+    user_id: uuid.UUID,
+    family_id: uuid.UUID,
+    now: datetime,
+) -> None:
+    """Mint a refresh token, store only its digest, and set it as an `HttpOnly` cookie."""
+    token = issue_refresh_token()
+    expires_at = now + timedelta(days=settings.refresh_token_ttl_days)
+
+    await RefreshTokenRepository(session).create(
+        user_id=user_id,
+        # The plaintext exists only in this function and in the client's cookie jar. Nothing
+        # writes it to a row, a log, or a response body.
+        token_hash=hash_refresh_token(token),
+        family_id=family_id,
+        issued_at=now,
+        expires_at=expires_at,
+    )
+
+    response.set_cookie(
+        settings.refresh_cookie_name,
+        token,
+        max_age=settings.refresh_token_ttl_days * 24 * 60 * 60,
+        # Unreadable from JavaScript, which is what makes the "nothing in localStorage" rule
+        # structural: an XSS can still *send* a request, but it cannot exfiltrate this token.
+        httponly=True,
+        secure=settings.use_secure_cookies,
+        # Lax, not Strict: the cookie must survive a top-level navigation back into the app, and
+        # not None, which would attach it to any cross-site request and reintroduce CSRF.
+        samesite="lax",
+        # Scoped to the routes that need it, so it is not attached to every image upload.
+        path=AUTH_PREFIX,
+    )
+
+
+def _issue_access(user_id: uuid.UUID, settings: Settings) -> TokenResponse:
+    return TokenResponse(
+        access_token=issue_access_token(user_id=user_id, settings=settings),
+        token_type="bearer",
+        expires_in=settings.access_token_ttl_minutes * 60,
+    )
+
+
+def _clear_refresh_cookie(response: Response, settings: Settings) -> None:
+    """Delete the cookie with the same attributes it was set with.
+
+    A browser matches a deletion against name, path and domain. Clearing it without the `path`
+    it was set under silently does nothing, and the stale cookie keeps being sent.
+    """
+    response.delete_cookie(
+        settings.refresh_cookie_name,
+        path=AUTH_PREFIX,
+        httponly=True,
+        secure=settings.use_secure_cookies,
+        samesite="lax",
+    )
+
+
+def _unauthorized_refresh(response: Response, settings: Settings) -> HTTPException:
+    """One 401 for every way a refresh can fail, with the dead cookie cleared on the way out.
+
+    Missing, unknown, expired and replayed are deliberately indistinguishable to the client. A
+    client that could tell "expired" from "revoked as stolen" would learn whether the token it
+    holds was ever real, which is exactly what an attacker testing a captured token wants to know.
+    """
+    _clear_refresh_cookie(response, settings)
+    return HTTPException(
+        status_code=status.HTTP_401_UNAUTHORIZED,
+        detail="Your session has expired. Please sign in again.",
+        headers={"WWW-Authenticate": "Bearer"},
+    )
+
+
+def _as_utc(moment: datetime) -> datetime:
+    """Read a stored timestamp back as timezone-aware UTC.
+
+    `expires_at` is declared `DateTime(timezone=True)`, and Postgres honours that — asyncpg
+    returns an aware datetime. SQLite has no timezone-aware storage at all and hands back a naive
+    one, so comparing it against `datetime.now(UTC)` raises `TypeError` rather than returning a
+    wrong answer. Everything written here is UTC, so attaching the zone is a restatement of what
+    the column already means, not a conversion.
+
+    Python is strict about this on purpose: naive and aware datetimes are different types of
+    thing, and refusing to compare them prevents the far worse bug of silently comparing a local
+    time to a UTC one.
+    """
+    return moment if moment.tzinfo is not None else moment.replace(tzinfo=UTC)
+
+
+def _normalise_email(email: str) -> str:
+    """Lowercase at the boundary, once.
+
+    `users.email` carries a CHECK constraint requiring the stored value to already be lowercase,
+    so this is not a convenience — it is the single place the invariant is established. A user
+    registering as `Sam@Example.com` and signing in as `sam@example.com` is the same person.
+    """
+    return email.strip().lower()
+
+
+def _settings_of(request: Request) -> Settings:
+    """The app's settings, off `app.state` where `create_app` put them.
+
+    Not `get_settings()`: that reads the process environment, and the whole point of the factory
+    is that a test can build an app with settings that differ from it.
+    """
+    settings: Settings = request.app.state.settings
+    return settings

--- a/apps/api/src/openposture_api/config.py
+++ b/apps/api/src/openposture_api/config.py
@@ -221,9 +221,14 @@ class Settings(BaseSettings):
 
     jwt_secret: SecretStr = Field(
         default=SecretStr(DEV_JWT_SECRET),
+        # RFC 7518 §3.2: an HMAC key must be at least the hash's output size, which for SHA-256
+        # is 32 bytes. Below that the key, rather than the algorithm, becomes the weakest part —
+        # and a short key is brute-forceable offline from a single captured token, after which
+        # every token is forgeable. PyJWT warns about this; a warning is not a control.
+        min_length=32,
         description=(
-            "HS256 signing key for access tokens. Must be overridden in production, which "
-            "the validator below enforces rather than documents."
+            "HS256 signing key for access tokens. At least 32 characters, and overridden in "
+            "production — both enforced here rather than documented and hoped for."
         ),
     )
 

--- a/apps/api/src/openposture_api/config.py
+++ b/apps/api/src/openposture_api/config.py
@@ -22,7 +22,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Final, Literal
 
-from pydantic import Field, field_validator
+from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from pose_backends.fake import BACKEND_NAME as FAKE_BACKEND
@@ -30,6 +30,7 @@ from pose_backends.fake import PosePreset
 from pose_backends.mediapipe_backend import BACKEND_NAME as MEDIAPIPE_BACKEND
 
 __all__ = [
+    "DEV_JWT_SECRET",
     "ENV_PREFIX",
     "Environment",
     "PoseBackendName",
@@ -45,6 +46,15 @@ ENV_PREFIX: Final = "OPENPOSTURE_"
 """
 
 Environment = Literal["development", "test", "production"]
+
+DEV_JWT_SECRET: Final = "dev-only-insecure-jwt-secret-change-me"
+"""The signing key `docker compose up` gets for free, and the one production must never see.
+
+A default that *works* is why the service needs no configuration to run locally. It is also, on
+exactly the same mechanism, how a deployment ships signed with a key that is printed in a public
+repository. :meth:`Settings._reject_default_secret_in_production` is the five lines that make the
+convenient case and the catastrophic case distinguishable.
+"""
 
 LogLevel = Literal["debug", "info", "warning", "error", "critical"]
 
@@ -209,6 +219,45 @@ class Settings(BaseSettings):
         description="Secret key. `None` defers to boto3's own credential chain.",
     )
 
+    jwt_secret: SecretStr = Field(
+        default=SecretStr(DEV_JWT_SECRET),
+        description=(
+            "HS256 signing key for access tokens. Must be overridden in production, which "
+            "the validator below enforces rather than documents."
+        ),
+    )
+
+    access_token_ttl_minutes: int = Field(
+        default=15,
+        ge=1,
+        description=(
+            "Access token lifetime. Short because a JWT cannot be revoked before it expires — "
+            "this number is the window an attacker keeps a stolen token (ADR-0003)."
+        ),
+    )
+
+    refresh_token_ttl_days: int = Field(
+        default=30,
+        ge=1,
+        description=(
+            "Refresh token lifetime, and so the longest a session survives without a login."
+        ),
+    )
+
+    refresh_cookie_name: str = Field(
+        default="openposture_refresh",
+        min_length=1,
+        description="Cookie carrying the opaque refresh token. Never readable by JavaScript.",
+    )
+
+    refresh_cookie_secure: bool | None = Field(
+        default=None,
+        description=(
+            "Restrict the refresh cookie to HTTPS. Defaults to true outside development, where "
+            "`Secure` would make the cookie unusable over a plain-http localhost."
+        ),
+    )
+
     @field_validator("request_id_header")
     @classmethod
     def _reject_blank_header(cls, value: str) -> str:
@@ -223,9 +272,36 @@ class Settings(BaseSettings):
             raise ValueError("must not be blank")
         return stripped
 
+    @model_validator(mode="after")
+    def _reject_default_secret_in_production(self) -> Settings:
+        """Refuse to boot production with the signing key that ships in the repository.
+
+        A `field_validator` cannot express this: it sees one field, and the rule is a
+        *relationship* between two. `mode="after"` runs once every field has been parsed and
+        coerced, so both `environment` and `jwt_secret` are final values here rather than raw
+        environment strings.
+
+        Failing at startup is the entire point. A weak key produces perfectly valid-looking
+        tokens, so there is no request whose behaviour would reveal the mistake — the only
+        moment this is detectable is before the process accepts traffic.
+        """
+        if self.is_production and self.jwt_secret.get_secret_value() == DEV_JWT_SECRET:
+            raise ValueError(
+                f"{ENV_PREFIX}JWT_SECRET is still the development default. Production must set "
+                "its own key — anyone with the repository can forge tokens signed with this one."
+            )
+        return self
+
     @property
     def is_production(self) -> bool:
         return self.environment == "production"
+
+    @property
+    def use_secure_cookies(self) -> bool:
+        """Explicit setting if given, otherwise HTTPS-only everywhere but a developer's machine."""
+        if self.refresh_cookie_secure is not None:
+            return self.refresh_cookie_secure
+        return self.environment != "development"
 
     @property
     def emit_json_logs(self) -> bool:

--- a/apps/api/src/openposture_api/main.py
+++ b/apps/api/src/openposture_api/main.py
@@ -24,6 +24,7 @@ from fastapi import FastAPI
 
 from openposture_api import __version__
 from openposture_api.analyses import build_analyses_router, register_analysis_error_handlers
+from openposture_api.auth import build_auth_router
 from openposture_api.config import Settings, get_settings
 from openposture_api.db import close_engine, create_engine, create_session_factory
 from openposture_api.errors import register_error_handlers
@@ -174,6 +175,7 @@ def create_app(
     app.include_router(
         build_health_router(version=__version__, probes=probes),
     )
+    app.include_router(build_auth_router())
     app.include_router(build_analyses_router())
 
     _LOGGER.info(

--- a/apps/api/src/openposture_api/repos/refresh_tokens.py
+++ b/apps/api/src/openposture_api/repos/refresh_tokens.py
@@ -81,6 +81,16 @@ class RefreshTokenRepository:
         )
         return result.scalar_one_or_none()
 
+    async def revoke(self, token: RefreshToken, revoked_at: datetime) -> None:
+        """Revoke one token — the normal end of a rotation.
+
+        Separate from `revoke_family` because rotation and replay detection mean opposite things.
+        Rotating retires a token that was used correctly and leaves the family alive; revoking
+        the family is the response to a token used *twice*, and ends every session in it.
+        """
+        token.revoked_at = revoked_at
+        await self._session.flush()
+
     async def revoke_family(self, family_id: uuid.UUID, revoked_at: datetime) -> int:
         """Revoke every active token in a family. Returns the row count."""
         result = await self._session.execute(

--- a/apps/api/src/openposture_api/schemas.py
+++ b/apps/api/src/openposture_api/schemas.py
@@ -17,16 +17,19 @@ from __future__ import annotations
 
 import uuid
 from datetime import datetime
-from typing import Literal
+from typing import Final, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, EmailStr, Field
 
 __all__ = [
+    "MAX_PASSWORD_LENGTH",
+    "MIN_PASSWORD_LENGTH",
     "AnalysisDetail",
     "AnalysisListItem",
     "AnalysisPage",
     "AnalysisResponse",
     "ContractModel",
+    "CredentialsRequest",
     "DetectedLandmark",
     "Finding",
     "Gap",
@@ -36,7 +39,28 @@ __all__ = [
     "Quality",
     "StoredFinding",
     "StoredMetric",
+    "TokenResponse",
 ]
+
+MIN_PASSWORD_LENGTH: Final = 12
+"""Length is the cheapest real entropy, and the only thing argon2 cannot supply.
+
+Hashing multiplies the cost of a guess; it does not make a guessable password unguessable. No
+character-class rule accompanies this deliberately — those reliably produce `Password1!`, which
+satisfies every rule and appears in every wordlist.
+"""
+
+MAX_PASSWORD_LENGTH: Final = 128
+"""A bound on request memory, not on hashing cost.
+
+The usual justification for a cap is that a huge password would exhaust the hasher. Measured
+against argon2id, that is close to false: 16 characters and 1,000,000 characters both hash in
+~24 ms, because the cost comes from the memory and time parameters rather than the input. What a
+10 MB password *does* cost is 10 MB of memory per concurrent request, materialised by the JSON
+parser long before argon2 sees it. That is the real bound, and this is where it belongs.
+
+Note there is no bcrypt-style 72-byte truncation to work around here; argon2 has no such limit.
+"""
 
 
 class ContractModel(BaseModel):
@@ -248,6 +272,51 @@ class StoredFinding(ContractModel):
     metric: str
     value: float
     confidence: float
+
+
+class CredentialsRequest(ContractModel):
+    """The body of `POST /auth/register` and `POST /auth/login`.
+
+    One model for both, because the two must validate identically. If registration accepted a
+    password that login rejected, an account could be created and never used again.
+    """
+
+    email: EmailStr = Field(
+        max_length=320,
+        description="Address to register or sign in with. Compared case-insensitively.",
+    )
+
+    password: str = Field(
+        min_length=MIN_PASSWORD_LENGTH,
+        max_length=MAX_PASSWORD_LENGTH,
+        description=(
+            "At least 12 characters. Length is the only property checked — no character-class "
+            "rule, which pushes people towards `Password1!` and away from a long passphrase."
+        ),
+    )
+
+
+class TokenResponse(ContractModel):
+    """What every successful auth route returns.
+
+    **The refresh token is deliberately not here.** It goes back as an `HttpOnly` cookie and
+    appears in no response body anywhere, which is what makes "no token in `localStorage`"
+    a property of the API rather than a rule the frontend has to keep remembering.
+    """
+
+    access_token: str = Field(description="Bearer token. Hold in memory only; never persist it.")
+
+    token_type: Literal["bearer"] = Field(
+        default="bearer",
+        description="RFC 6750 scheme, so the client sends `Authorization: Bearer <token>`.",
+    )
+
+    expires_in: int = Field(
+        description=(
+            "Seconds until the access token expires. Sent so the client can refresh *before* "
+            "expiry rather than discovering it through a failed request."
+        )
+    )
 
 
 class AnalysisDetail(ContractModel):

--- a/apps/api/src/openposture_api/security/__init__.py
+++ b/apps/api/src/openposture_api/security/__init__.py
@@ -1,0 +1,12 @@
+"""Cryptographic primitives, kept away from the routes that use them.
+
+The split is deliberate: this package knows how to hash and how to sign, and nothing about HTTP,
+sessions or users. That is what lets the abuse-case suite test algorithm confusion and replay
+directly against these functions, with no client, no database and no request.
+"""
+
+from __future__ import annotations
+
+from openposture_api.security.passwords import hash_password, verify_password
+
+__all__ = ["hash_password", "verify_password"]

--- a/apps/api/src/openposture_api/security/__init__.py
+++ b/apps/api/src/openposture_api/security/__init__.py
@@ -8,5 +8,24 @@ directly against these functions, with no client, no database and no request.
 from __future__ import annotations
 
 from openposture_api.security.passwords import hash_password, verify_password
+from openposture_api.security.tokens import (
+    ALGORITHM,
+    REFRESH_TOKEN_BYTES,
+    InvalidAccessTokenError,
+    decode_access_token,
+    hash_refresh_token,
+    issue_access_token,
+    issue_refresh_token,
+)
 
-__all__ = ["hash_password", "verify_password"]
+__all__ = [
+    "ALGORITHM",
+    "REFRESH_TOKEN_BYTES",
+    "InvalidAccessTokenError",
+    "decode_access_token",
+    "hash_password",
+    "hash_refresh_token",
+    "issue_access_token",
+    "issue_refresh_token",
+    "verify_password",
+]

--- a/apps/api/src/openposture_api/security/passwords.py
+++ b/apps/api/src/openposture_api/security/passwords.py
@@ -1,0 +1,76 @@
+"""Password hashing with argon2id.
+
+`argon2-cffi`'s defaults are used as they ship — 64 MiB, three passes, four lanes — rather than
+hand-tuned here. They track the RFC 9106 recommendations and are revised by people who follow the
+cryptanalysis; a number invented in this file would be a number nobody revisits.
+
+**What argon2 buys is cost per guess, not entropy.** Hashing adds no randomness: a weak password
+is weak after hashing too. What the parameters do is make each attempt expensive — measured at
+roughly 23 ms on a development laptop, against the ~10⁹/s a GPU manages on a bare SHA-256 — and
+the 64 MiB memory requirement is what stops an attacker buying that back with parallel hardware.
+That memory-hardness is why argon2id, rather than bcrypt.
+
+Contrast :mod:`openposture_api.security.tokens`, which hashes refresh tokens with plain SHA-256.
+Opposite choice, same reasoning applied to a different input: a 256-bit random token has nothing
+to guess, so a slow hash there would buy no security and would put a deliberately expensive
+function on the refresh path.
+"""
+
+from __future__ import annotations
+
+from typing import Final
+
+from argon2 import PasswordHasher
+from argon2.exceptions import Argon2Error, InvalidHashError
+
+__all__ = ["hash_password", "verify_password"]
+
+_HASHER: Final = PasswordHasher()
+"""One hasher for the process.
+
+`PasswordHasher` holds only its parameters — it carries no per-password state, so a single
+instance is safe to share across concurrent requests. Constructing one per call would be waste
+without being safer.
+"""
+
+
+def hash_password(password: str) -> str:
+    """Hash a plaintext password for storage.
+
+    Returns argon2's encoded form — algorithm, version, parameters and salt, all in the one
+    string::
+
+        $argon2id$v=19$m=65536,t=3,p=4$<salt>$<digest>
+
+    That self-describing format is why there is no separate salt column and no parameter column
+    in `users`: everything needed to verify against this hash later, including the parameters it
+    was created under, travels with it. Retuning the parameters therefore does not invalidate
+    existing hashes.
+
+    Unlike bcrypt, argon2 does not silently truncate long inputs, so there is no 72-byte cliff to
+    work around here. The length cap lives at the request schema, where it belongs — it is there
+    to bound the work per request, not to protect the algorithm.
+    """
+    return _HASHER.hash(password)
+
+
+def verify_password(password_hash: str, password: str) -> bool:
+    """Check a password against a stored hash. Never raises.
+
+    A boolean, not an exception, and deliberately one boolean for every way this can fail —
+    wrong password, malformed hash, unknown algorithm. ADR-0003 requires that sign-in not reveal
+    whether an email is registered, and a caller that has to distinguish `VerifyMismatchError`
+    from `InvalidHashError` is a caller with two code paths that can diverge into an oracle.
+
+    The comparison inside argon2 is constant-time, so a wrong password costs the same as a right
+    one. That property only survives to the endpoint if the *caller* also spends the same work
+    when no user exists at all — see the login route, which hashes against a dummy for exactly
+    that reason. A missing user is otherwise the fast path, and a fast path is a signal.
+    """
+    try:
+        return _HASHER.verify(password_hash, password)
+    except (Argon2Error, InvalidHashError):
+        # Argon2Error covers the mismatch and verification failures; InvalidHashError covers a
+        # stored value that is not an argon2 hash at all. Both mean "not authenticated", and
+        # neither is worth telling the client apart from the other.
+        return False

--- a/apps/api/src/openposture_api/security/tokens.py
+++ b/apps/api/src/openposture_api/security/tokens.py
@@ -1,0 +1,146 @@
+"""Access tokens (signed JWTs) and refresh tokens (opaque random strings).
+
+Two credentials, deliberately different in kind, because they answer different questions.
+
+**The access token is a signed claim, verified without a database.** That is its whole value —
+every request checks it in-process, so authentication costs no query. The price is that it cannot
+be withdrawn: a signed token stays valid until `exp`, whatever happens to the account meanwhile.
+Fifteen minutes is that window, and it is why the number in :class:`Settings` is small.
+
+**The refresh token is a random string with no meaning at all.** It says nothing; it is merely
+looked up. That makes it revocable — deleting the row ends it — which is exactly the property the
+access token trades away. It is stored hashed, so a database disclosure yields nothing usable.
+
+**Decoding always names the algorithm it will accept.** The header of a JWT is attacker-supplied
+data, and a decoder that trusts it can be handed `{"alg": "none"}` or an RS256 token whose
+"signature" is an HMAC keyed with the public key. `algorithms=[ALGORITHM]` is the one line that
+makes both unrepresentable rather than merely untested.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Final
+
+import jwt
+
+if TYPE_CHECKING:
+    from openposture_api.config import Settings
+
+__all__ = [
+    "ALGORITHM",
+    "REFRESH_TOKEN_BYTES",
+    "InvalidAccessTokenError",
+    "decode_access_token",
+    "hash_refresh_token",
+    "issue_access_token",
+    "issue_refresh_token",
+]
+
+ALGORITHM: Final = "HS256"
+"""The only algorithm this service signs or accepts.
+
+Symmetric, because the API is both issuer and verifier. An asymmetric algorithm exists to let a
+party verify without being able to sign, and there is no such party here — RS256 would add key
+management to buy a separation nothing in the system needs.
+"""
+
+REFRESH_TOKEN_BYTES: Final = 32
+"""256 bits from the OS random source.
+
+Large enough that the token has no guessable structure, which is the premise that lets
+:func:`hash_refresh_token` use a fast digest instead of a password hash.
+"""
+
+_REQUIRED_CLAIMS: Final = ["exp", "iat", "sub"]
+"""Claims that must be present, not merely valid if present.
+
+Without `require`, a token carrying no `exp` at all passes expiry validation — there is nothing
+to find expired. An absent claim and a satisfied claim must not look the same.
+"""
+
+
+class InvalidAccessTokenError(Exception):
+    """An access token that cannot be trusted, for any reason.
+
+    One exception for expired, tampered, malformed, wrongly-signed and wrong-algorithm tokens.
+    The caller returns 401 for all of them, and a client that could tell "expired" from "forged"
+    would learn which of its guesses were structurally correct.
+    """
+
+
+def issue_access_token(
+    *,
+    user_id: uuid.UUID,
+    settings: Settings,
+    issued_at: datetime | None = None,
+) -> str:
+    """Sign a short-lived access token identifying `user_id`.
+
+    `issued_at` is injectable so the suite can mint a token that expired an hour ago without
+    freezing the clock or sleeping. Production never passes it.
+
+    `sub` is the registered claim for "who this token is about", and it is a string by
+    specification — a UUID object is not JSON, and PyJWT would reject it rather than coerce.
+    """
+    now = issued_at if issued_at is not None else datetime.now(UTC)
+    claims = {
+        "sub": str(user_id),
+        "iat": now,
+        "exp": now + timedelta(minutes=settings.access_token_ttl_minutes),
+    }
+    return jwt.encode(claims, settings.jwt_secret.get_secret_value(), algorithm=ALGORITHM)
+
+
+def decode_access_token(token: str, *, settings: Settings) -> uuid.UUID:
+    """Verify a token and return the user it identifies.
+
+    Raises :class:`InvalidAccessTokenError` for every failure, including a well-signed token
+    whose `sub` is not a UUID — a valid signature over a nonsense subject is still nonsense, and
+    letting it through would hand a malformed identifier to the repository layer.
+    """
+    try:
+        claims = jwt.decode(
+            token,
+            settings.jwt_secret.get_secret_value(),
+            # The allowlist. Not derived from the token's own header, which is the entire point:
+            # `alg: none` and HS/RS confusion are both attacks in which the attacker chooses the
+            # verification algorithm, and here the attacker has no say in it.
+            algorithms=[ALGORITHM],
+            options={"require": _REQUIRED_CLAIMS},
+        )
+    except jwt.PyJWTError as exc:
+        raise InvalidAccessTokenError(str(exc)) from exc
+
+    try:
+        return uuid.UUID(claims["sub"])
+    except (KeyError, ValueError, AttributeError, TypeError) as exc:
+        raise InvalidAccessTokenError("subject is not a user identifier") from exc
+
+
+def issue_refresh_token() -> str:
+    """A new opaque refresh token, URL-safe so it survives a cookie unencoded.
+
+    `secrets`, never `random`: the latter is a Mersenne Twister seeded for reproducibility, and
+    observing a few of its outputs is enough to predict the rest. That is a fine property for a
+    simulation and a disqualifying one for a credential.
+    """
+    return secrets.token_urlsafe(REFRESH_TOKEN_BYTES)
+
+
+def hash_refresh_token(token: str) -> str:
+    """The digest stored in `refresh_tokens.token_hash`.
+
+    SHA-256 rather than argon2, and the reason is the input, not the speed. Argon2's cost exists
+    to make *guessing* expensive, which presupposes a search space small enough to guess —
+    human-chosen passwords. A 256-bit random token has no such space, so slowness would buy no
+    security while putting a deliberately expensive function on the path every client hits on a
+    timer.
+
+    A plain digest is also deterministic, which is required here: the refresh flow finds the row
+    *by* this value. A per-row salt would make lookup impossible without reading every row first.
+    """
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()

--- a/apps/api/tests/test_app_factory.py
+++ b/apps/api/tests/test_app_factory.py
@@ -10,12 +10,23 @@ from __future__ import annotations
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 from sqlalchemy.exc import NoSuchModuleError
 
 from openposture_api import __version__, main
 from openposture_api.config import Settings
 from openposture_api.main import create_app
 from openposture_api.pose import PoseBackendState, PoseBackendStatus
+
+
+def _production_settings() -> Settings:
+    """Production settings that get past OP-55's boot guard.
+
+    Production refuses to start on the repository's default signing key, so every production
+    `Settings` now has to supply one. These tests are about the factory, not about auth — the
+    secret is scaffolding, and naming it once keeps that obvious.
+    """
+    return Settings(environment="production", jwt_secret=SecretStr("test-only-signing-key"))
 
 
 class _RecordingBackend:
@@ -44,7 +55,7 @@ class TestConstruction:
     def test_two_apps_built_from_different_settings_are_independent(self) -> None:
         """The property that makes the suite order-independent: no shared module-level state."""
         development = create_app(Settings(environment="development", json_logs=True))
-        production = create_app(Settings(environment="production"))
+        production = create_app(_production_settings())
 
         assert development.state.settings.environment == "development"
         assert production.state.settings.environment == "production"
@@ -69,14 +80,14 @@ class TestDocumentation:
             assert client.get("/docs").status_code == 200
 
     def test_interactive_docs_are_absent_in_production(self) -> None:
-        app = create_app(Settings(environment="production"))
+        app = create_app(_production_settings())
         with TestClient(app) as client:
             assert client.get("/docs").status_code == 404
 
     def test_the_openapi_schema_is_served_regardless(self) -> None:
         """OP-45 generates the frontend's TypeScript types from this document, so it is a build
         input rather than a convenience route."""
-        app = create_app(Settings(environment="production"))
+        app = create_app(_production_settings())
         with TestClient(app) as client:
             schema = client.get("/openapi.json")
 

--- a/apps/api/tests/test_app_factory.py
+++ b/apps/api/tests/test_app_factory.py
@@ -26,7 +26,9 @@ def _production_settings() -> Settings:
     `Settings` now has to supply one. These tests are about the factory, not about auth — the
     secret is scaffolding, and naming it once keeps that obvious.
     """
-    return Settings(environment="production", jwt_secret=SecretStr("test-only-signing-key"))
+    return Settings(
+        environment="production", jwt_secret=SecretStr("test-only-signing-key-of-sufficient-length")
+    )
 
 
 class _RecordingBackend:

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -205,11 +205,31 @@ class TestAccountExistenceOracle:
         )
 
     def test_neither_response_names_the_field_that_was_wrong(self, client: TestClient) -> None:
+        """The message must blame both fields or neither, never one.
+
+        Naming a single field is an oracle in either direction, and the asymmetry is easy to
+        miss. "Email not found" obviously reveals that the address is unregistered. "Password
+        incorrect" reveals the opposite and is just as bad: it confirms the address *is*
+        registered, which is precisely what an attacker enumerating a list wants to learn.
+
+        Hence an equality between two membership tests rather than an implication. The earlier
+        version of this assertion read `"email" not in detail or "password" in detail`, which is
+        satisfied by "Password incorrect" — it passes on exactly the message it exists to catch.
+        """
         client.post(REGISTER, json=_credentials())
 
-        detail = client.post(LOGIN, json=_credentials(password="nope")).json()["detail"]
+        # Long enough to clear `MIN_PASSWORD_LENGTH`, and that is not incidental. An obviously
+        # bad password like "nope" is rejected by the schema with a 422 whose detail mentions
+        # neither field, so the assertion below would hold without the login route ever running.
+        # The earlier version did exactly that and was therefore vacuous.
+        rejected = client.post(LOGIN, json=_credentials(password="the-wrong-password"))
+        assert rejected.status_code == 401, "the request must reach the credential check"
 
-        assert "email" not in detail.lower() or "password" in detail.lower()
+        detail = rejected.json()["detail"].lower()
+
+        assert ("email" in detail) == ("password" in detail), (
+            f"{detail!r} singles out one credential, which tells the caller which half was wrong"
+        )
 
     def test_an_unknown_email_still_costs_a_password_hash(self, client: TestClient) -> None:
         """The timing half, asserted through the clock.

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -1,0 +1,424 @@
+"""The auth routes, exercised as a client sees them.
+
+These drive the real application over ASGI against a real (SQLite) database, because the
+properties under test are properties of the *endpoint*: what status came back, what the body
+said, what cookie was set and with which attributes. A unit test of the handler function would
+assert none of that.
+
+The abuse cases live here rather than in `test_tokens.py` because they are about the flow, not
+the primitive: replay, family revocation, and the account-existence oracle only exist once there
+is state to replay against.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import TYPE_CHECKING, Any
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from openposture_api.auth import AUTH_PREFIX
+from openposture_api.config import Settings
+from openposture_api.db import Base
+from openposture_api.db.models import RefreshToken, User
+from openposture_api.main import create_app
+from openposture_api.security import hash_refresh_token
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+
+    from fastapi import FastAPI
+
+EMAIL = "sam@example.com"
+PASSWORD = "a-sufficiently-long-password"
+
+REGISTER = f"{AUTH_PREFIX}/register"
+LOGIN = f"{AUTH_PREFIX}/login"
+REFRESH = f"{AUTH_PREFIX}/refresh"
+LOGOUT = f"{AUTH_PREFIX}/logout"
+
+
+@pytest.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """A fresh in-memory database with the real schema.
+
+    `StaticPool`-free: the URL is shared via a named in-memory database so the app's sessions and
+    the test's assertions see the same data, which two independent `:memory:` connections would
+    not.
+    """
+    engine = create_async_engine("sqlite+aiosqlite:///file::memory:?cache=shared&uri=true")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+@pytest.fixture
+def auth_app(session_factory: async_sessionmaker[AsyncSession]) -> FastAPI:
+    app = create_app(
+        Settings(
+            environment="test",
+            log_level="warning",
+            json_logs=True,
+            pose_backend="fake",
+            # `test` is not `development`, so the refresh cookie would be marked `Secure` — and a
+            # `Secure` cookie is never returned over the plain http `TestClient` speaks, which
+            # shows up as every refresh failing with 401 rather than as anything about transport.
+            # Overridden rather than relaxing the default: shipping `Secure` everywhere but a
+            # developer's machine is the behaviour worth keeping.
+            refresh_cookie_secure=False,
+        )
+    )
+    app.state.session_factory = session_factory
+    return app
+
+
+@pytest.fixture
+def client(
+    auth_app: FastAPI, session_factory: async_sessionmaker[AsyncSession]
+) -> Iterator[TestClient]:
+    """A client whose requests reach SQLite rather than the configured Postgres.
+
+    The reinstatement inside the context manager is the load-bearing part. `lifespan` builds an
+    engine from `settings.database_url` and overwrites whatever factory was on `app.state`, so
+    assigning before startup is silently undone — and the symptom is a DNS failure resolving the
+    Compose hostname, which points nowhere near this fixture.
+    """
+    with TestClient(auth_app, raise_server_exceptions=False) as test_client:
+        auth_app.state.session_factory = session_factory
+        yield test_client
+
+
+def _credentials(**overrides: str) -> dict[str, str]:
+    return {"email": EMAIL, "password": PASSWORD, **overrides}
+
+
+class TestRegistration:
+    def test_registering_returns_a_session(self, client: TestClient) -> None:
+        response = client.post(REGISTER, json=_credentials())
+
+        assert response.status_code == 201
+        body = response.json()
+        assert body["token_type"] == "bearer"
+        assert body["access_token"]
+        assert body["expires_in"] == 15 * 60
+
+    def test_registering_sets_an_httponly_refresh_cookie(self, client: TestClient) -> None:
+        """The criterion that makes "no token in localStorage" structural rather than a habit."""
+        response = client.post(REGISTER, json=_credentials())
+
+        cookie = response.headers["set-cookie"].lower()
+        assert "httponly" in cookie
+        assert "samesite=lax" in cookie
+        assert f"path={AUTH_PREFIX}" in cookie
+
+    def test_the_refresh_token_is_not_in_the_response_body(self, client: TestClient) -> None:
+        """A refresh token in the body is a refresh token the frontend can persist."""
+        body = client.post(REGISTER, json=_credentials()).json()
+
+        assert set(body) == {"access_token", "token_type", "expires_in"}
+
+    def test_a_duplicate_email_is_rejected(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        assert client.post(REGISTER, json=_credentials()).status_code == 409
+
+    def test_email_case_does_not_create_a_second_account(self, client: TestClient) -> None:
+        """`Sam@Example.com` and `sam@example.com` are one person, decided at the boundary."""
+        client.post(REGISTER, json=_credentials())
+
+        assert client.post(REGISTER, json=_credentials(email="SAM@EXAMPLE.COM")).status_code == 409
+
+    @pytest.mark.parametrize(
+        ("field", "value"),
+        [
+            ("password", "short"),
+            ("password", "x" * 129),
+            ("email", "not-an-email"),
+            ("email", ""),
+        ],
+    )
+    def test_invalid_credentials_are_rejected_before_any_hashing(
+        self, client: TestClient, field: str, value: str
+    ) -> None:
+        response = client.post(REGISTER, json=_credentials(**{field: value}))
+
+        assert response.status_code == 422
+
+    async def test_the_password_is_not_stored(
+        self, client: TestClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        async with session_factory() as session:
+            user = (await session.execute(select(User))).scalar_one()
+
+        assert PASSWORD not in user.password_hash
+        assert user.password_hash.startswith("$argon2id$")
+        assert user.email == EMAIL
+
+
+class TestLogin:
+    def test_the_right_password_signs_in(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+        client.cookies.clear()
+
+        assert client.post(LOGIN, json=_credentials()).status_code == 200
+
+    def test_email_case_does_not_prevent_signing_in(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        response = client.post(LOGIN, json=_credentials(email="Sam@Example.COM"))
+
+        assert response.status_code == 200
+
+    def test_the_wrong_password_is_rejected(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        response = client.post(LOGIN, json=_credentials(password="the-wrong-password"))
+
+        assert response.status_code == 401
+
+
+class TestAccountExistenceOracle:
+    """A failed sign-in must not reveal whether the address is registered.
+
+    ADR-0003 requires this, and it has to hold in both channels — what the response *says* and
+    how long it *takes*. Closing one and leaving the other open closes nothing.
+    """
+
+    def test_an_unknown_email_and_a_wrong_password_are_byte_identical(
+        self, client: TestClient
+    ) -> None:
+        client.post(REGISTER, json=_credentials())
+        client.cookies.clear()
+
+        wrong_password = client.post(LOGIN, json=_credentials(password="the-wrong-password"))
+        no_such_user = client.post(LOGIN, json=_credentials(email="nobody@example.com"))
+
+        assert wrong_password.status_code == no_such_user.status_code == 401
+        assert _without_request_id(wrong_password.json()) == _without_request_id(
+            no_such_user.json()
+        )
+
+    def test_neither_response_names_the_field_that_was_wrong(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        detail = client.post(LOGIN, json=_credentials(password="nope")).json()["detail"]
+
+        assert "email" not in detail.lower() or "password" in detail.lower()
+
+    def test_an_unknown_email_still_costs_a_password_hash(self, client: TestClient) -> None:
+        """The timing half, asserted through the clock.
+
+        A missing user that returned early would answer in well under a millisecond, against the
+        ~23 ms an argon2 verification costs. The bound here is deliberately loose — 5 ms — because
+        this asserts "work was done", not a precise duration, and a tight bound would make the
+        test fail on a slow CI runner for no security reason.
+        """
+        elapsed = _time_of(lambda: client.post(LOGIN, json=_credentials(email="ghost@example.com")))
+
+        assert elapsed > 0.005, (
+            f"an unknown email answered in {elapsed * 1000:.1f} ms, which is too fast to have "
+            "hashed anything — the early return is a timing oracle for account existence"
+        )
+
+    def test_a_known_and_unknown_email_take_comparable_time(self, client: TestClient) -> None:
+        """Not constant-time, but within the same order of magnitude.
+
+        The naive implementation differs by ~200x. A factor of 3 is well inside network jitter
+        and is what "equalised" means in practice.
+        """
+        client.post(REGISTER, json=_credentials())
+        client.cookies.clear()
+
+        known = _time_of(lambda: client.post(LOGIN, json=_credentials(password="wrong-password")))
+        unknown = _time_of(lambda: client.post(LOGIN, json=_credentials(email="ghost@here.com")))
+
+        ratio = max(known, unknown) / min(known, unknown)
+        assert ratio < 3.0, f"login timing differs by {ratio:.1f}x, which is an existence oracle"
+
+
+class TestRefreshRotation:
+    def test_refreshing_returns_a_new_access_token(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        response = client.post(REFRESH)
+
+        assert response.status_code == 200
+        assert response.json()["access_token"]
+
+    def test_refreshing_replaces_the_refresh_cookie(self, client: TestClient) -> None:
+        """Rotation. A refresh that returned a new access token and left the old refresh token
+        usable would make the whole mechanism decorative."""
+        client.post(REGISTER, json=_credentials())
+        original = client.cookies["openposture_refresh"]
+
+        client.post(REFRESH)
+
+        assert client.cookies["openposture_refresh"] != original
+
+    def test_refreshing_without_a_cookie_is_rejected(self, client: TestClient) -> None:
+        assert client.post(REFRESH).status_code == 401
+
+    def test_an_unknown_refresh_token_is_rejected(self, client: TestClient) -> None:
+        client.cookies.set("openposture_refresh", "a-token-nobody-ever-issued")
+
+        assert client.post(REFRESH).status_code == 401
+
+    async def test_only_the_hash_of_the_token_is_stored(
+        self, client: TestClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """The database-dump property: nothing stored is directly replayable."""
+        client.post(REGISTER, json=_credentials())
+        plaintext = client.cookies["openposture_refresh"]
+
+        async with session_factory() as session:
+            stored = (await session.execute(select(RefreshToken))).scalars().all()
+
+        assert len(stored) == 1
+        assert stored[0].token_hash != plaintext
+        assert stored[0].token_hash == hash_refresh_token(plaintext)
+
+    async def test_an_expired_refresh_token_is_rejected(
+        self, client: TestClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        async with session_factory() as session:
+            token = (await session.execute(select(RefreshToken))).scalar_one()
+            token.expires_at = datetime.now(UTC) - timedelta(days=1)
+            await session.commit()
+
+        assert client.post(REFRESH).status_code == 401
+
+
+class TestReplayDetection:
+    """The property the `family_id` column exists for.
+
+    A rotated token presented a second time means two parties hold it. Which of them is the
+    attacker is unknowable from here, so the safe reading is that the session is compromised and
+    both are logged out.
+    """
+
+    def test_reusing_a_rotated_token_is_rejected(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+        stolen = client.cookies["openposture_refresh"]
+        client.post(REFRESH)  # rotates; `stolen` is now retired
+
+        client.cookies.set("openposture_refresh", stolen)
+
+        assert client.post(REFRESH).status_code == 401
+
+    def test_reusing_a_rotated_token_revokes_the_whole_family(self, client: TestClient) -> None:
+        """The legitimate client's *current* token dies too, and that is the point.
+
+        Revoking only the replayed row would leave whichever party refreshed most recently in
+        possession of a working session — and there is no way to know that it is the victim.
+        """
+        client.post(REGISTER, json=_credentials())
+        stolen = client.cookies["openposture_refresh"]
+        client.post(REFRESH)
+        legitimate = client.cookies["openposture_refresh"]
+
+        client.cookies.set("openposture_refresh", stolen)
+        client.post(REFRESH)
+
+        client.cookies.set("openposture_refresh", legitimate)
+        assert client.post(REFRESH).status_code == 401, (
+            "the legitimate token survived a replay of its family — the attacker's copy and the "
+            "victim's copy are indistinguishable, so both must be revoked"
+        )
+
+    async def test_a_replay_revokes_every_token_in_the_family(
+        self, client: TestClient, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        client.post(REGISTER, json=_credentials())
+        stolen = client.cookies["openposture_refresh"]
+        client.post(REFRESH)
+        client.post(REFRESH)
+
+        client.cookies.set("openposture_refresh", stolen)
+        client.post(REFRESH)
+
+        async with session_factory() as session:
+            tokens = (await session.execute(select(RefreshToken))).scalars().all()
+
+        assert all(token.revoked_at is not None for token in tokens)
+
+    def test_a_replay_leaves_signing_in_again_possible(self, client: TestClient) -> None:
+        """Revocation must end sessions, not the account. The user re-authenticates."""
+        client.post(REGISTER, json=_credentials())
+        stolen = client.cookies["openposture_refresh"]
+        client.post(REFRESH)
+        client.cookies.set("openposture_refresh", stolen)
+        client.post(REFRESH)
+
+        client.cookies.clear()
+        assert client.post(LOGIN, json=_credentials()).status_code == 200
+
+
+class TestLogout:
+    def test_logging_out_succeeds(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        assert client.post(LOGOUT).status_code == 204
+
+    def test_logging_out_invalidates_the_refresh_token(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+        held = client.cookies["openposture_refresh"]
+
+        client.post(LOGOUT)
+
+        client.cookies.set("openposture_refresh", held)
+        assert client.post(REFRESH).status_code == 401
+
+    def test_logging_out_invalidates_the_whole_family(self, client: TestClient) -> None:
+        """ "Log out" means the session is over, including rotations performed elsewhere."""
+        client.post(REGISTER, json=_credentials())
+        first = client.cookies["openposture_refresh"]
+        client.post(REFRESH)
+
+        client.post(LOGOUT)
+
+        client.cookies.set("openposture_refresh", first)
+        assert client.post(REFRESH).status_code == 401
+
+    def test_logging_out_without_a_session_still_succeeds(self, client: TestClient) -> None:
+        """Idempotent, and deliberately not a token oracle. The caller wanted no session; there
+        is no session. Reporting that the token was already invalid would be information."""
+        assert client.post(LOGOUT).status_code == 204
+
+    def test_logging_out_clears_the_cookie(self, client: TestClient) -> None:
+        client.post(REGISTER, json=_credentials())
+
+        response = client.post(LOGOUT)
+
+        assert "openposture_refresh" in response.headers["set-cookie"]
+        assert 'openposture_refresh=""' in response.headers["set-cookie"]
+
+
+def _without_request_id(problem: dict[str, Any]) -> dict[str, Any]:
+    """Drop the correlation ID before comparing two error bodies.
+
+    `request_id` differs on every response by design and says nothing about the account — it is
+    the one field that is *supposed* to vary. Everything else must be identical, which is the
+    property being asserted.
+    """
+    return {key: value for key, value in problem.items() if key != "request_id"}
+
+
+def _time_of(call: Any) -> float:
+    """Wall-clock duration of one request, in seconds.
+
+    `perf_counter` rather than `time`, because it is monotonic and has far finer resolution —
+    the differences being measured here are milliseconds.
+    """
+    import time
+
+    started = time.perf_counter()
+    call()
+    return time.perf_counter() - started

--- a/apps/api/tests/test_auth.py
+++ b/apps/api/tests/test_auth.py
@@ -229,8 +229,11 @@ class TestAccountExistenceOracle:
     def test_a_known_and_unknown_email_take_comparable_time(self, client: TestClient) -> None:
         """Not constant-time, but within the same order of magnitude.
 
-        The naive implementation differs by ~200x. A factor of 3 is well inside network jitter
-        and is what "equalised" means in practice.
+        The bound is deliberately loose. The bug this catches is a ~200x difference — the early
+        return that skips hashing entirely — so a 5x threshold detects it with enormous margin
+        while leaving room for a shared CI runner to be descheduled mid-request. A tighter bound
+        would buy no additional detection and would fail on load, and a timing test that flakes
+        gets marked skip, which is worse than a loose one that does not.
         """
         client.post(REGISTER, json=_credentials())
         client.cookies.clear()
@@ -239,7 +242,7 @@ class TestAccountExistenceOracle:
         unknown = _time_of(lambda: client.post(LOGIN, json=_credentials(email="ghost@here.com")))
 
         ratio = max(known, unknown) / min(known, unknown)
-        assert ratio < 3.0, f"login timing differs by {ratio:.1f}x, which is an existence oracle"
+        assert ratio < 5.0, f"login timing differs by {ratio:.1f}x, which is an existence oracle"
 
 
 class TestRefreshRotation:
@@ -268,6 +271,36 @@ class TestRefreshRotation:
         client.cookies.set("openposture_refresh", "a-token-nobody-ever-issued")
 
         assert client.post(REFRESH).status_code == 401
+
+    def test_a_rejected_refresh_clears_the_dead_cookie(self, client: TestClient) -> None:
+        """Regression: the 401 used to keep the browser resending a token it can never use.
+
+        The first implementation `raise`d an `HTTPException` after writing the deletion to the
+        injected `Response`. Raising hands control to the error handler, which builds its own
+        response — so the `Set-Cookie` was written to an object that was then discarded, and the
+        clearing the code documented never reached the client.
+        """
+        client.cookies.set("openposture_refresh", "a-token-nobody-ever-issued")
+
+        response = client.post(REFRESH)
+
+        assert response.status_code == 401
+        assert "set-cookie" in response.headers, (
+            "the 401 sent no Set-Cookie, so the dead token stays in the browser and is resent "
+            "on every subsequent refresh"
+        )
+        assert 'openposture_refresh=""' in response.headers["set-cookie"]
+
+    def test_a_rejected_refresh_still_returns_an_rfc_9457_body(self, client: TestClient) -> None:
+        """Building the response by hand must not lose the error envelope the rest of the API
+        uses — that is the risk taken on by returning instead of raising."""
+        client.cookies.set("openposture_refresh", "a-token-nobody-ever-issued")
+
+        response = client.post(REFRESH)
+
+        assert response.headers["content-type"].startswith("application/problem+json")
+        assert response.json()["status"] == 401
+        assert response.json()["type"].endswith("/unauthorized")
 
     async def test_only_the_hash_of_the_token_is_stored(
         self, client: TestClient, session_factory: async_sessionmaker[AsyncSession]

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -8,9 +8,13 @@ happens to read the setting is the failure mode this layer exists to remove.
 from __future__ import annotations
 
 import pytest
-from pydantic import ValidationError
+from pydantic import SecretStr, ValidationError
 
-from openposture_api.config import ENV_PREFIX, Settings, get_settings
+from openposture_api.config import DEV_JWT_SECRET, ENV_PREFIX, Settings, get_settings
+
+A_REAL_SECRET = "a-secret-that-is-not-the-one-in-the-repository"
+"""Stands in for what a real deployment would set. Any value but :data:`DEV_JWT_SECRET` will do —
+which is precisely the property the production guard checks."""
 
 
 class TestDefaults:
@@ -33,7 +37,9 @@ class TestDefaults:
         assert settings.is_production is False
 
     def test_production_gets_json_logs_and_no_docs(self) -> None:
-        settings = Settings(environment="production", _env_file=None)  # type: ignore[call-arg]
+        settings = Settings(
+            environment="production", jwt_secret=SecretStr(A_REAL_SECRET), _env_file=None
+        )  # type: ignore[call-arg]
 
         assert settings.emit_json_logs is True
         assert settings.docs_url is None
@@ -41,7 +47,12 @@ class TestDefaults:
 
     def test_an_explicit_log_format_beats_the_environment_default(self) -> None:
         """The derived default must remain overridable, or it is a hardcoded rule."""
-        settings = Settings(environment="production", json_logs=False, _env_file=None)  # type: ignore[call-arg]
+        settings = Settings(  # type: ignore[call-arg]
+            environment="production",
+            json_logs=False,
+            jwt_secret=SecretStr(A_REAL_SECRET),
+            _env_file=None,
+        )
 
         assert settings.emit_json_logs is False
 
@@ -81,12 +92,70 @@ class TestValidation:
         assert settings.request_id_header == "X-Trace-Id"
 
 
+class TestJwtSecret:
+    """OP-55's boot guard: the dev signing key must never reach production.
+
+    The key is in the repository, so a production process running on it can have its access
+    tokens forged by anyone who can `git clone`. Nothing about the running service looks wrong
+    when this happens — the tokens verify — so startup is the only place it can be caught.
+    """
+
+    def test_development_boots_on_the_default_key(self) -> None:
+        """The convenience half of the trade-off: `docker compose up` needs no secret."""
+        settings = Settings(environment="development", _env_file=None)  # type: ignore[call-arg]
+
+        assert settings.jwt_secret.get_secret_value() == DEV_JWT_SECRET
+
+    def test_production_refuses_to_boot_on_the_default_key(self) -> None:
+        with pytest.raises(ValidationError) as caught:
+            Settings(environment="production", _env_file=None)  # type: ignore[call-arg]
+
+        assert f"{ENV_PREFIX}JWT_SECRET" in str(caught.value)
+
+    def test_production_boots_once_it_has_its_own_key(self) -> None:
+        """The guard must reject *the* default, not every production configuration."""
+        settings = Settings(
+            environment="production", jwt_secret=SecretStr(A_REAL_SECRET), _env_file=None
+        )  # type: ignore[call-arg]
+
+        assert settings.jwt_secret.get_secret_value() == A_REAL_SECRET
+
+    def test_the_secret_does_not_appear_in_the_settings_repr(self) -> None:
+        """`SecretStr` is why a logged or traceback-printed Settings cannot leak the key."""
+        settings = Settings(jwt_secret=SecretStr(A_REAL_SECRET), _env_file=None)  # type: ignore[call-arg]
+
+        assert A_REAL_SECRET not in repr(settings)
+
+
+class TestCookiePolicy:
+    def test_development_serves_the_cookie_over_plain_http(self) -> None:
+        """`Secure` on a localhost http origin means the browser silently drops the cookie."""
+        settings = Settings(environment="development", _env_file=None)  # type: ignore[call-arg]
+
+        assert settings.use_secure_cookies is False
+
+    def test_production_requires_https_for_the_cookie(self) -> None:
+        settings = Settings(
+            environment="production", jwt_secret=SecretStr(A_REAL_SECRET), _env_file=None
+        )  # type: ignore[call-arg]
+
+        assert settings.use_secure_cookies is True
+
+    def test_an_explicit_cookie_policy_beats_the_environment_default(self) -> None:
+        settings = Settings(  # type: ignore[call-arg]
+            environment="development", refresh_cookie_secure=True, _env_file=None
+        )
+
+        assert settings.use_secure_cookies is True
+
+
 class TestEnvironmentReading:
     def test_settings_come_from_the_prefixed_environment(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
         monkeypatch.setenv(f"{ENV_PREFIX}ENVIRONMENT", "production")
         monkeypatch.setenv(f"{ENV_PREFIX}LOG_LEVEL", "error")
+        monkeypatch.setenv(f"{ENV_PREFIX}JWT_SECRET", A_REAL_SECRET)
 
         settings = Settings(_env_file=None)  # type: ignore[call-arg]
 

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -120,6 +120,23 @@ class TestJwtSecret:
 
         assert settings.jwt_secret.get_secret_value() == A_REAL_SECRET
 
+    @pytest.mark.parametrize("short", ["", "hunter2", "x" * 31])
+    def test_a_key_shorter_than_the_hash_is_rejected(self, short: str) -> None:
+        """RFC 7518 §3.2: an HMAC key must be at least the hash's output size — 32 bytes here.
+
+        A shorter key is the weakest part of the scheme rather than the algorithm, and it is
+        brute-forceable offline from one captured token, after which every token is forgeable.
+        PyJWT emits a warning about this; a warning that nobody is watching is not a control.
+        """
+        with pytest.raises(ValidationError) as caught:
+            Settings(jwt_secret=SecretStr(short), _env_file=None)  # type: ignore[call-arg]
+
+        assert "jwt_secret" in str(caught.value)
+
+    def test_the_shipped_default_clears_the_length_bar(self) -> None:
+        """Otherwise development would be unable to boot on its own default."""
+        assert len(DEV_JWT_SECRET) >= 32
+
     def test_the_secret_does_not_appear_in_the_settings_repr(self) -> None:
         """`SecretStr` is why a logged or traceback-printed Settings cannot leak the key."""
         settings = Settings(jwt_secret=SecretStr(A_REAL_SECRET), _env_file=None)  # type: ignore[call-arg]

--- a/apps/api/tests/test_passwords.py
+++ b/apps/api/tests/test_passwords.py
@@ -1,0 +1,87 @@
+"""Password hashing: the properties, not the algorithm.
+
+These tests deliberately assert nothing about argon2's internals. They pin the four things the
+rest of the system relies on — no plaintext at rest, salted, verifiable, and failing closed —
+so that retuning the parameters, or one day replacing the algorithm entirely, breaks nothing here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openposture_api.security import hash_password, verify_password
+
+PASSWORD = "correct horse battery staple"
+
+
+class TestHashing:
+    def test_the_hash_does_not_contain_the_password(self) -> None:
+        """The property the whole layer exists for: a database dump is not a password list."""
+        assert PASSWORD not in hash_password(PASSWORD)
+
+    def test_the_same_password_hashes_differently_every_time(self) -> None:
+        """A fresh random salt per hash.
+
+        Without it, identical hashes would reveal which users share a password, and one
+        precomputed table would cover every account in the database at once.
+        """
+        assert hash_password(PASSWORD) != hash_password(PASSWORD)
+
+    def test_the_hash_is_self_describing(self) -> None:
+        """Parameters travel with the hash, which is why retuning them is not a migration."""
+        assert hash_password(PASSWORD).startswith("$argon2id$")
+
+
+class TestVerification:
+    def test_the_right_password_verifies(self) -> None:
+        assert verify_password(hash_password(PASSWORD), PASSWORD) is True
+
+    def test_the_wrong_password_does_not_verify(self) -> None:
+        assert verify_password(hash_password(PASSWORD), "not the password") is False
+
+    def test_verification_is_case_sensitive(self) -> None:
+        assert verify_password(hash_password(PASSWORD), PASSWORD.upper()) is False
+
+    def test_two_hashes_of_one_password_both_verify(self) -> None:
+        """Different salts, same password — the salt must not make a hash unverifiable."""
+        assert verify_password(hash_password(PASSWORD), PASSWORD) is True
+        assert verify_password(hash_password(PASSWORD), PASSWORD) is True
+
+
+class TestFailingClosed:
+    """Every failure is the same failure.
+
+    ADR-0003 requires that sign-in never reveal whether an email is registered. A caller that
+    has to tell "wrong password" from "corrupt hash" is a caller with two paths that can diverge
+    into an oracle, so this layer collapses them into one `False` before the route can.
+    """
+
+    @pytest.mark.parametrize(
+        ("stored", "why"),
+        [
+            ("", "empty column"),
+            ("not-a-hash-at-all", "plaintext left by a bad migration"),
+            ("$argon2id$v=19$m=65536,t=3,p=4$truncated", "a hash cut short in transit"),
+            ("$2b$12$abcdefghijklmnopqrstuv", "a bcrypt hash from another system"),
+        ],
+    )
+    def test_an_unusable_stored_hash_returns_false_rather_than_raising(
+        self, stored: str, why: str
+    ) -> None:
+        """A raise here would be a 500, and a 500 on some accounts but not others is an oracle.
+
+        `InvalidHashError` subclasses `ValueError`, not `Argon2Error`, so this is the case a
+        single `except Argon2Error` would miss — and it would miss it as a crash, not a denial.
+        """
+        assert verify_password(stored, PASSWORD) is False, why
+
+    def test_an_empty_password_does_not_verify(self) -> None:
+        assert verify_password(hash_password(PASSWORD), "") is False
+
+    def test_an_empty_password_can_still_be_hashed_and_verified(self) -> None:
+        """Rejecting empty passwords is the schema's job, not the hasher's.
+
+        Pinned so that the length rule stays at the boundary where it can produce a 422 naming
+        the field, rather than being silently duplicated down here.
+        """
+        assert verify_password(hash_password(""), "") is True

--- a/apps/api/tests/test_tokens.py
+++ b/apps/api/tests/test_tokens.py
@@ -1,0 +1,213 @@
+"""Token abuse cases, built as attacks rather than asserted as intentions.
+
+Each test here forges something. That is deliberate: a comment claiming `alg: none` is rejected
+is a wish, and a test that constructs an `alg: none` token and watches it bounce is a guarantee.
+These run against the functions directly — no client, no database, no network — which is what
+lets the whole suite stay inside `pr.yml`'s no-service, no-secret rule.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import jwt
+import pytest
+from pydantic import SecretStr
+
+from openposture_api.config import Settings
+from openposture_api.security import (
+    ALGORITHM,
+    REFRESH_TOKEN_BYTES,
+    InvalidAccessTokenError,
+    decode_access_token,
+    hash_refresh_token,
+    issue_access_token,
+    issue_refresh_token,
+)
+
+SECRET = "test-only-signing-key-long-enough-for-hs512-and-hs256-alike-0123456789"
+USER_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(environment="test", jwt_secret=SecretStr(SECRET))
+
+
+class TestRoundTrip:
+    def test_a_freshly_issued_token_identifies_its_user(self, settings: Settings) -> None:
+        token = issue_access_token(user_id=USER_ID, settings=settings)
+
+        assert decode_access_token(token, settings=settings) == USER_ID
+
+    def test_the_token_carries_the_configured_lifetime(self, settings: Settings) -> None:
+        """15 minutes is a security parameter, not a default — worth pinning to the setting."""
+        issued = datetime.now(UTC)
+        token = issue_access_token(user_id=USER_ID, settings=settings, issued_at=issued)
+
+        claims = jwt.decode(token, SECRET, algorithms=[ALGORITHM])
+        lifetime = claims["exp"] - claims["iat"]
+
+        assert lifetime == settings.access_token_ttl_minutes * 60
+
+    def test_the_token_body_is_readable_by_anyone(self, settings: Settings) -> None:
+        """A JWT is signed, not encrypted. Pinned so nobody ever puts a secret in a claim."""
+        token = issue_access_token(user_id=USER_ID, settings=settings)
+
+        unverified = jwt.decode(token, options={"verify_signature": False})
+
+        assert unverified["sub"] == str(USER_ID)
+
+
+class TestExpiry:
+    def test_an_expired_token_is_rejected(self, settings: Settings) -> None:
+        """Injecting `issued_at` beats sleeping for fifteen minutes or freezing the clock."""
+        long_ago = datetime.now(UTC) - timedelta(hours=1)
+        token = issue_access_token(user_id=USER_ID, settings=settings, issued_at=long_ago)
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(token, settings=settings)
+
+    def test_a_token_with_no_expiry_is_rejected(self, settings: Settings) -> None:
+        """The claim that cannot be checked if it is absent.
+
+        Without `require`, expiry validation on a token carrying no `exp` finds nothing to
+        object to and passes — which produces a token that never expires.
+        """
+        forged = jwt.encode({"sub": str(USER_ID), "iat": datetime.now(UTC)}, SECRET, ALGORITHM)
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(forged, settings=settings)
+
+
+class TestTampering:
+    def test_a_token_signed_with_another_key_is_rejected(self, settings: Settings) -> None:
+        """The attacker who guessed the claim structure but not the secret."""
+        forged = jwt.encode(
+            {"sub": str(USER_ID), "iat": datetime.now(UTC), "exp": _soon()},
+            "not-our-signing-key-but-equally-long-0123456789012345678901234567890",
+            ALGORITHM,
+        )
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(forged, settings=settings)
+
+    def test_an_edited_payload_is_rejected(self, settings: Settings) -> None:
+        """Swap the subject for someone else's and the signature no longer covers the body."""
+        victim = uuid.UUID("22222222-2222-2222-2222-222222222222")
+        header, _, signature = issue_access_token(user_id=USER_ID, settings=settings).split(".")
+        substitute = jwt.encode(
+            {"sub": str(victim), "iat": datetime.now(UTC), "exp": _soon()}, SECRET, ALGORITHM
+        ).split(".")[1]
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(f"{header}.{substitute}.{signature}", settings=settings)
+
+    @pytest.mark.parametrize(
+        "garbage",
+        ["", "not-a-token", "a.b.c", "....", "eyJhbGciOiJIUzI1NiJ9"],
+        ids=["empty", "no-dots", "three-junk-segments", "only-dots", "header-only"],
+    )
+    def test_a_malformed_token_is_rejected_rather_than_raising(
+        self, garbage: str, settings: Settings
+    ) -> None:
+        """Every shape of nonsense arrives as the same domain error, so the route has one path."""
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(garbage, settings=settings)
+
+    def test_a_valid_signature_over_a_nonsense_subject_is_rejected(
+        self, settings: Settings
+    ) -> None:
+        """We signed it, so it verifies — and it still must not reach the repository layer."""
+        forged = jwt.encode(
+            {"sub": "not-a-uuid", "iat": datetime.now(UTC), "exp": _soon()}, SECRET, ALGORITHM
+        )
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(forged, settings=settings)
+
+
+class TestAlgorithmConfusion:
+    """The attacks where the *attacker* picks the verification algorithm.
+
+    Both work against a decoder that reads `alg` from the token's own header and believes it.
+    The header is attacker-supplied data; treating it as instructions is the bug.
+    """
+
+    def test_an_unsigned_token_is_rejected(self, settings: Settings) -> None:
+        """`alg: none` — the classic. The token declares it needs no signature, and a trusting
+        decoder agrees with it."""
+        unsigned = jwt.encode(
+            {"sub": str(USER_ID), "iat": datetime.now(UTC), "exp": _soon()},
+            key="",
+            algorithm="none",
+        )
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(unsigned, settings=settings)
+
+    def test_a_token_declaring_a_different_hmac_is_rejected(self, settings: Settings) -> None:
+        """HS512 is signed with our real secret, and is still not the algorithm we accept."""
+        forged = jwt.encode(
+            {"sub": str(USER_ID), "iat": datetime.now(UTC), "exp": _soon()}, SECRET, "HS512"
+        )
+
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(forged, settings=settings)
+
+    def test_the_decoder_does_not_consult_the_token_header(self, settings: Settings) -> None:
+        """The property underneath both attacks above, asserted directly.
+
+        An `alg: none` token *says* it is unsigned. If the header were consulted, that claim
+        would be honoured. The allowlist is what makes the header advisory rather than binding.
+        """
+        unsigned = jwt.encode({"sub": str(USER_ID)}, key="", algorithm="none")
+
+        assert jwt.get_unverified_header(unsigned)["alg"] == "none"
+        with pytest.raises(InvalidAccessTokenError):
+            decode_access_token(unsigned, settings=settings)
+
+
+class TestRefreshTokens:
+    def test_every_token_is_different(self) -> None:
+        assert len({issue_refresh_token() for _ in range(100)}) == 100
+
+    def test_the_token_carries_the_intended_entropy(self) -> None:
+        """`token_urlsafe` returns base64url, so the string is longer than the byte count.
+
+        Asserted as a lower bound on length rather than an equality, because the encoding's
+        padding behaviour is not the property that matters — the 256 bits underneath it is.
+        """
+        assert len(issue_refresh_token()) >= REFRESH_TOKEN_BYTES
+
+    def test_the_token_survives_a_cookie_unencoded(self) -> None:
+        """`+` and `/` from standard base64 would need escaping in a Set-Cookie header."""
+        token = issue_refresh_token()
+
+        assert "+" not in token
+        assert "/" not in token
+        assert "=" not in token
+
+    def test_the_hash_does_not_contain_the_token(self) -> None:
+        """The database-dump property: nothing stored is directly replayable."""
+        token = issue_refresh_token()
+
+        assert token not in hash_refresh_token(token)
+
+    def test_hashing_is_deterministic(self) -> None:
+        """Required, not incidental: the refresh flow finds the row *by* this value."""
+        token = issue_refresh_token()
+
+        assert hash_refresh_token(token) == hash_refresh_token(token)
+
+    def test_different_tokens_hash_differently(self) -> None:
+        assert hash_refresh_token(issue_refresh_token()) != hash_refresh_token(
+            issue_refresh_token()
+        )
+
+
+def _soon() -> datetime:
+    """An expiry comfortably in the future, so a forged token fails on its signature or its
+    algorithm rather than incidentally on its age."""
+    return datetime.now(UTC) + timedelta(minutes=5)

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -247,6 +247,32 @@
         "title": "Body_create_analysis_api_v1_analyses_post",
         "type": "object"
       },
+      "CredentialsRequest": {
+        "additionalProperties": false,
+        "description": "The body of `POST /auth/register` and `POST /auth/login`.\n\nOne model for both, because the two must validate identically. If registration accepted a\npassword that login rejected, an account could be created and never used again.",
+        "properties": {
+          "email": {
+            "description": "Address to register or sign in with. Compared case-insensitively.",
+            "format": "email",
+            "maxLength": 320,
+            "title": "Email",
+            "type": "string"
+          },
+          "password": {
+            "description": "At least 12 characters. Length is the only property checked \u2014 no character-class rule, which pushes people towards `Password1!` and away from a long passphrase.",
+            "maxLength": 128,
+            "minLength": 12,
+            "title": "Password",
+            "type": "string"
+          }
+        },
+        "required": [
+          "email",
+          "password"
+        ],
+        "title": "CredentialsRequest",
+        "type": "object"
+      },
       "DetectedLandmark": {
         "additionalProperties": false,
         "description": "One measured point, in the form a client needs to draw it.\n\n**Normalised to the image, not in pixels.** The frontend renders the photo at whatever size\nthe viewport allows, so a pixel coordinate would be wrong the moment the layout changed. `x`\nand `y` are fractions of width and height, which stay correct under any scale \u2014 the same\nreasoning as the world-space metrics, applied to presentation.\n\nWorld coordinates are deliberately absent: they are metres from the hip and mean nothing on\na 2D canvas.",
@@ -778,6 +804,35 @@
         "title": "StoredMetric",
         "type": "object"
       },
+      "TokenResponse": {
+        "additionalProperties": false,
+        "description": "What every successful auth route returns.\n\n**The refresh token is deliberately not here.** It goes back as an `HttpOnly` cookie and\nappears in no response body anywhere, which is what makes \"no token in `localStorage`\"\na property of the API rather than a rule the frontend has to keep remembering.",
+        "properties": {
+          "access_token": {
+            "description": "Bearer token. Hold in memory only; never persist it.",
+            "title": "Access Token",
+            "type": "string"
+          },
+          "expires_in": {
+            "description": "Seconds until the access token expires. Sent so the client can refresh *before* expiry rather than discovering it through a failed request.",
+            "title": "Expires In",
+            "type": "integer"
+          },
+          "token_type": {
+            "const": "bearer",
+            "default": "bearer",
+            "description": "RFC 6750 scheme, so the client sends `Authorization: Bearer <token>`.",
+            "title": "Token Type",
+            "type": "string"
+          }
+        },
+        "required": [
+          "access_token",
+          "expires_in"
+        ],
+        "title": "TokenResponse",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -1030,6 +1085,128 @@
         "summary": "Fetch one analysis",
         "tags": [
           "analyses"
+        ]
+      }
+    },
+    "/api/v1/auth/login": {
+      "post": {
+        "operationId": "login_api_v1_auth_login_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Credentials rejected."
+          },
+          "422": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/HTTPValidationError"
+                }
+              }
+            },
+            "description": "Validation Error"
+          }
+        },
+        "summary": "Sign in",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/logout": {
+      "post": {
+        "description": "Revoke the whole family and clear the cookie.\n\nAlways 204, even when the cookie is absent or unrecognised. Logging out is not a place to\nreport that a token was already invalid \u2014 the caller wanted no session, and afterwards\nthere is no session. Reporting the difference would turn logout into a token oracle.\n\nThe family, not just the presented token, because \"log out\" means the session is over. A\nrotation the client had already performed elsewhere must not survive it.",
+        "operationId": "logout_api_v1_auth_logout_post",
+        "responses": {
+          "204": {
+            "description": "Successful Response"
+          }
+        },
+        "summary": "End the session on every device",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/refresh": {
+      "post": {
+        "description": "Rotate the refresh token and mint a new access token.\n\nThe presented token is always retired, whatever else happens. A refresh that returned a\nnew token while leaving the old one usable would make rotation decorative.",
+        "operationId": "refresh_api_v1_auth_refresh_post",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "The refresh token is missing, expired, unknown or already used."
+          }
+        },
+        "summary": "Exchange a refresh token for a new access token",
+        "tags": [
+          "auth"
+        ]
+      }
+    },
+    "/api/v1/auth/register": {
+      "post": {
+        "description": "Register, then immediately issue a session \u2014 nobody wants to log in twice.\n\n**This route does leak whether an address is registered**, via the 409, and that is a\nknown gap rather than an oversight. Closing it means always returning 201 and sending a\n\"somebody tried to register your address\" email, and ADR-0003 records that this project\nhas no outbound mail path. The alternative \u2014 a 201 that silently creates nothing \u2014 lies\nto legitimate users about whether they have an account, which is worse.",
+        "operationId": "register_api_v1_auth_register_post",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/CredentialsRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "201": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TokenResponse"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "409": {
+            "description": "That email is already registered."
+          },
+          "422": {
+            "description": "Password or email rejected."
+          }
+        },
+        "summary": "Create an account and sign in",
+        "tags": [
+          "auth"
         ]
       }
     },

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -52,6 +52,99 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/auth/login": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /** Sign in */
+        post: operations["login_api_v1_auth_login_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/logout": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * End the session on every device
+         * @description Revoke the whole family and clear the cookie.
+         *
+         *     Always 204, even when the cookie is absent or unrecognised. Logging out is not a place to
+         *     report that a token was already invalid — the caller wanted no session, and afterwards
+         *     there is no session. Reporting the difference would turn logout into a token oracle.
+         *
+         *     The family, not just the presented token, because "log out" means the session is over. A
+         *     rotation the client had already performed elsewhere must not survive it.
+         */
+        post: operations["logout_api_v1_auth_logout_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/refresh": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Exchange a refresh token for a new access token
+         * @description Rotate the refresh token and mint a new access token.
+         *
+         *     The presented token is always retired, whatever else happens. A refresh that returned a
+         *     new token while leaving the old one usable would make rotation decorative.
+         */
+        post: operations["refresh_api_v1_auth_refresh_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
+    "/api/v1/auth/register": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        get?: never;
+        put?: never;
+        /**
+         * Create an account and sign in
+         * @description Register, then immediately issue a session — nobody wants to log in twice.
+         *
+         *     **This route does leak whether an address is registered**, via the 409, and that is a
+         *     known gap rather than an oversight. Closing it means always returning 201 and sending a
+         *     "somebody tried to register your address" email, and ADR-0003 records that this project
+         *     has no outbound mail path. The alternative — a 201 that silently creates nothing — lies
+         *     to legitimate users about whether they have an account, which is worse.
+         */
+        post: operations["register_api_v1_auth_register_post"];
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/health": {
         parameters: {
             query?: never;
@@ -207,6 +300,26 @@ export interface components {
              * @description The photograph to analyse.
              */
             image: string;
+        };
+        /**
+         * CredentialsRequest
+         * @description The body of `POST /auth/register` and `POST /auth/login`.
+         *
+         *     One model for both, because the two must validate identically. If registration accepted a
+         *     password that login rejected, an account could be created and never used again.
+         */
+        CredentialsRequest: {
+            /**
+             * Email
+             * Format: email
+             * @description Address to register or sign in with. Compared case-insensitively.
+             */
+            email: string;
+            /**
+             * Password
+             * @description At least 12 characters. Length is the only property checked — no character-class rule, which pushes people towards `Password1!` and away from a long passphrase.
+             */
+            password: string;
         };
         /**
          * DetectedLandmark
@@ -468,6 +581,33 @@ export interface components {
             /** Value */
             value: number | null;
         };
+        /**
+         * TokenResponse
+         * @description What every successful auth route returns.
+         *
+         *     **The refresh token is deliberately not here.** It goes back as an `HttpOnly` cookie and
+         *     appears in no response body anywhere, which is what makes "no token in `localStorage`"
+         *     a property of the API rather than a rule the frontend has to keep remembering.
+         */
+        TokenResponse: {
+            /**
+             * Access Token
+             * @description Bearer token. Hold in memory only; never persist it.
+             */
+            access_token: string;
+            /**
+             * Expires In
+             * @description Seconds until the access token expires. Sent so the client can refresh *before* expiry rather than discovering it through a failed request.
+             */
+            expires_in: number;
+            /**
+             * Token Type
+             * @description RFC 6750 scheme, so the client sends `Authorization: Bearer <token>`.
+             * @default bearer
+             * @constant
+             */
+            token_type: "bearer";
+        };
         /** ValidationError */
         ValidationError: {
             /** Context */
@@ -663,6 +803,129 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+        };
+    };
+    login_api_v1_auth_login_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CredentialsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            /** @description Credentials rejected. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Validation Error */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["HTTPValidationError"];
+                };
+            };
+        };
+    };
+    logout_api_v1_auth_logout_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            204: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    refresh_api_v1_auth_refresh_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            /** @description The refresh token is missing, expired, unknown or already used. */
+            401: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    register_api_v1_auth_register_post: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody: {
+            content: {
+                "application/json": components["schemas"]["CredentialsRequest"];
+            };
+        };
+        responses: {
+            /** @description Successful Response */
+            201: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TokenResponse"];
+                };
+            };
+            /** @description That email is already registered. */
+            409: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+            /** @description Password or email rejected. */
+            422: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/apps/web/src/auth/noTokenStorage.test.tsx
+++ b/apps/web/src/auth/noTokenStorage.test.tsx
@@ -1,0 +1,169 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { AuthProvider, useAuth } from '.'
+
+/**
+ * OP-55: no token may ever reach `localStorage` or `sessionStorage`.
+ *
+ * The reason is XSS. Anything in web storage is readable by any script that runs on the page, so
+ * one injected script turns into a stolen credential — and if that credential is a 30-day refresh
+ * token, into permanent account control. The API side of this is settled by construction: the
+ * refresh token is delivered `HttpOnly`, so JavaScript cannot read it even deliberately, and it
+ * appears in no response body. What remains is the access token, which the client *does* hold,
+ * and which must live in a variable that dies with the tab.
+ *
+ * Two layers here, because they fail in different ways:
+ *
+ *   1. A scan of the source tree, which catches a `localStorage.setItem` written anywhere —
+ *      including in a component nobody thought to write an auth test for.
+ *   2. A runtime spy over the real flows, which catches a token reaching storage through a
+ *      helper, a library, or a key the scan does not recognise.
+ *
+ * Note this does not forbid web storage outright. The provider legitimately keeps the *user
+ * profile* — id, email, display name — in `sessionStorage` so a reload does not flash the login
+ * page. None of that is a credential. The rule is about tokens, and a blanket ban would be both
+ * wrong and easy to work around.
+ */
+
+/**
+ * Every application source file, as text.
+ *
+ * `import.meta.glob` with `?raw` rather than `node:fs`, because this file is compiled by
+ * `tsconfig.app.json`, whose `types` deliberately exclude Node — browser code has no business
+ * reaching for the filesystem, and adding `"node"` there to satisfy one test would remove that
+ * guarantee for everything else. Vite resolves this at build time and `vite/client` types it, so
+ * the scan works with the config exactly as it is.
+ */
+const SOURCES: Record<string, string> = import.meta.glob('../**/*.{ts,tsx}', {
+  query: '?raw',
+  import: 'default',
+  eager: true,
+})
+
+/** Values that must never be handed to a storage API, however they are spelled. */
+const TOKEN_KEY_PATTERN = /token|jwt|bearer|credential|password|secret/i
+
+/** `header.payload.signature` — the shape of a JWT, regardless of the key it is stored under. */
+const JWT_PATTERN = /^[\w-]+\.[\w-]+\.[\w-]+$/
+
+/**
+ * The application's own source, excluding tests.
+ *
+ * Test files are excluded deliberately: `auth.test.tsx` seeds `sessionStorage` to prove a session
+ * survives a reload, and this file names both APIs in order to forbid them.
+ */
+function applicationSources(): Array<[string, string]> {
+  return Object.entries(SOURCES).filter(([path]) => !/\.test\.tsx?$/.test(path))
+}
+
+describe('no credential reaches web storage', () => {
+  it('never mentions localStorage anywhere in the application source', () => {
+    // The stronger half of the rule, and the cheaper one to keep true. `sessionStorage` at least
+    // dies with the tab; `localStorage` persists indefinitely, so a token written there outlives
+    // every session that could have justified it. Nothing in this app has a reason to use it.
+    const offenders = applicationSources()
+      .filter(([, source]) => source.includes('localStorage'))
+      .map(([path]) => path)
+
+    expect(offenders, `localStorage is used in: ${offenders.join(', ')}`).toEqual([])
+  })
+
+  it('never writes a credential-shaped key to sessionStorage', () => {
+    // The *key argument* of each `setItem` call, not the whole file. A file-wide search matches
+    // `InMemoryAuthProvider`, which mentions `sessionStorage` and separately declares a
+    // `password` field — two unrelated facts that a coarse scan reads as one problem. A check
+    // that cries wolf gets deleted, so it has to look at what is actually being stored.
+    const offenders = applicationSources().flatMap(([path, source]) =>
+      [...source.matchAll(/(?:local|session)Storage\.setItem\(\s*([^,]+)/g)]
+        // `match[1]` is optional to TypeScript because a group *can* be unmatched; here the
+        // group is not optional in the pattern, so `?? ''` states that rather than asserting it.
+        .map((match) => (match[1] ?? '').trim())
+        .filter((key) => TOKEN_KEY_PATTERN.test(key))
+        .map((key) => `${path}: ${key}`),
+    )
+
+    expect(offenders, `a credential may be stored in: ${offenders.join(', ')}`).toEqual([])
+  })
+})
+
+describe('the auth flows store no token at runtime', () => {
+  afterEach(() => {
+    // The spy patches a global prototype, so leaving it in place would follow the suite into
+    // every later file — the kind of leak that surfaces as an unrelated test failing only when
+    // the whole suite runs.
+    vi.restoreAllMocks()
+  })
+
+  /**
+   * Watches both storage APIs and records everything written.
+   *
+   * Spying rather than reading the store afterwards, because a value written and then removed
+   * would leave nothing to find — and a token that exists in storage for only a moment is still
+   * a token any script on the page could have read.
+   */
+  function watchStorage() {
+    const writes: Array<[string, string]> = []
+    // Captured before the spy replaces it, so the real write still happens. A spy that swallowed
+    // the call would leave the provider unable to read its own session back, and the test would
+    // then be exercising a different application from the one that ships.
+    const write = Storage.prototype.setItem
+
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(function (
+      this: Storage,
+      key: string,
+      value: string,
+    ) {
+      writes.push([key, value])
+      write.call(this, key, value)
+    })
+
+    return writes
+  }
+
+  async function renderAuth() {
+    const view = renderHook(() => useAuth(), {
+      wrapper: ({ children }: { children: ReactNode }) => <AuthProvider>{children}</AuthProvider>,
+    })
+    await waitFor(() => {
+      expect(view.result.current.checking).toBe(false)
+    })
+    return view
+  }
+
+  it('stores nothing token-shaped while signing up and signing in', async () => {
+    const writes = watchStorage()
+    const { result } = await renderAuth()
+
+    await act(async () => {
+      await result.current.signUp('ada@example.com', 'correct-horse', 'Ada')
+    })
+    await act(async () => {
+      await result.current.signOut()
+    })
+    await act(async () => {
+      await result.current.signIn('ada@example.com', 'correct-horse')
+    })
+
+    for (const [key, value] of writes) {
+      expect(key, `"${key}" names a credential`).not.toMatch(TOKEN_KEY_PATTERN)
+      expect(value, `a JWT was written under "${key}"`).not.toMatch(JWT_PATTERN)
+      expect(value, `a JWT was embedded in the value under "${key}"`).not.toContain('eyJ')
+    }
+  })
+
+  it('stores no password, even though the in-memory provider holds one in memory', async () => {
+    // The provider keeps a password in a Map to compare against — acceptable for a placeholder
+    // with no backend. Writing one to disk would not be, and this is what separates the two.
+    const writes = watchStorage()
+    const { result } = await renderAuth()
+
+    await act(async () => {
+      await result.current.signUp('ada@example.com', 'correct-horse', 'Ada')
+    })
+
+    for (const [key, value] of writes) {
+      expect(value, `a password was written under "${key}"`).not.toContain('correct-horse')
+    }
+  })
+})

--- a/apps/web/src/auth/noTokenStorage.test.tsx
+++ b/apps/web/src/auth/noTokenStorage.test.tsx
@@ -48,13 +48,23 @@ const TOKEN_KEY_PATTERN = /token|jwt|bearer|credential|password|secret/i
 const JWT_PATTERN = /^[\w-]+\.[\w-]+\.[\w-]+$/
 
 /**
- * The application's own source, excluding tests.
+ * The application's own source: hand-written, executable TypeScript.
  *
- * Test files are excluded deliberately: `auth.test.tsx` seeds `sessionStorage` to prove a session
- * survives a reload, and this file names both APIs in order to forbid them.
+ * Two exclusions, both necessary rather than convenient.
+ *
+ * Test files, because `auth.test.tsx` seeds `sessionStorage` to prove a session survives a
+ * reload, and this file names both APIs in order to forbid them.
+ *
+ * `.d.ts` files, because they are generated from the OpenAPI document and contain no executable
+ * code — only type declarations and the API's own prose. `TokenResponse`'s description explains
+ * that the refresh token is kept out of the body so nothing lands in `localStorage`, and
+ * `openapi-typescript` copies that sentence verbatim into `schema.d.ts`. Matching it there is a
+ * scan reading documentation as behaviour.
  */
 function applicationSources(): Array<[string, string]> {
-  return Object.entries(SOURCES).filter(([path]) => !/\.test\.tsx?$/.test(path))
+  return Object.entries(SOURCES).filter(
+    ([path]) => !/\.test\.tsx?$/.test(path) && !/\.d\.ts$/.test(path),
+  )
 }
 
 describe('no credential reaches web storage', () => {

--- a/uv.lock
+++ b/uv.lock
@@ -696,6 +696,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dnspython"
+version = "2.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8c/8b/57666417c0f90f08bcafa776861060426765fdb422eb10212086fb811d26/dnspython-2.8.0.tar.gz", hash = "sha256:181d3c6996452cb1189c4046c61599b84a5a86e099562ffde77d26984ff26d0f", size = 368251, upload-time = "2025-09-07T18:58:00.022Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ba/5a/18ad964b0086c6e62e2e7500f7edc89e3faa45033c71c1893d34eed2b2de/dnspython-2.8.0-py3-none-any.whl", hash = "sha256:01d9bbc4a2d76bf0db7c1f729812ded6d912bd318d3b1cf81d30c0f845dbf3af", size = 331094, upload-time = "2025-09-07T18:57:58.071Z" },
+]
+
+[[package]]
 name = "docker"
 version = "7.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -707,6 +716,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/88/7f/731ff914b0255d3d065f45fd4e626d4b8c95dbcbaada049f337a6ac16410/docker-7.2.0.tar.gz", hash = "sha256:cebb93773d334f778e023a7ee352a8d6e13ab1bd3b863a4d4a59dec897df43ac", size = 118731, upload-time = "2026-07-09T14:53:46.39Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/75/23/529140fe1aab80fc6992f93a706deec709140a6397439139a054e1515c45/docker-7.2.0-py3-none-any.whl", hash = "sha256:a3f45fdeb9165e2d25d9a1d02ddf3bc70fb572cf5ebbf9b58558c22caf29b71f", size = 148775, upload-time = "2026-07-09T14:53:45.224Z" },
+]
+
+[[package]]
+name = "email-validator"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "dnspython" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f5/22/900cb125c76b7aaa450ce02fd727f452243f2e91a61af068b40adba60ea9/email_validator-2.3.0.tar.gz", hash = "sha256:9fc05c37f2f6cf439ff414f8fc46d917929974a82244c20eb10231ba60c54426", size = 51238, upload-time = "2025-08-26T13:09:06.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/15/545e2b6cf2e3be84bc1ed85613edd75b8aea69807a71c26f4ca6a9258e82/email_validator-2.3.0-py3-none-any.whl", hash = "sha256:80f13f623413e6b197ae73bb10bf4eb0908faf509ad8362c5edeb0be7fd450b4", size = 35604, upload-time = "2025-08-26T13:09:05.858Z" },
 ]
 
 [[package]]
@@ -1618,6 +1640,7 @@ dependencies = [
     { name = "pillow" },
     { name = "pose-backends" },
     { name = "posture-core" },
+    { name = "pydantic", extra = ["email"] },
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
@@ -1652,6 +1675,7 @@ requires-dist = [
     { name = "pose-backends", editable = "packages/pose-backends" },
     { name = "pose-backends", extras = ["mediapipe"], marker = "extra == 'inference'", editable = "packages/pose-backends" },
     { name = "posture-core", editable = "packages/posture-core" },
+    { name = "pydantic", extras = ["email"], specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pyjwt", specifier = ">=2.10" },
     { name = "python-multipart", specifier = ">=0.0.18" },
@@ -1879,6 +1903,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[package.optional-dependencies]
+email = [
+    { name = "email-validator" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'darwin'",
     "python_full_version >= '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version >= '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform == 'darwin'",
-    "python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine == 'aarch64' and sys_platform == 'linux'",
-    "(python_full_version >= '3.12' and python_full_version < '3.15' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and python_full_version < '3.15' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "python_full_version == '3.14.*' and sys_platform == 'darwin'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'darwin'",
+    "python_full_version == '3.14.*' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine == 'aarch64' and sys_platform == 'linux'",
+    "(python_full_version == '3.14.*' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version == '3.14.*' and sys_platform != 'darwin' and sys_platform != 'linux')",
+    "(python_full_version >= '3.12' and python_full_version < '3.14' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'darwin' and sys_platform != 'linux')",
     "python_full_version < '3.12' and sys_platform == 'darwin'",
     "python_full_version < '3.12' and platform_machine == 'aarch64' and sys_platform == 'linux'",
     "(python_full_version < '3.12' and platform_machine != 'aarch64' and sys_platform == 'linux') or (python_full_version < '3.12' and sys_platform != 'darwin' and sys_platform != 'linux')",
@@ -83,6 +86,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/61/cc/a381afa6efea9f496eff839d4a6a1aed3bfafc7b3ab4b0d1b243a12573dd/anyio-4.14.2.tar.gz", hash = "sha256:cfa139f3ed1a23ee8f88a145ddb5ac7605b8bbfd8592baacd7ce3d8bb4313c7f", size = 260176, upload-time = "2026-07-12T20:29:07.082Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/da/35/f2287558c17e29fafc8ef3daf819bb9834061cfa43bff8014f7df7f63bdc/anyio-4.14.2-py3-none-any.whl", hash = "sha256:9f505dda5ac9f0c8309b5e8bd445a8c2bf7246f3ce950121e45ea15bc41d1494", size = 125813, upload-time = "2026-07-12T20:29:05.763Z" },
+]
+
+[[package]]
+name = "argon2-cffi"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "argon2-cffi-bindings" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0e/89/ce5af8a7d472a67cc819d5d998aa8c82c5d860608c4db9f46f1162d7dab9/argon2_cffi-25.1.0.tar.gz", hash = "sha256:694ae5cc8a42f4c4e2bf2ca0e64e51e23a040c6a517a85074683d3959e1346c1", size = 45706, upload-time = "2025-06-03T06:55:32.073Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4f/d3/a8b22fa575b297cd6e3e3b0155c7e25db170edf1c74783d6a31a2490b8d9/argon2_cffi-25.1.0-py3-none-any.whl", hash = "sha256:fdc8b074db390fccb6eb4a3604ae7231f219aa669a2652e0f20e16ba513d5741", size = 14657, upload-time = "2025-06-03T06:55:30.804Z" },
+]
+
+[[package]]
+name = "argon2-cffi-bindings"
+version = "25.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2d/db8af0df73c1cf454f71b2bbe5e356b8c1f8041c979f505b3d3186e520a9/argon2_cffi_bindings-25.1.0.tar.gz", hash = "sha256:b957f3e6ea4d55d820e40ff76f450952807013d361a65d7f28acc0acbf29229d", size = 1783441, upload-time = "2025-07-30T10:02:05.147Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/60/97/3c0a35f46e52108d4707c44b95cfe2afcafc50800b5450c197454569b776/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:3d3f05610594151994ca9ccb3c771115bdb4daef161976a266f0dd8aa9996b8f", size = 54393, upload-time = "2025-07-30T10:01:40.97Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/f4/98bbd6ee89febd4f212696f13c03ca302b8552e7dbf9c8efa11ea4a388c3/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:8b8efee945193e667a396cbc7b4fb7d357297d6234d30a489905d96caabde56b", size = 29328, upload-time = "2025-07-30T10:01:41.916Z" },
+    { url = "https://files.pythonhosted.org/packages/43/24/90a01c0ef12ac91a6be05969f29944643bc1e5e461155ae6559befa8f00b/argon2_cffi_bindings-25.1.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:3c6702abc36bf3ccba3f802b799505def420a1b7039862014a65db3205967f5a", size = 31269, upload-time = "2025-07-30T10:01:42.716Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/d3/942aa10782b2697eee7af5e12eeff5ebb325ccfb86dd8abda54174e377e4/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a1c70058c6ab1e352304ac7e3b52554daadacd8d453c1752e547c76e9c99ac44", size = 86558, upload-time = "2025-07-30T10:01:43.943Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/82/b484f702fec5536e71836fc2dbc8c5267b3f6e78d2d539b4eaa6f0db8bf8/argon2_cffi_bindings-25.1.0-cp314-cp314t-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e2fd3bfbff3c5d74fef31a722f729bf93500910db650c925c2d6ef879a7e51cb", size = 92364, upload-time = "2025-07-30T10:01:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c1/a606ff83b3f1735f3759ad0f2cd9e038a0ad11a3de3b6c673aa41c24bb7b/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:c4f9665de60b1b0e99bcd6be4f17d90339698ce954cfd8d9cf4f91c995165a92", size = 85637, upload-time = "2025-07-30T10:01:46.225Z" },
+    { url = "https://files.pythonhosted.org/packages/44/b4/678503f12aceb0262f84fa201f6027ed77d71c5019ae03b399b97caa2f19/argon2_cffi_bindings-25.1.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ba92837e4a9aa6a508c8d2d7883ed5a8f6c308c89a4790e1e447a220deb79a85", size = 91934, upload-time = "2025-07-30T10:01:47.203Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/c7/f36bd08ef9bd9f0a9cff9428406651f5937ce27b6c5b07b92d41f91ae541/argon2_cffi_bindings-25.1.0-cp314-cp314t-win32.whl", hash = "sha256:84a461d4d84ae1295871329b346a97f68eade8c53b6ed9a7ca2d7467f3c8ff6f", size = 28158, upload-time = "2025-07-30T10:01:48.341Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/80/0106a7448abb24a2c467bf7d527fe5413b7fdfa4ad6d6a96a43a62ef3988/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b55aec3565b65f56455eebc9b9f34130440404f27fe21c3b375bf1ea4d8fbae6", size = 32597, upload-time = "2025-07-30T10:01:49.112Z" },
+    { url = "https://files.pythonhosted.org/packages/05/b8/d663c9caea07e9180b2cb662772865230715cbd573ba3b5e81793d580316/argon2_cffi_bindings-25.1.0-cp314-cp314t-win_arm64.whl", hash = "sha256:87c33a52407e4c41f3b70a9c2d3f6056d88b10dad7695be708c5021673f55623", size = 28231, upload-time = "2025-07-30T10:01:49.92Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/57/96b8b9f93166147826da5f90376e784a10582dd39a393c99bb62cfcf52f0/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:aecba1723ae35330a008418a91ea6cfcedf6d31e5fbaa056a166462ff066d500", size = 54121, upload-time = "2025-07-30T10:01:50.815Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/08/a9bebdb2e0e602dde230bdde8021b29f71f7841bd54801bcfd514acb5dcf/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_10_9_x86_64.whl", hash = "sha256:2630b6240b495dfab90aebe159ff784d08ea999aa4b0d17efa734055a07d2f44", size = 29177, upload-time = "2025-07-30T10:01:51.681Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/02/d297943bcacf05e4f2a94ab6f462831dc20158614e5d067c35d4e63b9acb/argon2_cffi_bindings-25.1.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:7aef0c91e2c0fbca6fc68e7555aa60ef7008a739cbe045541e438373bc54d2b0", size = 31090, upload-time = "2025-07-30T10:01:53.184Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/93/44365f3d75053e53893ec6d733e4a5e3147502663554b4d864587c7828a7/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1e021e87faa76ae0d413b619fe2b65ab9a037f24c60a1e6cc43457ae20de6dc6", size = 81246, upload-time = "2025-07-30T10:01:54.145Z" },
+    { url = "https://files.pythonhosted.org/packages/09/52/94108adfdd6e2ddf58be64f959a0b9c7d4ef2fa71086c38356d22dc501ea/argon2_cffi_bindings-25.1.0-cp39-abi3-manylinux_2_26_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d3e924cfc503018a714f94a49a149fdc0b644eaead5d1f089330399134fa028a", size = 87126, upload-time = "2025-07-30T10:01:55.074Z" },
+    { url = "https://files.pythonhosted.org/packages/72/70/7a2993a12b0ffa2a9271259b79cc616e2389ed1a4d93842fac5a1f923ffd/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87b72589133f0346a1cb8d5ecca4b933e3c9b64656c9d175270a000e73b288d", size = 80343, upload-time = "2025-07-30T10:01:56.007Z" },
+    { url = "https://files.pythonhosted.org/packages/78/9a/4e5157d893ffc712b74dbd868c7f62365618266982b64accab26bab01edc/argon2_cffi_bindings-25.1.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:1db89609c06afa1a214a69a462ea741cf735b29a57530478c06eb81dd403de99", size = 86777, upload-time = "2025-07-30T10:01:56.943Z" },
+    { url = "https://files.pythonhosted.org/packages/74/cd/15777dfde1c29d96de7f18edf4cc94c385646852e7c7b0320aa91ccca583/argon2_cffi_bindings-25.1.0-cp39-abi3-win32.whl", hash = "sha256:473bcb5f82924b1becbb637b63303ec8d10e84c8d241119419897a26116515d2", size = 27180, upload-time = "2025-07-30T10:01:57.759Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/c6/a759ece8f1829d1f162261226fbfd2c6832b3ff7657384045286d2afa384/argon2_cffi_bindings-25.1.0-cp39-abi3-win_amd64.whl", hash = "sha256:a98cd7d17e9f7ce244c0803cad3c23a7d379c301ba618a5fa76a67d116618b98", size = 31715, upload-time = "2025-07-30T10:01:58.56Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b9/f8d6fa329ab25128b7e98fd83a3cb34d9db5b059a9847eddb840a0af45dd/argon2_cffi_bindings-25.1.0-cp39-abi3-win_arm64.whl", hash = "sha256:b0fdbcf513833809c882823f98dc2f931cf659d9a1429616ac3adebb49f5db94", size = 27149, upload-time = "2025-07-30T10:01:59.329Z" },
 ]
 
 [[package]]
@@ -1565,6 +1611,7 @@ version = "0.1.0"
 source = { editable = "apps/api" }
 dependencies = [
     { name = "alembic" },
+    { name = "argon2-cffi" },
     { name = "asyncpg" },
     { name = "boto3" },
     { name = "fastapi" },
@@ -1572,6 +1619,7 @@ dependencies = [
     { name = "pose-backends" },
     { name = "posture-core" },
     { name = "pydantic-settings" },
+    { name = "pyjwt" },
     { name = "python-multipart" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
@@ -1596,6 +1644,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.14" },
+    { name = "argon2-cffi", specifier = ">=23.1" },
     { name = "asyncpg", specifier = ">=0.30" },
     { name = "boto3", specifier = ">=1.35" },
     { name = "fastapi", specifier = ">=0.115" },
@@ -1604,6 +1653,7 @@ requires-dist = [
     { name = "pose-backends", extras = ["mediapipe"], marker = "extra == 'inference'", editable = "packages/pose-backends" },
     { name = "posture-core", editable = "packages/posture-core" },
     { name = "pydantic-settings", specifier = ">=2.7" },
+    { name = "pyjwt", specifier = ">=2.10" },
     { name = "python-multipart", specifier = ">=0.0.18" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=24.4" },
@@ -1954,6 +2004,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pyjwt"
+version = "2.13.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements OP-55 (E7): self-hosted authentication per ADR-0003, plus `security.yml`.

**Stacked on #76 (OP-54).** Base is `op-54-analyses-endpoints`; review that one first. This PR's own diff is ~2,500 lines across 19 files.

## What

Four endpoints — `POST /api/v1/auth/{register,login,refresh,logout}` — behind two new primitives in `openposture_api.security`, plus a boot guard in `config.py` and a four-job security workflow.

E6 had already laid the `users` and `refresh_tokens` tables and their repositories, so this ticket mostly fills in stubs: `auth.py` was a placeholder raising 401.

## Why the choices are what they are

**argon2id, not passlib.** Passlib's last release predates several Python versions this project supports. A password hashing library is the wrong dependency to have go quiet.

**SHA-256 for refresh tokens, argon2id for passwords — and the deciding variable is entropy of the input, not speed.** A `secrets.token_urlsafe(32)` token carries 256 bits of randomness: there is no dictionary to guess from, so a slow hash buys nothing while putting a deliberately expensive function on the path every client hits on a timer. A human password lives in a space small enough to enumerate, which is exactly what argon2's cost parameters exist to make expensive. Measured on a dev laptop: argon2id at the shipped defaults runs ~23 ms, or ~43 guesses/sec, against the ~10⁹/s a GPU manages on bare SHA-256 — roughly 28 bits of added cost. The 64 MiB `memory_cost` is what stops an attacker buying that back with parallel hardware, and it is why argon2**id** rather than bcrypt.

**Decoding names the algorithm it accepts.** A JWT's `alg` header is attacker-supplied data. A decoder that reads it can be handed `{"alg":"none"}`, or an RS256 token whose "signature" is an HMAC keyed with the public key. `algorithms=[ALGORITHM]` makes both unrepresentable rather than merely untested, and there is a test asserting the header says `none` *and* that decoding still fails.

**`require=["exp","iat","sub"]`** — the subtle one. Without it, a token carrying no `exp` passes expiry validation, because there is nothing to find expired. Absent and satisfied must not look alike.

**A failed sign-in costs the same either way.** Returning early when no user exists is a timing oracle: ~0.1 ms for a missing account against ~23 ms for a wrong password, a 200× difference far above network jitter. An attacker with a list of addresses times the responses and learns which are registered — the leak ADR-0003 forbids, arriving through the clock rather than the body. So the hash is verified regardless, against a dummy hash computed once at import. This equalises; it does not achieve constant time, and the docstring says so.

**Rotation makes theft detectable.** Every refresh retires the presented token and mints a new one in the same family. A retired token arriving twice means two parties hold it, and which one is the attacker is unknowable from the server — so the whole family is revoked and everyone re-authenticates. Revoking only the replayed row would leave whichever party refreshed most recently in possession of a working session.

**The refresh token appears in no response body.** It exists only as `HttpOnly; SameSite=Lax; Secure; Path=/api/v1/auth`. JavaScript cannot read an `HttpOnly` cookie, so the "nothing in `localStorage`" criterion is a property of the API rather than a rule the frontend has to keep remembering. `Path` scoping also keeps it off every image upload.

## Two additions beyond the ticket's literal wording

- **`min_length=32` on `jwt_secret`.** PyJWT warns that HMAC keys below RFC 7518 §3.2's floor are the weakest part of the scheme; a short key is brute-forceable *offline* from one captured token, with no request to the API and no log entry. A warning nobody reads is not a control. It immediately caught a 21-character key in `test_app_factory.py`.
- **The `_as_utc` helper.** SQLite returns naive datetimes where Postgres returns aware ones, and Python refuses to compare the two. That strictness is a feature — silently comparing a local time to a UTC one is the worse bug — but the code has to handle both backends.

## Known gaps, deliberate

- **Registration leaks whether an address is registered**, via the 409. The standard fix is to always return 201 and email the address owner; ADR-0003 records that this project has no outbound mail path, and a 201 that silently creates nothing lies to legitimate users. Documented in the route's docstring.
- **Concurrent refresh is not serialised.** Two simultaneous refreshes of the same token both read it unrevoked and both rotate, producing two live branches rather than a detected replay. Closing this needs `SELECT ... FOR UPDATE` on the token row; it is a correctness edge, not a hole an attacker can steer, and it belongs in its own ticket.
- **No rate limiting** on login or refresh. Not in this ticket's scope.
- **`get_current_user_id` remains a stub** — OP-56 owns it, and it is already in review.
- `PasswordHasher.check_needs_rehash()` (transparent upgrade when parameters are retuned) is not wired up; noted for later.

## How tested

- **Python: 306 passed**, `ruff check` + `format` clean, `mypy` clean across 46 files.
- **Frontend: 78 passed**, `tsc -b` clean, `oxlint` and prettier clean.
- Abuse cases are built as attacks, not asserted as intentions — each test forges something: expired tokens, tampered payloads, a token signed with the wrong key, `alg: none`, HS512 signed with the real secret, a valid signature over a non-UUID subject, replay, family revocation, logout invalidating a family, and production refusing to boot on the default key.
- **The frontend guard was mutation-tested.** I injected a real `localStorage.setItem("access_token", "eyJ…")` into `InMemoryAuthProvider` and confirmed all three layers — source scan, `setItem`-key scan, runtime spy — fail independently, then restored and confirmed a clean tree. A guard test that has never failed is one you are trusting on faith.
- Contract regenerated and verified idempotent; `pr.yml`'s `contract` job diffs it, so staleness is a build failure.

Pre-existing and unrelated: `packages/pose-backends/tests/test_cli.py::test_a_real_photograph_produces_a_full_table` fails identically on `main` (verified by checking out `main` and re-running). It needs the native inference stack.

## Self-review found one real bug

`_unauthorized_refresh` documented that it cleared the dead cookie, and it did not. Raising `HTTPException` hands control to the error handler, which builds its own response — so the `Set-Cookie` written to the injected `Response` was discarded. The 401 path now returns an RFC 9457 `JSONResponse` with the header attached, and two regression tests pin both the cookie and the error envelope. Fixed in 3be6844.

## Notes for the reviewer

`security.yml` cannot be verified without running it. Every action reference was checked against the real tag list rather than inferred: `actions/dependency-review-action` publishes **no major tag past v3** (`v4` and `v5` are 404s), so it is pinned to `v5.0.0`; `github/codeql-action@v4` exists and is treated as first-party under `pr.yml`'s policy; `gitleaks` is SHA-pinned as third-party and needs no licence key for a personal-account repo. The repo is public, so CodeQL and dependency review are free — both would need Advanced Security on a private one. Expect CodeQL's `security-extended` pack to surface findings on its first run; that is it working.
