### PR TITLE
OP-59: Rate limit login and analysis uploads

### DIFF
--- a/apps/api/pyproject.toml
+++ b/apps/api/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     # library; registration validates the shape of an address at the boundary rather than
     # discovering it is unroutable at send time — which this project has no path to do anyway.
     "pydantic[email]>=2.0",
+    "slowapi>=0.1.10",
 ]
 
 [project.optional-dependencies]

--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -63,8 +63,10 @@ from posture_core.thresholds import DEFAULT_THRESHOLDS as _DEFAULT_THRESHOLDS
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
+    from slowapi import Limiter
     from starlette.responses import JSONResponse
 
+    from openposture_api.config import Settings
     from openposture_api.db.models import Analysis
     from posture_core import PoseFrame, PostureReport
 
@@ -85,11 +87,15 @@ client is not typed to handle (the same argument as the 502 below).
 """
 
 
-def build_analyses_router() -> APIRouter:
+def build_analyses_router(limiter: Limiter, settings: Settings) -> APIRouter:
     """The analyses routes.
 
     A builder rather than a module-level router for the same reason `create_app` is a factory:
-    two apps in one test session must not share mutable route state.
+    two apps in one test session must not share mutable route state. `limiter` and `settings`
+    arrive as arguments for the same reason `auth.build_auth_router` takes them: the upload
+    route's rate limit (OP-59, `Settings.analyses_rate_limit`) has to be a concrete string at
+    `@limiter.limit(...)` decoration time, before any request — and so before `settings` could
+    be read off `request.app.state` the way the route body reads it for everything else.
     """
     router = APIRouter(prefix=API_PREFIX, tags=["analyses"])
 
@@ -113,8 +119,13 @@ def build_analyses_router() -> APIRouter:
             # an unlisted status is a response the client is not typed to handle.
             status.HTTP_502_BAD_GATEWAY: {"description": "Inference or storage failed downstream."},
             status.HTTP_503_SERVICE_UNAVAILABLE: {"description": "Inference is unavailable."},
+            status.HTTP_429_TOO_MANY_REQUESTS: {"description": "Too many uploads."},
         },
     )
+    # A resource control, not a credential one (OP-59, `Settings.analyses_rate_limit`): pose
+    # inference is the most expensive thing this service does, so this caps how much of the
+    # worker pool one client can occupy rather than guarding against guessing anything.
+    @limiter.limit(settings.analyses_rate_limit)
     async def create_analysis(
         request: Request,
         user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],

--- a/apps/api/src/openposture_api/auth.py
+++ b/apps/api/src/openposture_api/auth.py
@@ -49,6 +49,7 @@ from openposture_api.security import (
 )
 
 if TYPE_CHECKING:
+    from slowapi import Limiter
     from starlette.responses import JSONResponse
 
     from openposture_api.config import Settings
@@ -141,11 +142,15 @@ def _unauthenticated() -> HTTPException:
     )
 
 
-def build_auth_router() -> APIRouter:
+def build_auth_router(limiter: Limiter, settings: Settings) -> APIRouter:
     """The authentication routes.
 
     A builder rather than a module-level router, for the same reason `create_app` is a factory:
-    two apps in one test session must not share mutable route state.
+    two apps in one test session must not share mutable route state. `limiter` and `settings`
+    arrive as arguments for the same reason: `/login`'s rate limit (OP-59) is read from
+    `settings.login_rate_limit` once, at build time, rather than the route reaching into
+    `request.app.state` the way the other routes read settings — `@limiter.limit(...)` needs a
+    concrete string (or a callable) at decoration time, before any request exists.
     """
     router = APIRouter(prefix=AUTH_PREFIX, tags=["auth"])
 
@@ -203,8 +208,15 @@ def build_auth_router() -> APIRouter:
         "/login",
         response_model=TokenResponse,
         summary="Sign in",
-        responses={status.HTTP_401_UNAUTHORIZED: {"description": "Credentials rejected."}},
+        responses={
+            status.HTTP_401_UNAUTHORIZED: {"description": "Credentials rejected."},
+            status.HTTP_429_TOO_MANY_REQUESTS: {"description": "Too many attempts."},
+        },
     )
+    # A credential-stuffing control, not a resource one (OP-59, `Settings.login_rate_limit`).
+    # Applied below `@router.post` so it wraps the plain function before FastAPI ever sees it —
+    # the order the two decorators are usually shown in slowapi's own documentation.
+    @limiter.limit(settings.login_rate_limit)
     async def login(
         credentials: CredentialsRequest,
         request: Request,

--- a/apps/api/src/openposture_api/config.py
+++ b/apps/api/src/openposture_api/config.py
@@ -22,6 +22,7 @@ from functools import lru_cache
 from pathlib import Path
 from typing import Final, Literal
 
+from limits import parse as parse_rate_limit
 from pydantic import Field, SecretStr, field_validator, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -262,6 +263,62 @@ class Settings(BaseSettings):
             "`Secure` would make the cookie unusable over a plain-http localhost."
         ),
     )
+
+    login_rate_limit: str = Field(
+        default="5/minute",
+        description=(
+            "Per-IP limit on `POST /api/v1/auth/login`, in `limits` syntax (OP-59). This is a "
+            "credential-stuffing control, not a resource one: Argon2id makes every guess "
+            "expensive for the server too, so an unlimited login endpoint is a DoS amplifier as "
+            "much as an account-security hole. Five per minute is generous for a human and "
+            "useless for a botnet. Per-IP only — a distributed attacker, or genuine users behind "
+            "one NAT'd IP, are known gaps; per-account limiting is future work, not implemented "
+            "here."
+        ),
+    )
+
+    analyses_rate_limit: str = Field(
+        default="10/minute",
+        description=(
+            "Per-IP limit on `POST /api/v1/analyses`, in `limits` syntax (OP-59). This is a "
+            "resource control, not a credential one: pose inference is the most expensive thing "
+            "this service does, and without a cap one client saturates the worker pool and every "
+            "other upload queues behind it. Ten per minute is well above what a person "
+            "photographing themselves needs and well below what lets one client starve the "
+            "others. Per-IP only; a global inference concurrency cap is future work, not "
+            "implemented here."
+        ),
+    )
+
+    trusted_proxy_hops: int = Field(
+        default=0,
+        ge=0,
+        description=(
+            "How many reverse-proxy hops' worth of `X-Forwarded-For` entries to trust when "
+            "resolving the client IP for rate limiting. `0` (the default) ignores the header "
+            "entirely and uses the direct TCP peer — correct today, since nothing sits in front "
+            "of this service in Compose (the Vite dev proxy does not set the header) and no "
+            "production overlay exists yet. Set to the number of trusted proxies between the "
+            "internet and this process once one is introduced (usually `1`); trusting the wrong "
+            "count either lets a client spoof its own address or collapses every client behind "
+            "the proxy onto one IP."
+        ),
+    )
+
+    @field_validator("login_rate_limit", "analyses_rate_limit")
+    @classmethod
+    def _validate_rate_limit_syntax(cls, value: str) -> str:
+        """Reject a malformed limit at startup, in the field that named it.
+
+        `limits.parse` is what `slowapi.Limiter` calls internally at request time — validating
+        here means a typo like `"5/minuet"` stops the process immediately instead of surfacing as
+        every request to the route silently going unlimited.
+        """
+        try:
+            parse_rate_limit(value)
+        except ValueError as exc:
+            raise ValueError(f"not a valid rate limit expression: {value!r} ({exc})") from exc
+        return value
 
     @field_validator("request_id_header")
     @classmethod

--- a/apps/api/src/openposture_api/main.py
+++ b/apps/api/src/openposture_api/main.py
@@ -37,6 +37,7 @@ from openposture_api.pose import (
     handle_pose_backend_unavailable,
     load_pose_backend,
 )
+from openposture_api.rate_limit import build_limiter, register_rate_limit_handlers
 from openposture_api.storage import create_storage
 
 if TYPE_CHECKING:
@@ -155,6 +156,10 @@ def create_app(
     # Present before startup so that a route reaching for it during a failed lifespan finds a
     # state object describing "not loaded" rather than an AttributeError.
     app.state.pose_backend_state = PoseBackendState()
+    # Built here, one per app, for the same reason `app.state.settings` is: two apps in one test
+    # session must not share limiter state. `resolve_client_ip` reads `app.state.settings`, which
+    # is why this is assigned after it rather than before.
+    app.state.limiter = build_limiter()
 
     # Registered before the routes it wraps. Starlette runs middleware outermost-first, so this
     # binds the request ID before any handler — including the error handlers — can log.
@@ -163,6 +168,7 @@ def create_app(
     register_error_handlers(app)
     app.add_exception_handler(PoseBackendUnavailableError, handle_pose_backend_unavailable)
     register_analysis_error_handlers(app)
+    register_rate_limit_handlers(app)
 
     # The probe reads `app.state` when it runs, not when it is registered, so binding it here —
     # before lifespan has produced a state — reports the real thing at request time.
@@ -175,8 +181,8 @@ def create_app(
     app.include_router(
         build_health_router(version=__version__, probes=probes),
     )
-    app.include_router(build_auth_router())
-    app.include_router(build_analyses_router())
+    app.include_router(build_auth_router(app.state.limiter, resolved))
+    app.include_router(build_analyses_router(app.state.limiter, resolved))
 
     _LOGGER.info(
         "app_created",

--- a/apps/api/src/openposture_api/rate_limit.py
+++ b/apps/api/src/openposture_api/rate_limit.py
@@ -1,0 +1,105 @@
+"""slowapi-backed rate limiting (OP-59): five per minute on login, a tunable cap on analyses.
+
+Two limits, for two different reasons, and the docstrings on `Settings.login_rate_limit` and
+`Settings.analyses_rate_limit` say which is which rather than repeating it here.
+
+**The client-IP question is the load-bearing part.** `slowapi`'s default key function trusts
+`request.client.host` — the direct TCP peer — which is exactly right when nothing sits in front
+of this service, and exactly wrong once something does: every request would then key off the
+proxy's own address, and the limit would apply to the whole userbase as one client. The opposite
+mistake is trusting `X-Forwarded-For` unconditionally, which lets any caller pick its own bucket
+by sending the header itself. :func:`resolve_client_ip` is the seam that makes the trusted case
+configurable (`Settings.trusted_proxy_hops`) without ever taking a client's word for its own
+address.
+
+Both limited routes fail the same way: 429, `Retry-After`, and the same `application/problem+json`
+envelope as every other error (OP-50) — never `slowapi`'s own default JSON shape.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from slowapi import Limiter
+from slowapi.errors import RateLimitExceeded
+from starlette import status
+
+from openposture_api.errors import problem_response
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+
+    from openposture_api.config import Settings
+
+__all__ = ["build_limiter", "register_rate_limit_handlers", "resolve_client_ip"]
+
+
+def resolve_client_ip(request: Request) -> str:
+    """The address a rate limit should key on, honouring only *configured* proxy hops.
+
+    `Settings.trusted_proxy_hops` (default `0`) says how many proxies between the internet and
+    this process are trusted to append correctly to `X-Forwarded-For`. With the default, the
+    header is not read at all — the direct TCP peer is used, which an HTTP client cannot forge.
+
+    With `hops = N > 0`, each trusted proxy is assumed to append the address it received the
+    request from, so the entry contributed by the *outermost* trusted proxy — the one closest to
+    the real client — sits `N` places from the right. Anything to its left, including a client's
+    own claimed IP in position zero, is attacker-controlled and never consulted. A header with
+    fewer entries than `N` (a misconfigured or lied-to proxy) falls back to the leftmost entry
+    rather than raising, since a rate-limit key is not worth failing the request over.
+    """
+    settings: Settings = request.app.state.settings
+    hops = settings.trusted_proxy_hops
+    if hops > 0:
+        forwarded_for = request.headers.get("X-Forwarded-For")
+        if forwarded_for:
+            parts = [part.strip() for part in forwarded_for.split(",") if part.strip()]
+            if parts:
+                return parts[max(len(parts) - hops, 0)]
+    client = request.client
+    return client.host if client is not None else "unknown"
+
+
+def build_limiter() -> Limiter:
+    """One `Limiter` per app, for the same reason routers are built per app rather than shared.
+
+    `slowapi`'s default in-memory storage is process-local, which is what every other piece of
+    state in this codebase already is (no shared cache exists yet) — fine for a single API
+    process, and the first thing to revisit if this service is ever run with more than one.
+    """
+    return Limiter(key_func=resolve_client_ip)
+
+
+def _retry_after_seconds(request: Request) -> int:
+    """Seconds until the limit that was just hit resets, read from the same state `slowapi`
+    itself would use to build the `Retry-After` header — computed directly rather than through
+    `Limiter._inject_headers`, which no-ops unless `headers_enabled` is set and would otherwise
+    require every limited route to accept a `response` parameter it has no other use for.
+    """
+    limiter: Limiter = request.app.state.limiter
+    current = getattr(request.state, "view_rate_limit", None)
+    if current is None:  # pragma: no cover - defensive; slowapi always sets this before raising
+        return 1
+    item, identifiers = current
+    stats = limiter.limiter.get_window_stats(item, *identifiers)
+    return max(1, int(stats.reset_time - time.time()))
+
+
+async def _handle_rate_limit_exceeded(request: Request, exc: Exception) -> JSONResponse:
+    """The one place a 429 is built, so it looks like every other error this API returns."""
+    assert isinstance(exc, RateLimitExceeded)
+    retry_after = _retry_after_seconds(request)
+    return problem_response(
+        request,
+        status.HTTP_429_TOO_MANY_REQUESTS,
+        f"Rate limit exceeded: {exc.detail}. Retry after {retry_after} seconds.",
+        headers={"Retry-After": str(retry_after)},
+    )
+
+
+def register_rate_limit_handlers(app: FastAPI) -> None:
+    """Attach the 429 handler to one app instance — see `errors.register_error_handlers`."""
+    app.add_exception_handler(RateLimitExceeded, _handle_rate_limit_exceeded)

--- a/apps/api/src/openposture_api/rate_limit.py
+++ b/apps/api/src/openposture_api/rate_limit.py
@@ -18,6 +18,7 @@ envelope as every other error (OP-50) — never `slowapi`'s own default JSON sha
 
 from __future__ import annotations
 
+import math
 import time
 from typing import TYPE_CHECKING
 
@@ -78,6 +79,10 @@ def _retry_after_seconds(request: Request) -> int:
     itself would use to build the `Retry-After` header — computed directly rather than through
     `Limiter._inject_headers`, which no-ops unless `headers_enabled` is set and would otherwise
     require every limited route to accept a `response` parameter it has no other use for.
+
+    Rounds up, not down: flooring `10.9` to `10` would tell a client it's safe to retry a full
+    second before the window actually resets, and it would land right back on a 429. Ceiling is
+    the only rounding direction that never advertises a wait shorter than the real one.
     """
     limiter: Limiter = request.app.state.limiter
     current = getattr(request.state, "view_rate_limit", None)
@@ -85,7 +90,7 @@ def _retry_after_seconds(request: Request) -> int:
         return 1
     item, identifiers = current
     stats = limiter.limiter.get_window_stats(item, *identifiers)
-    return max(1, int(stats.reset_time - time.time()))
+    return max(1, math.ceil(stats.reset_time - time.time()))
 
 
 async def _handle_rate_limit_exceeded(request: Request, exc: Exception) -> JSONResponse:

--- a/apps/api/tests/test_config.py
+++ b/apps/api/tests/test_config.py
@@ -195,3 +195,41 @@ class TestEnvironmentReading:
             assert get_settings() is get_settings()
         finally:
             get_settings.cache_clear()
+
+
+class TestRateLimiting:
+    """OP-59: the two limits and the proxy-trust knob are all tunable, not hardcoded."""
+
+    def test_the_documented_defaults_are_what_ships(self) -> None:
+        settings = Settings(_env_file=None)  # type: ignore[call-arg]
+
+        assert settings.login_rate_limit == "5/minute"
+        assert settings.analyses_rate_limit == "10/minute"
+        assert settings.trusted_proxy_hops == 0
+
+    def test_both_limits_are_overridable_without_a_deploy(self) -> None:
+        settings = Settings(  # type: ignore[call-arg]
+            login_rate_limit="3/second",
+            analyses_rate_limit="1/hour",
+            trusted_proxy_hops=2,
+            _env_file=None,
+        )
+
+        assert settings.login_rate_limit == "3/second"
+        assert settings.analyses_rate_limit == "1/hour"
+        assert settings.trusted_proxy_hops == 2
+
+    @pytest.mark.parametrize("field", ["login_rate_limit", "analyses_rate_limit"])
+    def test_a_malformed_limit_names_the_field_at_startup(self, field: str) -> None:
+        """The same principle as the log-level and header checks above: a typo here must stop
+        the process, not silently leave the route unlimited on the first request that reads it."""
+        with pytest.raises(ValidationError) as caught:
+            Settings(**{field: "five per minuet"}, _env_file=None)  # type: ignore[arg-type, call-arg]
+
+        assert field in str(caught.value)
+
+    def test_a_negative_proxy_hop_count_is_rejected(self) -> None:
+        with pytest.raises(ValidationError) as caught:
+            Settings(trusted_proxy_hops=-1, _env_file=None)  # type: ignore[call-arg]
+
+        assert "trusted_proxy_hops" in str(caught.value)

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -11,6 +11,7 @@ system, not of any one function.
 from __future__ import annotations
 
 import io
+import time
 import uuid
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
@@ -27,7 +28,7 @@ from openposture_api.config import Settings
 from openposture_api.db import Base, get_session
 from openposture_api.main import create_app
 from openposture_api.pose import get_pose_backend
-from openposture_api.rate_limit import resolve_client_ip
+from openposture_api.rate_limit import _retry_after_seconds, resolve_client_ip
 from openposture_api.storage import LocalDiskStorage, get_storage
 from pose_backends.fake import FakePoseBackend
 
@@ -127,6 +128,24 @@ class TestClientIpResolution:
         )
 
         assert resolve_client_ip(request) == "only-one-entry"
+
+
+class TestRetryAfterRounding:
+    """`Retry-After` must never advertise a shorter wait than the window actually has left —
+    flooring a fractional reset (e.g. 10.9s -> 10) would let a client retry before the window
+    resets and land right back on a 429."""
+
+    def test_a_fractional_reset_rounds_up_not_down(self) -> None:
+        stats = MagicMock()
+        stats.reset_time = time.time() + 10.1
+        limiter = MagicMock()
+        limiter.limiter.get_window_stats.return_value = stats
+
+        request = MagicMock()
+        request.app.state.limiter = limiter
+        request.state.view_rate_limit = (MagicMock(), MagicMock())
+
+        assert _retry_after_seconds(request) == 11
 
 
 @pytest.fixture

--- a/apps/api/tests/test_rate_limit.py
+++ b/apps/api/tests/test_rate_limit.py
@@ -1,0 +1,334 @@
+"""OP-59: 5/minute on login, a configurable cap on analyses, both as RFC 9457 429s.
+
+Two layers under test. `TestClientIpResolution` is a direct, no-HTTP unit test of
+`resolve_client_ip` — the trust-boundary decision the ticket calls out as the part most likely to
+be subtly wrong. `TestLoginRateLimit`, `TestAnalysesRateLimit` and
+`TestClientIpResolutionEndToEnd` drive the real routes over ASGI, because "the sixth request in a
+minute is refused" and "a spoofed header does not buy a fresh bucket" are properties of the wired
+system, not of any one function.
+"""
+
+from __future__ import annotations
+
+import io
+import uuid
+from contextlib import contextmanager
+from typing import TYPE_CHECKING, Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi.testclient import TestClient
+from PIL import Image
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from starlette.requests import Request
+
+from openposture_api.auth import AUTH_PREFIX, get_current_user_id
+from openposture_api.config import Settings
+from openposture_api.db import Base, get_session
+from openposture_api.main import create_app
+from openposture_api.pose import get_pose_backend
+from openposture_api.rate_limit import resolve_client_ip
+from openposture_api.storage import LocalDiskStorage, get_storage
+from pose_backends.fake import FakePoseBackend
+
+if TYPE_CHECKING:
+    from collections.abc import AsyncIterator, Iterator
+    from pathlib import Path
+
+    from fastapi import FastAPI
+
+LOGIN = f"{AUTH_PREFIX}/login"
+ANALYSES = "/api/v1/analyses"
+
+_CREDENTIALS = {"email": "sam@example.com", "password": "the-wrong-password-every-time"}
+"""Deliberately wrong. The rate limit is enforced before the route body runs a query, so a login
+attempt that will 401 anyway still counts against the bucket — using real credentials would make
+these tests also depend on registration succeeding, which is not what is under test here."""
+
+
+def _settings(**overrides: Any) -> Settings:
+    return Settings(
+        environment="test",
+        log_level="warning",
+        json_logs=True,
+        pose_backend="fake",
+        refresh_cookie_secure=False,
+        **overrides,
+    )
+
+
+class TestClientIpResolution:
+    """`resolve_client_ip` in isolation — no ASGI, no TestClient, just scopes."""
+
+    @staticmethod
+    def _request(
+        *,
+        settings: Settings,
+        client_host: str = "203.0.113.9",
+        forwarded_for: str | None = None,
+    ) -> Request:
+        headers = [(b"x-forwarded-for", forwarded_for.encode())] if forwarded_for else []
+        scope: dict[str, Any] = {
+            "type": "http",
+            "headers": headers,
+            "client": (client_host, 12345),
+            "app": create_app(settings, load_backend=False),
+        }
+        return Request(scope)
+
+    def test_by_default_the_header_is_not_read_at_all(self) -> None:
+        """`trusted_proxy_hops=0` — today's topology: nothing sits in front of this service."""
+        request = self._request(
+            settings=_settings(trusted_proxy_hops=0),
+            client_host="203.0.113.9",
+            forwarded_for="6.6.6.6",
+        )
+
+        assert resolve_client_ip(request) == "203.0.113.9"
+
+    def test_no_header_falls_back_to_the_direct_peer_regardless_of_hop_count(self) -> None:
+        request = self._request(settings=_settings(trusted_proxy_hops=1), client_host="203.0.113.9")
+
+        assert resolve_client_ip(request) == "203.0.113.9"
+
+    def test_one_trusted_hop_reads_the_proxy_appended_entry(self) -> None:
+        """`"attacker-claim, 9.9.9.9"` — a real proxy appends what it saw, at the *end*."""
+        request = self._request(
+            settings=_settings(trusted_proxy_hops=1),
+            forwarded_for="attacker-claim, 9.9.9.9",
+        )
+
+        assert resolve_client_ip(request) == "9.9.9.9"
+
+    def test_the_client_supplied_entry_is_never_trusted_however_it_is_spelled(self) -> None:
+        """The whole point: only the position counts. Whatever the attacker writes in the
+        untrusted slot, the resolved key is unchanged as long as the trusted slot is unchanged."""
+        settings = _settings(trusted_proxy_hops=1)
+        first = self._request(settings=settings, forwarded_for="1.1.1.1, 9.9.9.9")
+        second = self._request(settings=settings, forwarded_for="totally-different-lie, 9.9.9.9")
+
+        assert resolve_client_ip(first) == resolve_client_ip(second) == "9.9.9.9"
+
+    def test_two_trusted_hops_reads_the_outermost_trusted_entry(self) -> None:
+        """A chain of two trusted proxies: the untrusted, attacker-supplied prefix is discarded
+        no matter how many fake entries it contains, by counting from the right."""
+        request = self._request(
+            settings=_settings(trusted_proxy_hops=2),
+            forwarded_for="attacker-lie, real-browser-ip, proxy1-ip",
+        )
+
+        assert resolve_client_ip(request) == "real-browser-ip"
+
+    def test_fewer_entries_than_configured_hops_falls_back_rather_than_crashing(self) -> None:
+        """A misconfigured or lying proxy must not turn every request into a 500."""
+        request = self._request(
+            settings=_settings(trusted_proxy_hops=3),
+            forwarded_for="only-one-entry",
+        )
+
+        assert resolve_client_ip(request) == "only-one-entry"
+
+
+@pytest.fixture
+async def session_factory() -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    """A fresh in-memory database, matching `tests/test_auth.py`'s fixture of the same name."""
+    engine = create_async_engine("sqlite+aiosqlite:///file::memory:?cache=shared&uri=true")
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    yield async_sessionmaker(engine, expire_on_commit=False)
+    await engine.dispose()
+
+
+@contextmanager
+def _login_client(
+    settings: Settings, session_factory: async_sessionmaker[AsyncSession]
+) -> Iterator[TestClient]:
+    app: FastAPI = create_app(settings)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        # `lifespan` overwrites `app.state.session_factory` from `settings.database_url`, so this
+        # has to happen after the context manager has entered, not before — see `test_auth.py`.
+        app.state.session_factory = session_factory
+        yield client
+
+
+class TestLoginRateLimit:
+    """5 per minute per IP, the credential-stuffing control (OP-59)."""
+
+    def test_a_sixth_attempt_within_the_window_is_refused(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        with _login_client(_settings(), session_factory) as client:
+            for _ in range(5):
+                response = client.post(LOGIN, json=_CREDENTIALS)
+                assert response.status_code == 401
+
+            sixth = client.post(LOGIN, json=_CREDENTIALS)
+
+        assert sixth.status_code == 429
+
+    def test_the_429_carries_retry_after_and_the_problem_envelope(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        with _login_client(_settings(), session_factory) as client:
+            for _ in range(5):
+                client.post(LOGIN, json=_CREDENTIALS)
+            response = client.post(LOGIN, json=_CREDENTIALS)
+
+        assert response.status_code == 429
+        assert response.headers["content-type"].startswith("application/problem+json")
+        retry_after = response.headers["retry-after"]
+        assert retry_after.isdigit()
+        assert int(retry_after) > 0
+
+        body = response.json()
+        assert body["status"] == 429
+        assert body["type"].endswith("/too-many-requests")
+        assert body["instance"] == LOGIN
+        assert "detail" in body
+
+    def test_the_limit_is_configurable(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """A tighter limit than the 5/minute default must take effect without touching code."""
+        with _login_client(_settings(login_rate_limit="1/minute"), session_factory) as client:
+            first = client.post(LOGIN, json=_CREDENTIALS)
+            second = client.post(LOGIN, json=_CREDENTIALS)
+
+        assert first.status_code == 401
+        assert second.status_code == 429
+
+
+class TestClientIpResolutionEndToEnd:
+    """The trust boundary again, but through the real route rather than a bare `Request`."""
+
+    def test_spoofing_the_forwarded_header_does_not_buy_a_fresh_bucket_by_default(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """`trusted_proxy_hops=0` is today's default. A different `X-Forwarded-For` on every
+        request must not look like five different attackers to the limiter."""
+        with _login_client(_settings(), session_factory) as client:
+            for i in range(5):
+                client.post(LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": f"6.6.6.{i}"})
+            sixth = client.post(LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": "6.6.6.99"})
+
+        assert sixth.status_code == 429
+
+    def test_two_real_clients_behind_one_trusted_proxy_get_independent_buckets(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Once a proxy hop is trusted, users sharing it must not be collapsed onto one bucket —
+        the "punishes users behind shared NAT" failure the ticket names."""
+        settings = _settings(trusted_proxy_hops=1, login_rate_limit="1/minute")
+        with _login_client(settings, session_factory) as client:
+            user_a = client.post(
+                LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": "claim, 10.0.0.1"}
+            )
+            user_b = client.post(
+                LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": "claim, 10.0.0.2"}
+            )
+
+        assert user_a.status_code == 401
+        assert user_b.status_code == 401
+
+    def test_rotating_the_spoofable_prefix_does_not_evade_a_trusted_hop_either(
+        self, session_factory: async_sessionmaker[AsyncSession]
+    ) -> None:
+        """Even with a hop trusted, only the proxy-appended entry counts — the client's own
+        claimed identity, wherever it sits, is never load-bearing."""
+        settings = _settings(trusted_proxy_hops=1, login_rate_limit="1/minute")
+        with _login_client(settings, session_factory) as client:
+            first = client.post(
+                LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": "lie-one, 10.0.0.1"}
+            )
+            second = client.post(
+                LOGIN, json=_CREDENTIALS, headers={"X-Forwarded-For": "lie-two, 10.0.0.1"}
+            )
+
+        assert first.status_code == 401
+        assert second.status_code == 429
+
+
+def _image_bytes() -> bytes:
+    buffer = io.BytesIO()
+    Image.new("RGB", (64, 64), color=(120, 130, 140)).save(buffer, format="JPEG")
+    return buffer.getvalue()
+
+
+@pytest.fixture
+def storage(tmp_path: Path) -> LocalDiskStorage:
+    return LocalDiskStorage(tmp_path / "objects")
+
+
+async def _fake_session() -> AsyncIterator[Any]:
+    """Enough of a session for `AnalysisRepository.create` to look successful, matching the mock
+    in `tests/test_analyses.py`."""
+    pending: list[Any] = []
+
+    async def _flush() -> None:
+        for obj in pending:
+            if getattr(obj, "id", None) is None:
+                obj.id = uuid.uuid4()
+
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = None
+    execute_result.scalars.return_value.all.return_value = []
+
+    mock = MagicMock()
+    mock.add = MagicMock(side_effect=pending.append)
+    mock.add_all = MagicMock(side_effect=pending.extend)
+    mock.get = AsyncMock(return_value=None)
+    mock.flush = AsyncMock(side_effect=_flush)
+    mock.commit = AsyncMock()
+    mock.close = AsyncMock()
+    mock.execute = AsyncMock(return_value=execute_result)
+    yield mock
+
+
+@contextmanager
+def _analyses_client(settings: Settings, storage: LocalDiskStorage) -> Iterator[TestClient]:
+    app: FastAPI = create_app(settings, load_backend=False)
+    app.dependency_overrides[get_pose_backend] = lambda: FakePoseBackend()
+    app.dependency_overrides[get_storage] = lambda: storage
+    app.dependency_overrides[get_session] = _fake_session
+    app.dependency_overrides[get_current_user_id] = lambda: uuid.uuid4()
+    with TestClient(app, raise_server_exceptions=False) as client:
+        yield client
+
+
+class TestAnalysesRateLimit:
+    """A resource control, not a credential one — a small limit here to keep the test fast."""
+
+    def test_a_request_past_the_limit_is_refused(self, storage: LocalDiskStorage) -> None:
+        settings = _settings(analyses_rate_limit="2/minute")
+        with _analyses_client(settings, storage) as client:
+            for _ in range(2):
+                response = client.post(
+                    ANALYSES, files={"image": ("photo.jpg", _image_bytes(), "image/jpeg")}
+                )
+                assert response.status_code == 201
+
+            third = client.post(
+                ANALYSES, files={"image": ("photo.jpg", _image_bytes(), "image/jpeg")}
+            )
+
+        assert third.status_code == 429
+        assert third.headers["retry-after"].isdigit()
+        body = third.json()
+        assert body["type"].endswith("/too-many-requests")
+        assert body["instance"] == ANALYSES
+
+    def test_the_analyses_limit_is_independent_of_the_login_limit(
+        self, storage: LocalDiskStorage
+    ) -> None:
+        """The two are configured, and so enforced, separately — exhausting one must not touch
+        the other."""
+        settings = _settings(analyses_rate_limit="1/minute", login_rate_limit="5/minute")
+        with _analyses_client(settings, storage) as client:
+            client.post(ANALYSES, files={"image": ("photo.jpg", _image_bytes(), "image/jpeg")})
+            blocked = client.post(
+                ANALYSES, files={"image": ("photo.jpg", _image_bytes(), "image/jpeg")}
+            )
+            login_attempt = client.post(LOGIN, json=_CREDENTIALS)
+
+        assert blocked.status_code == 429
+        assert login_attempt.status_code in (401, 422)

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -1008,6 +1008,9 @@
             },
             "description": "Validation Error"
           },
+          "429": {
+            "description": "Too many uploads."
+          },
           "502": {
             "description": "Inference or storage failed downstream."
           },
@@ -1163,6 +1166,9 @@
               }
             },
             "description": "Validation Error"
+          },
+          "429": {
+            "description": "Too many attempts."
           }
         },
         "summary": "Sign in",

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -730,6 +730,13 @@ export interface operations {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
             };
+            /** @description Too many uploads. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
             /** @description Inference or storage failed downstream. */
             502: {
                 headers: {
@@ -871,6 +878,13 @@ export interface operations {
                 content: {
                     "application/json": components["schemas"]["HTTPValidationError"];
                 };
+            };
+            /** @description Too many attempts. */
+            429: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
             };
         };
     };

--- a/uv.lock
+++ b/uv.lock
@@ -696,6 +696,18 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecated"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wrapt" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/49/85/12f0a49a7c4ffb70572b6c2ef13c90c88fd190debda93b23f026b25f9634/deprecated-1.3.1.tar.gz", hash = "sha256:b1b50e0ff0c1fddaa5708a2c6b0a6588bb09b892825ab2b214ac9ea9d92a5223", size = 2932523, upload-time = "2025-10-30T08:19:02.757Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/d0/205d54408c08b13550c733c4b85429e7ead111c7f0014309637425520a9a/deprecated-1.3.1-py2.py3-none-any.whl", hash = "sha256:597bfef186b6f60181535a29fbe44865ce137a5079f295b479886c82729d5f3f", size = 11298, upload-time = "2025-10-30T08:19:00.758Z" },
+]
+
+[[package]]
 name = "dnspython"
 version = "2.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1276,6 +1288,20 @@ wheels = [
 ]
 
 [[package]]
+name = "limits"
+version = "5.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "deprecated" },
+    { name = "packaging" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/69/826a5d1f45426c68d8f6539f8d275c0e4fcaa57f0c017ec3100986558a41/limits-5.8.0.tar.gz", hash = "sha256:c9e0d74aed837e8f6f50d1fcebcf5fd8130957287206bc3799adaee5092655da", size = 226104, upload-time = "2026-02-05T07:17:35.859Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/98/cb5ca20618d205a09d5bec7591fbc4130369c7e6308d9a676a28ff3ab22c/limits-5.8.0-py3-none-any.whl", hash = "sha256:ae1b008a43eb43073c3c579398bd4eb4c795de60952532dc24720ab45e1ac6b8", size = 60954, upload-time = "2026-02-05T07:17:34.425Z" },
+]
+
+[[package]]
 name = "mako"
 version = "1.3.12"
 source = { registry = "https://pypi.org/simple" }
@@ -1644,6 +1670,7 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "pyjwt" },
     { name = "python-multipart" },
+    { name = "slowapi" },
     { name = "sqlalchemy", extra = ["asyncio"] },
     { name = "structlog" },
 ]
@@ -1679,6 +1706,7 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.7" },
     { name = "pyjwt", specifier = ">=2.10" },
     { name = "python-multipart", specifier = ">=0.0.18" },
+    { name = "slowapi", specifier = ">=0.1.10" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0.36" },
     { name = "structlog", specifier = ">=24.4" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.51.0" },
@@ -2397,6 +2425,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/94/e7/b2c673351809dca68a0e064b6af791aa332cf192da575fd474ed7d6f16a2/six-1.17.0.tar.gz", hash = "sha256:ff70335d468e7eb6ec65b95b99d3a2836546063f63acc5171de367e834932a81", size = 34031, upload-time = "2024-12-04T17:35:28.174Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/b7/ce/149a00dd41f10bc29e5921b496af8b574d8413afcd5e30dfa0ed46c2cc5e/six-1.17.0-py2.py3-none-any.whl", hash = "sha256:4721f391ed90541fddacab5acf947aa0d3dc7d27b2e1e8eda2be8970586c3274", size = 11050, upload-time = "2024-12-04T17:35:26.475Z" },
+]
+
+[[package]]
+name = "slowapi"
+version = "0.1.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "limits" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b9/52/24527cf25a8b508926aff53350b0136561dfe86c7125f61526653666e1b2/slowapi-0.1.10.tar.gz", hash = "sha256:d320d5bc04d9f171a77fb16700faf3036d85b00f420f22924c8a225f95bd14f9", size = 13841, upload-time = "2026-06-13T11:59:31.571Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c4/8b/1d359f38706b4097d9a943bf8bd22599f537de4cbaff1e622d3e3936e164/slowapi-0.1.10-py3-none-any.whl", hash = "sha256:3acb61561dc9d687e3d3669362ff6a439de9ba44e2fed3a9c165da26b4b83e28", size = 14921, upload-time = "2026-06-13T11:59:30.485Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

- `slowapi`-backed rate limiting: 5/min per IP on `POST /api/v1/auth/login`, 10/min per IP on `POST /api/v1/analyses`. Both limits are `Settings` fields (`login_rate_limit`, `analyses_rate_limit`), not hardcoded, and validated against `limits` syntax at startup so a typo fails fast instead of silently leaving a route unlimited.
- `resolve_client_ip` (`rate_limit.py`) — a hop-count trust model for `X-Forwarded-For`, gated by a new `trusted_proxy_hops` setting (default `0`). At `0` the header is never read; the direct TCP peer is used. This is today's correct answer — nothing sits in front of the API in Compose yet.
- 429s go through the same `problem_response` helper every other error uses (RFC 9457 `application/problem+json`), with a `Retry-After` header computed straight from `slowapi`'s window stats.
- Regenerated `apps/web/src/api/openapi.json` / `schema.d.ts` for the two new 429 responses.

## Why

Two limits, two different threat models — kept separate rather than reasoned about together:

- **Login** is a credential-stuffing control. Argon2id makes every guess expensive for the server too, so an unlimited login endpoint is simultaneously an account-security hole and a DoS amplifier.
- **Analyses** is a resource control. Pose inference is the most expensive thing this service does; without a cap, one client saturates the worker pool and every other upload queues behind it.

Known, intentionally out of scope: per-IP limiting is defeated by a distributed attacker and punishes users behind shared NAT (mitigated for the NAT case by `trusted_proxy_hops`, once there's a real proxy in front). Per-account login limiting and a global inference concurrency cap are future work, not implemented here.

## Design decision worth a look

`trusted_proxy_hops` is a hop-*count* trust model (Werkzeug `ProxyFix` / Express `trust proxy` style) — it discards the outermost N-minus-configured entries in `X-Forwarded-For` rather than verifying the connecting peer is an actual allowlisted proxy IP (nginx `set_real_ip_from` style). Sufficient for the current topology (no proxy at all, default `0`), but worth confirming this is the model we want once a production reverse-proxy overlay exists.

## How tested

- `ruff check` / `ruff format --check` — clean
- `mypy --strict` (`packages apps`) — clean, 108 source files
- `pytest -m "not model"` — 357 passed
- `uv lock --check` — no diff, lockfile authoritative
- `docker compose up -d --wait` — `/health/ready` ready, web healthy, clean teardown
- New tests: `test_config.py::TestRateLimiting` (defaults, overridability, malformed-limit and negative-hop-count validation) and `test_rate_limit.py` (14 tests) — direct unit tests of `resolve_client_ip` including a spoofing attempt, exhausting both limiters end-to-end, RFC 9457/`Retry-After` shape, and independence between the login and analyses buckets.