### PR TITLE
OP-58: History view with thumbnails and trunk-inclination trend sparkline

### DIFF
--- a/apps/api/src/openposture_api/analyses.py
+++ b/apps/api/src/openposture_api/analyses.py
@@ -53,11 +53,14 @@ from openposture_api.schemas import (
     PostureReportModel,
     StoredFinding,
     StoredMetric,
+    TrendPoint,
+    TrendSeries,
 )
 from openposture_api.storage import StorageBackend, StorageError, get_storage
 from pose_backends.base import PoseBackend
 from pose_backends.errors import PoseBackendError
 from posture_core import build_report
+from posture_core.metrics.trunk import NAME as _TRUNK_INCLINATION_CODE
 from posture_core.report import SCHEMA_VERSION as _SCHEMA_VERSION
 from posture_core.thresholds import DEFAULT_THRESHOLDS as _DEFAULT_THRESHOLDS
 
@@ -273,6 +276,7 @@ def build_analyses_router(limiter: Limiter, settings: Settings) -> APIRouter:
     )
     async def list_analyses(
         user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
+        storage: Annotated[StorageBackend, Depends(get_storage)],
         session: Annotated[AsyncSession, Depends(get_session)],
         limit: int = Query(default=20, ge=1, le=100, description="Page size."),
         cursor: str | None = Query(default=None, description="Opaque cursor from `next_cursor`."),
@@ -296,8 +300,40 @@ def build_analyses_router(limiter: Limiter, settings: Settings) -> APIRouter:
         next_cursor = _encode_cursor(rows[-1].created_at, rows[-1].id) if has_more else None
 
         return AnalysisPage(
-            items=[_to_list_item(a) for a in rows],
+            items=[_to_list_item(a, storage) for a in rows],
             next_cursor=next_cursor,
+        )
+
+    @router.get(
+        "/analyses/metrics/trunk-inclination",
+        status_code=status.HTTP_200_OK,
+        response_model=TrendSeries,
+        summary="Trunk inclination trend across all analyses",
+        description=(
+            "Returns every trunk_inclination_deg measurement for the authenticated user, newest "
+            "first, from a single indexed query — the history sparkline's data source. A "
+            "`rules_version` change partway through the series marks a retuned threshold, not a "
+            "change in the user's posture; a `null` value is a gap the engine could not measure, "
+            "never a zero."
+        ),
+        responses={**_UNAUTHORIZED},
+    )
+    async def get_trunk_inclination_trend(
+        user_id: Annotated[uuid.UUID, Depends(get_current_user_id)],
+        session: Annotated[AsyncSession, Depends(get_session)],
+    ) -> TrendSeries:
+        repo = AnalysisRepository(session)
+        points = await repo.list_metric_trend(user_id, code=_TRUNK_INCLINATION_CODE)
+        return TrendSeries(
+            points=[
+                TrendPoint(
+                    created_at=p.created_at,
+                    value=p.value,
+                    status=p.status,  # type: ignore[arg-type]
+                    rules_version=p.rules_version,
+                )
+                for p in points
+            ]
         )
 
     @router.get(
@@ -405,11 +441,14 @@ def _decode_cursor(cursor: str) -> tuple[datetime, uuid.UUID]:
         ) from exc
 
 
-def _to_list_item(analysis: Analysis) -> AnalysisListItem:
+def _to_list_item(analysis: Analysis, storage: StorageBackend) -> AnalysisListItem:
     return AnalysisListItem(
         id=analysis.id,
         created_at=analysis.created_at,
         object_key=analysis.object_key,
+        # Built here, on every response, from the key alone — never a URL read back out of the
+        # row. See the storage module docstring (D3).
+        image_url=storage.url_for(analysis.object_key),
         pose_detected=analysis.pose_detected,
         overall_score=analysis.overall_score,
     )

--- a/apps/api/src/openposture_api/main.py
+++ b/apps/api/src/openposture_api/main.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING
 
 import structlog
 from fastapi import FastAPI
+from starlette.staticfiles import StaticFiles
 
 from openposture_api import __version__
 from openposture_api.analyses import build_analyses_router, register_analysis_error_handlers
@@ -38,7 +39,7 @@ from openposture_api.pose import (
     load_pose_backend,
 )
 from openposture_api.rate_limit import build_limiter, register_rate_limit_handlers
-from openposture_api.storage import create_storage
+from openposture_api.storage import LOCAL_BACKEND, create_storage
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -183,6 +184,23 @@ def create_app(
     )
     app.include_router(build_auth_router(app.state.limiter, resolved))
     app.include_router(build_analyses_router(app.state.limiter, resolved))
+
+    if resolved.storage_backend == LOCAL_BACKEND:
+        # `LocalDiskStorage.url_for` builds URLs under `media_base_url` (D3) on the promise that
+        # something serves them; until E10 nothing dereferenced one, so nothing had to yet. The
+        # `s3` backend needs no mount here — its `url_for` returns a presigned URL straight to
+        # the object store.
+        #
+        # `check_dir=False`: at this point in `create_app`, `lifespan` has not run, so
+        # `LocalDiskStorage.__init__` has not yet created `storage_root`. It exists by the time a
+        # request can arrive — lifespan startup completes before the ASGI server accepts
+        # connections — so the check would only ever fail on a directory the app is about to
+        # create itself.
+        app.mount(
+            resolved.media_base_url,
+            StaticFiles(directory=resolved.storage_root, check_dir=False),
+            name="media",
+        )
 
     _LOGGER.info(
         "app_created",

--- a/apps/api/src/openposture_api/repos/analyses.py
+++ b/apps/api/src/openposture_api/repos/analyses.py
@@ -32,7 +32,23 @@ from openposture_api.db.models import Analysis, Finding, Keypoint, Metric
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncSession
 
-__all__ = ["AnalysisRepository", "FindingRecord", "KeypointRecord", "MetricRecord"]
+__all__ = [
+    "AnalysisRepository",
+    "FindingRecord",
+    "KeypointRecord",
+    "MetricRecord",
+    "MetricTrendPoint",
+]
+
+
+@dataclasses.dataclass(frozen=True)
+class MetricTrendPoint:
+    """One point of a metric's trend across a user's analyses, newest first."""
+
+    created_at: datetime
+    rules_version: str
+    value: float | None
+    status: str
 
 
 @dataclasses.dataclass(frozen=True)
@@ -225,6 +241,41 @@ class AnalysisRepository:
             )
 
         return list((await self._session.execute(stmt)).scalars().all())
+
+    async def list_metric_trend(
+        self,
+        user_id: uuid.UUID,
+        *,
+        code: str,
+    ) -> list[MetricTrendPoint]:
+        """Every value of one metric across a user's analyses, newest first, in one query.
+
+        This is the query named in `Metric.__table_args__`: it drives off
+        `ix_analyses_user_id_created_at_id` and looks each metric up on the
+        `(analysis_id, code)` prefix of `uq_metrics_analysis_id_code`. A plain indexed `SELECT`
+        rather than an application-side loop deserialising documents is the entire payoff E2
+        argued for and E10 spends.
+
+        `value` and `status` come through unfiltered, gaps included — a row with
+        `status != 'ok'` has `value IS NULL` by the database's own check constraint, so a gap
+        here is already a gap, never a 0 this method would have to know to avoid inventing.
+        """
+        stmt = (
+            select(Analysis.created_at, Analysis.rules_version, Metric.value, Metric.status)
+            .join(Metric, Metric.analysis_id == Analysis.id)
+            .where(Analysis.user_id == user_id, Metric.code == code)
+            .order_by(Analysis.created_at.desc())
+        )
+        rows = (await self._session.execute(stmt)).all()
+        return [
+            MetricTrendPoint(
+                created_at=row.created_at,
+                rules_version=row.rules_version,
+                value=row.value,
+                status=row.status,
+            )
+            for row in rows
+        ]
 
     async def delete(
         self,

--- a/apps/api/src/openposture_api/schemas.py
+++ b/apps/api/src/openposture_api/schemas.py
@@ -236,6 +236,12 @@ class AnalysisListItem(ContractModel):
     id: uuid.UUID
     created_at: datetime
     object_key: str
+    image_url: str = Field(
+        description=(
+            "Built from `object_key` via the storage layer's own URL construction, on every "
+            "response — never a URL read back out of the database (D3)."
+        )
+    )
     pose_detected: bool
     overall_score: float | None
 
@@ -250,6 +256,28 @@ class AnalysisPage(ContractModel):
             "`null` when this is the last page."
         )
     )
+
+
+class TrendPoint(ContractModel):
+    """One analysis's trunk-inclination measurement, for the history sparkline."""
+
+    created_at: datetime
+    value: float | None = Field(
+        description="`null` whenever `status` is not `ok` — a gap in the line, never a 0."
+    )
+    status: MetricStatus
+    rules_version: str = Field(
+        description=(
+            "The ruleset in force when this point was measured. A change partway through the "
+            "series marks a retuned threshold, not a change in the user's posture."
+        )
+    )
+
+
+class TrendSeries(ContractModel):
+    """The full trunk-inclination trend for one user, newest first — one indexed query."""
+
+    points: list[TrendPoint]
 
 
 class StoredMetric(ContractModel):

--- a/apps/api/tests/integration/test_analysis_repo.py
+++ b/apps/api/tests/integration/test_analysis_repo.py
@@ -396,3 +396,174 @@ async def test_delete_returns_none_for_another_users_analysis(session: AsyncSess
     assert result is None
     # The row is still there for its owner.
     assert await repo.get(owner, analysis.id) is not None
+
+
+# ---------------------------------------------------------------------------
+# E10: metric trend, for the history sparkline
+# ---------------------------------------------------------------------------
+
+_TRUNK = "trunk_inclination_deg"
+
+
+async def _create_with_trunk_metric(
+    session: AsyncSession,
+    *,
+    user_id: uuid.UUID,
+    object_key: str,
+    rules_version: str = "1.0.0",
+    value: float | None,
+    status: str = "ok",
+) -> Analysis:
+    """An analysis with a single `trunk_inclination_deg` metric row, gap or not.
+
+    `status` and `value` are both caller-supplied rather than one derived from the other,
+    because `Metric`'s own check constraint (`a_value_exists_exactly_when_the_status_is_ok`) is
+    exactly the invariant these tests exist to exercise — passing a mismatched pair should fail
+    at the database, not be silently corrected here.
+    """
+    repo = AnalysisRepository(session)
+    return await repo.create(
+        user_id=user_id,
+        object_key=object_key,
+        pose_detected=status == "ok",
+        image_width=640,
+        image_height=480,
+        overall_score=72.0 if status == "ok" else None,
+        assessed=1 if status == "ok" else 0,
+        total=1,
+        inference_ms=18.3,
+        pose_backend="fake",
+        rules_version=rules_version,
+        schema_version="1.0",
+        metrics=[
+            MetricRecord(
+                code=_TRUNK,
+                value=value,
+                unit="deg",
+                status=status,
+                detail="",
+                confidence=0.9 if status == "ok" else None,
+            )
+        ],
+    )
+
+
+async def test_list_metric_trend_returns_empty_for_user_with_no_analyses(
+    session: AsyncSession,
+) -> None:
+    user_id = await _make_user_id(session)
+    repo = AnalysisRepository(session)
+    points = await repo.list_metric_trend(user_id, code=_TRUNK)
+    assert points == []
+
+
+async def test_list_metric_trend_returns_only_the_requested_users_points(
+    session: AsyncSession,
+) -> None:
+    user_a = await _make_user_id(session)
+    user_b = await _make_user_id(session)
+
+    await _create_with_trunk_metric(session, user_id=user_a, object_key="a1.jpg", value=10.0)
+    await _create_with_trunk_metric(session, user_id=user_b, object_key="b1.jpg", value=20.0)
+
+    repo = AnalysisRepository(session)
+    points = await repo.list_metric_trend(user_a, code=_TRUNK)
+
+    assert len(points) == 1
+    assert points[0].value == pytest.approx(10.0)
+
+
+async def test_list_metric_trend_only_returns_the_requested_code(session: AsyncSession) -> None:
+    """A metric row for a different code is not mistaken for a gap in this one."""
+    user_id = await _make_user_id(session)
+    repo = AnalysisRepository(session)
+    await repo.create(
+        user_id=user_id,
+        object_key="other.jpg",
+        pose_detected=True,
+        image_width=640,
+        image_height=480,
+        overall_score=72.0,
+        assessed=1,
+        total=1,
+        inference_ms=18.3,
+        pose_backend="fake",
+        rules_version="1.0.0",
+        schema_version="1.0",
+        metrics=[
+            MetricRecord(
+                code="neck_flexion_deg",
+                value=5.0,
+                unit="deg",
+                status="ok",
+                detail="",
+                confidence=0.9,
+            )
+        ],
+    )
+
+    points = await repo.list_metric_trend(user_id, code=_TRUNK)
+    assert points == []
+
+
+async def test_list_metric_trend_is_newest_first(session: AsyncSession) -> None:
+    user_id = await _make_user_id(session)
+
+    first = await _create_with_trunk_metric(session, user_id=user_id, object_key="1.jpg", value=5.0)
+    second = await _create_with_trunk_metric(
+        session, user_id=user_id, object_key="2.jpg", value=8.0
+    )
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    first.created_at = base
+    second.created_at = base + timedelta(seconds=1)
+    await session.flush()
+
+    repo = AnalysisRepository(session)
+    points = await repo.list_metric_trend(user_id, code=_TRUNK)
+
+    assert [p.value for p in points] == [8.0, 5.0]
+
+
+async def test_list_metric_trend_preserves_gaps_as_null_not_zero(session: AsyncSession) -> None:
+    """A metric the engine could not measure comes back `None`, never `0`.
+
+    Plotting a gap as `0` would invent an upright posture the user never had — the original
+    engine's silent-`None`-to-"Straight back" defect, reincarnated in chart form.
+    """
+    user_id = await _make_user_id(session)
+    await _create_with_trunk_metric(
+        session,
+        user_id=user_id,
+        object_key="gap.jpg",
+        value=None,
+        status="insufficient_keypoints",
+    )
+
+    repo = AnalysisRepository(session)
+    points = await repo.list_metric_trend(user_id, code=_TRUNK)
+
+    assert len(points) == 1
+    assert points[0].value is None
+    assert points[0].status == "insufficient_keypoints"
+
+
+async def test_list_metric_trend_carries_rules_version_per_point(session: AsyncSession) -> None:
+    """Each point keeps the ruleset in force when it was measured, so a caller can mark a
+    version boundary rather than plot a retune as a step in the user's posture."""
+    user_id = await _make_user_id(session)
+
+    old = await _create_with_trunk_metric(
+        session, user_id=user_id, object_key="old.jpg", value=12.0, rules_version="1.0.0"
+    )
+    new = await _create_with_trunk_metric(
+        session, user_id=user_id, object_key="new.jpg", value=14.0, rules_version="2.0.0"
+    )
+    base = datetime(2026, 1, 1, tzinfo=UTC)
+    old.created_at = base
+    new.created_at = base + timedelta(seconds=1)
+    await session.flush()
+
+    repo = AnalysisRepository(session)
+    points = await repo.list_metric_trend(user_id, code=_TRUNK)
+
+    assert [p.rules_version for p in points] == ["2.0.0", "1.0.0"]

--- a/apps/api/tests/test_analyses.py
+++ b/apps/api/tests/test_analyses.py
@@ -10,6 +10,8 @@ from __future__ import annotations
 import io
 import uuid
 from contextlib import contextmanager
+from datetime import UTC, datetime
+from types import SimpleNamespace
 from typing import TYPE_CHECKING, Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -21,6 +23,7 @@ from pydantic import ValidationError
 from openposture_api.auth import get_current_user_id
 from openposture_api.config import Settings
 from openposture_api.db import get_session
+from openposture_api.db.models import Analysis
 from openposture_api.images import MAX_IMAGE_BYTES
 from openposture_api.main import create_app
 from openposture_api.pose import get_pose_backend
@@ -560,3 +563,98 @@ class TestReadAndDeleteEndpoints:
 
         assert response.status_code == 204
         assert not storage.exists(stored.key), "the object outlived the row that named it"
+
+
+class TestListThumbnails:
+    """E10: the history list's `image_url`, built from storage, never read out of a row."""
+
+    _USER_ID = uuid.uuid4()
+
+    def test_list_items_carry_a_storage_built_image_url(
+        self, settings: Settings, storage: LocalDiskStorage
+    ) -> None:
+        stored = storage.put(b"not-really-a-jpeg", content_type="image/jpeg")
+        row = Analysis(
+            id=uuid.uuid4(),
+            created_at=datetime.now(UTC),
+            object_key=stored.key,
+            pose_detected=True,
+            overall_score=72.0,
+        )
+
+        async def _session_holding_one_row() -> Any:
+            result = MagicMock()
+            result.scalars.return_value.all.return_value = [row]
+            mock = MagicMock()
+            mock.execute = AsyncMock(return_value=result)
+            yield mock
+
+        app = create_app(settings, load_backend=False)
+        app.dependency_overrides[get_session] = _session_holding_one_row
+        app.dependency_overrides[get_storage] = lambda: storage
+        app.dependency_overrides[get_current_user_id] = lambda: self._USER_ID
+
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/analyses")
+
+        assert response.status_code == 200
+        item = response.json()["items"][0]
+        # Same construction the storage layer would do for any other caller, not a value copied
+        # out of the row — there is no `image_url` column for it to have come from.
+        assert item["image_url"] == storage.url_for(stored.key)
+        assert item["object_key"] == stored.key
+
+
+class TestTrunkInclinationTrendEndpoint:
+    """E10: GET /analyses/metrics/trunk-inclination — the history sparkline's data source."""
+
+    _USER_ID = uuid.uuid4()
+
+    def test_requires_authentication(self, settings: Settings) -> None:
+        app = create_app(settings, load_backend=False)
+        app.dependency_overrides[get_session] = _fake_session
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/analyses/metrics/trunk-inclination")
+        assert response.status_code == 401
+
+    def test_returns_an_empty_series_for_a_new_user(self, settings: Settings) -> None:
+        app = create_app(settings, load_backend=False)
+        app.dependency_overrides[get_session] = _fake_session
+        app.dependency_overrides[get_current_user_id] = lambda: self._USER_ID
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/analyses/metrics/trunk-inclination")
+        assert response.status_code == 200
+        assert response.json() == {"points": []}
+
+    def test_a_gap_is_null_not_zero(self, settings: Settings) -> None:
+        """A row with no measured value must not become a plotted `0`.
+
+        The original engine's silent-`None`-to-"Straight back" defect, in chart form — this is
+        the response-schema half of the guarantee the repo test covers at the query level.
+        """
+
+        async def _session_with_one_gap() -> Any:
+            # `.created_at` etc., not tuple indices — the repository reads these the same way
+            # SQLAlchemy's own `Row` objects support attribute access for labelled columns.
+            row = SimpleNamespace(
+                created_at=datetime.now(UTC),
+                rules_version="1.0.0",
+                value=None,
+                status="insufficient_keypoints",
+            )
+            result = MagicMock()
+            result.all.return_value = [row]
+            mock = MagicMock()
+            mock.execute = AsyncMock(return_value=result)
+            yield mock
+
+        app = create_app(settings, load_backend=False)
+        app.dependency_overrides[get_session] = _session_with_one_gap
+        app.dependency_overrides[get_current_user_id] = lambda: self._USER_ID
+        with TestClient(app, raise_server_exceptions=False) as client:
+            response = client.get("/api/v1/analyses/metrics/trunk-inclination")
+
+        assert response.status_code == 200
+        point = response.json()["points"][0]
+        assert point["value"] is None
+        assert point["status"] == "insufficient_keypoints"

--- a/apps/api/tests/test_tenancy.py
+++ b/apps/api/tests/test_tenancy.py
@@ -351,7 +351,8 @@ class TestRouteTable:
             route for route in _iter_api_routes(app) if route.path.startswith(ANALYSES)
         ]
 
-        assert len(analyses_routes) == 4
+        # 5 as of E10's trend endpoint: create, list, get, delete, trunk-inclination trend.
+        assert len(analyses_routes) == 5
         assert all(_depends_on_current_user(route) for route in analyses_routes)
 
 

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -3,6 +3,7 @@ import { useAuth } from './auth'
 import ProtectedRoute from './components/ProtectedRoute'
 import HomeView from './views/HomeView'
 import Dashboard from './views/Dashboard'
+import History from './views/History'
 import Login from './views/auth/Login'
 import Registration from './views/auth/Registration'
 import logo from './assets/openPose.png'
@@ -57,6 +58,9 @@ export default function App() {
             <NavLink className={navLinkClass} to="/dashboard">
               Dashboard
             </NavLink>
+            <NavLink className={navLinkClass} to="/history">
+              History
+            </NavLink>
             {isLoggedIn ? (
               <button
                 className={cx('button', 'buttonSecondary', styles.navButton)}
@@ -89,6 +93,14 @@ export default function App() {
             element={
               <ProtectedRoute>
                 <Dashboard />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/history"
+            element={
+              <ProtectedRoute>
+                <History />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/api/client.ts
+++ b/apps/web/src/api/client.ts
@@ -12,7 +12,14 @@
  * this ticket deletes, just better dressed. XHR's `upload.onprogress` reports real bytes.
  */
 
-import type { AnalysisResponse, CredentialsRequest, Problem, TokenResponse } from './types'
+import type {
+  AnalysisPage,
+  AnalysisResponse,
+  CredentialsRequest,
+  Problem,
+  TokenResponse,
+  TrendSeries,
+} from './types'
 import { getAccessToken, setAccessToken } from '../auth/tokenStore'
 
 export const ANALYSES_ENDPOINT = '/api/v1/analyses'
@@ -323,4 +330,62 @@ async function performRefresh(): Promise<string | null> {
     setAccessToken(null)
     return null
   }
+}
+
+/**
+ * `GET` against the analyses API: `Authorization: Bearer`, same as `analysePosture`, not the
+ * `credentials: 'include'` cookie `postJson` uses — the analyses routes authenticate off the
+ * access token, not the refresh cookie.
+ *
+ * Same single-retry-on-401 shape as `attemptAnalysis`: a second 401 after a successful refresh
+ * falls straight through to the ordinary error branch instead of refreshing again, so a server
+ * that keeps answering 401 cannot recurse forever.
+ */
+async function getJson<T>(
+  path: string,
+  options: { signal?: AbortSignal } = {},
+  allowRetry = true,
+): Promise<T> {
+  const init: RequestInit = {}
+  if (options.signal) init.signal = options.signal
+  const token = getAccessToken()
+  if (token !== null) {
+    init.headers = { Authorization: `Bearer ${token}` }
+  }
+
+  const response = await fetch(path, init)
+
+  if (response.status === 401 && allowRetry) {
+    const refreshed = await refreshAccessToken()
+    if (refreshed === null) {
+      throw new ApiError('Your session has expired. Please sign in again.', { status: 401 })
+    }
+    return getJson<T>(path, options, /* allowRetry */ false)
+  }
+
+  if (!response.ok) {
+    const problem = (await response.json().catch(() => null)) as Problem | null
+    throw new ApiError(problem?.detail ?? `The server responded with ${response.status}.`, {
+      status: response.status,
+      type: problem?.type,
+      requestId: problem?.request_id,
+    })
+  }
+
+  return (await response.json()) as T
+}
+
+/** One page of the authenticated user's analysis history, newest first. */
+export function listAnalyses(
+  options: { cursor?: string; signal?: AbortSignal } = {},
+): Promise<AnalysisPage> {
+  const query = options.cursor ? `?cursor=${encodeURIComponent(options.cursor)}` : ''
+  const getOptions = options.signal ? { signal: options.signal } : {}
+  return getJson<AnalysisPage>(`${ANALYSES_ENDPOINT}${query}`, getOptions)
+}
+
+/** The trunk-inclination trend behind the history sparkline, newest first. */
+export function getTrunkInclinationTrend(signal?: AbortSignal): Promise<TrendSeries> {
+  const getOptions = signal ? { signal } : {}
+  return getJson<TrendSeries>(`${ANALYSES_ENDPOINT}/metrics/trunk-inclination`, getOptions)
 }

--- a/apps/web/src/api/openapi.json
+++ b/apps/web/src/api/openapi.json
@@ -117,6 +117,11 @@
             "title": "Id",
             "type": "string"
           },
+          "image_url": {
+            "description": "Built from `object_key` via the storage layer's own URL construction, on every response \u2014 never a URL read back out of the database (D3).",
+            "title": "Image Url",
+            "type": "string"
+          },
           "object_key": {
             "title": "Object Key",
             "type": "string"
@@ -141,6 +146,7 @@
           "id",
           "created_at",
           "object_key",
+          "image_url",
           "pose_detected",
           "overall_score"
         ],
@@ -833,6 +839,69 @@
         "title": "TokenResponse",
         "type": "object"
       },
+      "TrendPoint": {
+        "additionalProperties": false,
+        "description": "One analysis's trunk-inclination measurement, for the history sparkline.",
+        "properties": {
+          "created_at": {
+            "format": "date-time",
+            "title": "Created At",
+            "type": "string"
+          },
+          "rules_version": {
+            "description": "The ruleset in force when this point was measured. A change partway through the series marks a retuned threshold, not a change in the user's posture.",
+            "title": "Rules Version",
+            "type": "string"
+          },
+          "status": {
+            "enum": [
+              "ok",
+              "insufficient_keypoints",
+              "low_confidence"
+            ],
+            "title": "Status",
+            "type": "string"
+          },
+          "value": {
+            "anyOf": [
+              {
+                "type": "number"
+              },
+              {
+                "type": "null"
+              }
+            ],
+            "description": "`null` whenever `status` is not `ok` \u2014 a gap in the line, never a 0.",
+            "title": "Value"
+          }
+        },
+        "required": [
+          "created_at",
+          "value",
+          "status",
+          "rules_version"
+        ],
+        "title": "TrendPoint",
+        "type": "object"
+      },
+      "TrendSeries": {
+        "additionalProperties": false,
+        "description": "The full trunk-inclination trend for one user, newest first \u2014 one indexed query.",
+        "properties": {
+          "points": {
+            "items": {
+              "$ref": "#/components/schemas/TrendPoint"
+            },
+            "title": "Points",
+            "type": "array"
+          }
+        },
+        "required": [
+          "points"
+        ],
+        "title": "TrendSeries",
+        "type": "object"
+      },
       "ValidationError": {
         "properties": {
           "ctx": {
@@ -1024,6 +1093,36 @@
           }
         ],
         "summary": "Analyse posture in a photograph",
+        "tags": [
+          "analyses"
+        ]
+      }
+    },
+    "/api/v1/analyses/metrics/trunk-inclination": {
+      "get": {
+        "description": "Returns every trunk_inclination_deg measurement for the authenticated user, newest first, from a single indexed query \u2014 the history sparkline's data source. A `rules_version` change partway through the series marks a retuned threshold, not a change in the user's posture; a `null` value is a gap the engine could not measure, never a zero.",
+        "operationId": "get_trunk_inclination_trend_api_v1_analyses_metrics_trunk_inclination_get",
+        "responses": {
+          "200": {
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/TrendSeries"
+                }
+              }
+            },
+            "description": "Successful Response"
+          },
+          "401": {
+            "description": "Missing or invalid access token."
+          }
+        },
+        "security": [
+          {
+            "HTTPBearer": []
+          }
+        ],
+        "summary": "Trunk inclination trend across all analyses",
         "tags": [
           "analyses"
         ]

--- a/apps/web/src/api/schema.d.ts
+++ b/apps/web/src/api/schema.d.ts
@@ -28,6 +28,26 @@ export interface paths {
         patch?: never;
         trace?: never;
     };
+    "/api/v1/analyses/metrics/trunk-inclination": {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        /**
+         * Trunk inclination trend across all analyses
+         * @description Returns every trunk_inclination_deg measurement for the authenticated user, newest first, from a single indexed query — the history sparkline's data source. A `rules_version` change partway through the series marks a retuned threshold, not a change in the user's posture; a `null` value is a gap the engine could not measure, never a zero.
+         */
+        get: operations["get_trunk_inclination_trend_api_v1_analyses_metrics_trunk_inclination_get"];
+        put?: never;
+        post?: never;
+        delete?: never;
+        options?: never;
+        head?: never;
+        patch?: never;
+        trace?: never;
+    };
     "/api/v1/analyses/{analysis_id}": {
         parameters: {
             query?: never;
@@ -245,6 +265,11 @@ export interface components {
              * Format: uuid
              */
             id: string;
+            /**
+             * Image Url
+             * @description Built from `object_key` via the storage layer's own URL construction, on every response — never a URL read back out of the database (D3).
+             */
+            image_url: string;
             /** Object Key */
             object_key: string;
             /** Overall Score */
@@ -608,6 +633,40 @@ export interface components {
              */
             token_type: "bearer";
         };
+        /**
+         * TrendPoint
+         * @description One analysis's trunk-inclination measurement, for the history sparkline.
+         */
+        TrendPoint: {
+            /**
+             * Created At
+             * Format: date-time
+             */
+            created_at: string;
+            /**
+             * Rules Version
+             * @description The ruleset in force when this point was measured. A change partway through the series marks a retuned threshold, not a change in the user's posture.
+             */
+            rules_version: string;
+            /**
+             * Status
+             * @enum {string}
+             */
+            status: "ok" | "insufficient_keypoints" | "low_confidence";
+            /**
+             * Value
+             * @description `null` whenever `status` is not `ok` — a gap in the line, never a 0.
+             */
+            value: number | null;
+        };
+        /**
+         * TrendSeries
+         * @description The full trunk-inclination trend for one user, newest first — one indexed query.
+         */
+        TrendSeries: {
+            /** Points */
+            points: components["schemas"]["TrendPoint"][];
+        };
         /** ValidationError */
         ValidationError: {
             /** Context */
@@ -746,6 +805,33 @@ export interface operations {
             };
             /** @description Inference is unavailable. */
             503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content?: never;
+            };
+        };
+    };
+    get_trunk_inclination_trend_api_v1_analyses_metrics_trunk_inclination_get: {
+        parameters: {
+            query?: never;
+            header?: never;
+            path?: never;
+            cookie?: never;
+        };
+        requestBody?: never;
+        responses: {
+            /** @description Successful Response */
+            200: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["TrendSeries"];
+                };
+            };
+            /** @description Missing or invalid access token. */
+            401: {
                 headers: {
                     [name: string]: unknown;
                 };

--- a/apps/web/src/api/types.ts
+++ b/apps/web/src/api/types.ts
@@ -32,6 +32,18 @@ export type PostureReport = Schemas['PostureReportModel']
 
 export type AnalysisResponse = Schemas['AnalysisResponse']
 
+/** One row in the history list. */
+export type AnalysisListItem = Schemas['AnalysisListItem']
+
+/** One page of `GET /analyses`. */
+export type AnalysisPage = Schemas['AnalysisPage']
+
+/** One point on the trunk-inclination trend line. `value` is `null` on a gap, never `0`. */
+export type TrendPoint = Schemas['TrendPoint']
+
+/** The full trend returned by `GET /analyses/metrics/trunk-inclination`. */
+export type TrendSeries = Schemas['TrendSeries']
+
 /** The body of `POST /auth/register` and `POST /auth/login`. */
 export type CredentialsRequest = Schemas['CredentialsRequest']
 

--- a/apps/web/src/views/History.module.css
+++ b/apps/web/src/views/History.module.css
@@ -1,0 +1,105 @@
+.container {
+  max-width: 52rem;
+}
+
+.container > h1 {
+  margin-bottom: var(--space-5);
+}
+
+.loading,
+.empty {
+  padding: var(--space-5);
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+  text-align: center;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.error {
+  margin-bottom: var(--space-5);
+  padding: var(--space-5);
+  border-radius: var(--radius-lg);
+  border: 1px solid color-mix(in srgb, var(--color-danger) 35%, transparent);
+  background: var(--color-danger-soft);
+}
+
+.error h2 {
+  margin-bottom: var(--space-2);
+  font-size: 1.125rem;
+  color: var(--color-danger);
+}
+
+.error p {
+  color: var(--color-text);
+  font-size: 0.9375rem;
+}
+
+.requestId {
+  margin-top: var(--space-3);
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
+}
+
+.requestId code {
+  padding: 0.1em 0.4em;
+  border-radius: var(--radius-sm);
+  background: var(--color-surface-sunken);
+  font-family: var(--font-mono);
+  font-size: 0.9em;
+}
+
+.trendCard {
+  margin-bottom: var(--space-6);
+  padding: var(--space-5);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-sm);
+}
+
+.trendCard h2 {
+  margin-bottom: var(--space-4);
+}
+
+.list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+  list-style: none;
+}
+
+.item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  padding: var(--space-3);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+}
+
+.thumbnail {
+  width: 4.5rem;
+  height: 4.5rem;
+  flex-shrink: 0;
+  object-fit: cover;
+  border-radius: var(--radius-md);
+  background: var(--color-surface-sunken);
+}
+
+.itemBody {
+  min-width: 0;
+}
+
+.itemDate {
+  font-weight: 600;
+  font-size: 0.9375rem;
+}
+
+.itemScore {
+  color: var(--color-text-muted);
+  font-size: 0.875rem;
+}

--- a/apps/web/src/views/History.test.tsx
+++ b/apps/web/src/views/History.test.tsx
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest'
+import { screen, waitFor, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { http, HttpResponse } from 'msw'
+import History from './History'
+import { renderWithProviders } from '../test/renderWithProviders'
+import { server } from '../test/mswServer'
+import { mockSignedIn } from '../test/authFixtures'
+import { ANALYSES_ENDPOINT } from '../api/client'
+import type { AnalysisListItem, AnalysisPage, TrendSeries } from '../api/types'
+
+const TREND_ENDPOINT = `${ANALYSES_ENDPOINT}/metrics/trunk-inclination`
+
+function signedInAs() {
+  mockSignedIn({ id: 'u1', email: 'ada@example.com', displayName: 'Ada' })
+}
+
+function item(overrides: Partial<AnalysisListItem> = {}): AnalysisListItem {
+  return {
+    id: 'a1',
+    created_at: '2026-01-01T00:00:00Z',
+    object_key: 'analyses/a1.jpg',
+    image_url: '/media/analyses/a1.jpg',
+    pose_detected: true,
+    overall_score: 72,
+    ...overrides,
+  }
+}
+
+function respondWithPage(page: AnalysisPage) {
+  server.use(http.get(ANALYSES_ENDPOINT, () => HttpResponse.json(page)))
+}
+
+function respondWithTrend(series: TrendSeries) {
+  server.use(http.get(TREND_ENDPOINT, () => HttpResponse.json(series)))
+}
+
+/** Both requests `History` fires on mount, answered with the emptiest valid response. */
+function respondEmpty() {
+  respondWithPage({ items: [], next_cursor: null })
+  respondWithTrend({ points: [] })
+}
+
+describe('History', () => {
+  it('says so plainly when there is nothing yet, rather than an empty list with no explanation', async () => {
+    signedInAs()
+    respondEmpty()
+    renderWithProviders(<History />)
+
+    expect(await screen.findByText(/have not analysed any photos yet/)).toBeInTheDocument()
+  })
+
+  it('renders a thumbnail and the score for each analysis', async () => {
+    signedInAs()
+    respondWithPage({
+      items: [item({ id: 'a1', overall_score: 91, image_url: '/media/analyses/a1.jpg' })],
+      next_cursor: null,
+    })
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    const thumbnail = await screen.findByRole('img', { name: /Photo analysed on/ })
+    expect(thumbnail).toHaveAttribute('src', '/media/analyses/a1.jpg')
+    expect(screen.getByText('91 / 100')).toBeInTheDocument()
+  })
+
+  it('describes an unscored analysis without inventing a number', async () => {
+    signedInAs()
+    respondWithPage({
+      items: [item({ overall_score: null, pose_detected: true })],
+      next_cursor: null,
+    })
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    expect(await screen.findByText(/Not enough was visible to score/)).toBeInTheDocument()
+  })
+
+  it('says plainly when no person was detected, rather than a blank or zero score', async () => {
+    signedInAs()
+    respondWithPage({
+      items: [item({ pose_detected: false, overall_score: null })],
+      next_cursor: null,
+    })
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    expect(await screen.findByText('No person detected')).toBeInTheDocument()
+  })
+
+  it('renders the trend sparkline fed from its own endpoint', async () => {
+    signedInAs()
+    respondWithPage({ items: [item()], next_cursor: null })
+    respondWithTrend({
+      points: [
+        { created_at: '2026-01-01T00:00:00Z', value: 12, status: 'ok', rules_version: '1.0.0' },
+      ],
+    })
+    renderWithProviders(<History />)
+
+    expect(await screen.findByTestId('sparkline')).toBeInTheDocument()
+  })
+
+  it('loads the next page on request and appends rather than replacing', async () => {
+    signedInAs()
+    server.use(
+      http.get(ANALYSES_ENDPOINT, ({ request }) => {
+        const cursor = new URL(request.url).searchParams.get('cursor')
+        return cursor === null
+          ? HttpResponse.json({ items: [item({ id: 'a1' })], next_cursor: 'page2' })
+          : HttpResponse.json({ items: [item({ id: 'a2' })], next_cursor: null })
+      }),
+    )
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    const list = await screen.findByRole('list')
+    await within(list).findByRole('img', { name: /Photo analysed on/ })
+    expect(within(list).getAllByRole('listitem')).toHaveLength(1)
+
+    const user = userEvent.setup()
+    await user.click(screen.getByRole('button', { name: 'Load more' }))
+
+    await waitFor(() => expect(within(list).getAllByRole('listitem')).toHaveLength(2))
+    // The page that answered `cursor=page2` had no further page.
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+  })
+
+  it('has no "Load more" control once the last page has loaded', async () => {
+    signedInAs()
+    respondWithPage({ items: [item()], next_cursor: null })
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    await screen.findByRole('img', { name: /Photo analysed on/ })
+    expect(screen.queryByRole('button', { name: 'Load more' })).not.toBeInTheDocument()
+  })
+
+  it('reports a failure to load without pretending the history is empty', async () => {
+    signedInAs()
+    server.use(
+      http.get(ANALYSES_ENDPOINT, () =>
+        HttpResponse.json(
+          { type: 't', title: 'x', status: 500, detail: 'Something broke.' },
+          { status: 500 },
+        ),
+      ),
+    )
+    respondWithTrend({ points: [] })
+    renderWithProviders(<History />)
+
+    const alert = await screen.findByRole('alert')
+    expect(alert).toHaveTextContent('Something broke.')
+    expect(screen.queryByText(/have not analysed any photos yet/)).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/views/History.tsx
+++ b/apps/web/src/views/History.tsx
@@ -1,0 +1,166 @@
+/**
+ * Past analyses: thumbnails and a trend line, over the E6 cursor-paginated list.
+ *
+ * Two requests happen independently on mount — the first page of the list, and the full
+ * trunk-inclination trend from its own single-query endpoint — because they answer different
+ * questions. The list is deliberately one page at a time; the trend wants every point that
+ * exists, which is the reason it is not derived from whatever page happens to be loaded.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { ApiError, getTrunkInclinationTrend, listAnalyses } from '../api/client'
+import type { AnalysisListItem, TrendPoint } from '../api/types'
+import Sparkline from './Sparkline'
+import styles from './History.module.css'
+import { cx } from '../ui/cx'
+
+type Status = 'loading' | 'ready' | 'error'
+
+export default function History() {
+  const [items, setItems] = useState<AnalysisListItem[]>([])
+  const [nextCursor, setNextCursor] = useState<string | null>(null)
+  const [trend, setTrend] = useState<TrendPoint[] | null>(null)
+  const [status, setStatus] = useState<Status>('loading')
+  const [loadingMore, setLoadingMore] = useState(false)
+  const [error, setError] = useState<ApiError | null>(null)
+
+  useEffect(() => {
+    const controller = new AbortController()
+
+    Promise.all([
+      listAnalyses({ signal: controller.signal }),
+      getTrunkInclinationTrend(controller.signal),
+    ])
+      .then(([page, series]) => {
+        // Superseded — StrictMode's dev-only mount/cleanup/remount runs this effect twice, and
+        // the first pass's request is aborted by its own cleanup below. Checking this specific
+        // request's own signal, rather than a persistent "is the component still here" flag, is
+        // what keeps that first pass from clobbering the second, real one — a flag set once in
+        // an unmount cleanup has no way to know a later mount should turn it back on.
+        if (controller.signal.aborted) return
+        setItems(page.items)
+        setNextCursor(page.next_cursor)
+        setTrend(series.points)
+        setStatus('ready')
+      })
+      .catch((caught: unknown) => {
+        if (controller.signal.aborted) return
+        setError(
+          caught instanceof ApiError
+            ? caught
+            : new ApiError('Something went wrong loading your history.', { status: 0 }),
+        )
+        setStatus('error')
+      })
+
+    return () => controller.abort()
+  }, [])
+
+  const loadMoreAbortRef = useRef<AbortController | null>(null)
+  useEffect(() => {
+    return () => loadMoreAbortRef.current?.abort()
+  }, [])
+
+  const loadMore = useCallback(async () => {
+    if (nextCursor === null || loadingMore) return
+
+    const controller = new AbortController()
+    loadMoreAbortRef.current = controller
+    setLoadingMore(true)
+    try {
+      const page = await listAnalyses({ cursor: nextCursor, signal: controller.signal })
+      if (controller.signal.aborted) return
+      setItems((prev) => [...prev, ...page.items])
+      setNextCursor(page.next_cursor)
+    } catch (caught) {
+      if (controller.signal.aborted) return
+      setError(
+        caught instanceof ApiError
+          ? caught
+          : new ApiError('Could not load more of your history.', { status: 0 }),
+      )
+    } finally {
+      if (loadMoreAbortRef.current === controller) loadMoreAbortRef.current = null
+      if (!controller.signal.aborted) setLoadingMore(false)
+    }
+  }, [nextCursor, loadingMore])
+
+  return (
+    <div className={styles.container}>
+      <h1>Your history</h1>
+
+      {status === 'loading' && <p className={styles.loading}>Loading your history…</p>}
+
+      {status === 'error' && error && (
+        <div className={styles.error} role="alert">
+          <h2>We could not load your history</h2>
+          <p>{error.message}</p>
+          {error.requestId && (
+            <p className={styles.requestId}>
+              Reference: <code>{error.requestId}</code>
+            </p>
+          )}
+        </div>
+      )}
+
+      {status === 'ready' && (
+        <>
+          <section className={styles.trendCard} aria-labelledby="trend-heading">
+            <h2 id="trend-heading">Trunk inclination over time</h2>
+            <Sparkline points={trend ?? []} />
+          </section>
+
+          {items.length === 0 ? (
+            <p className={styles.empty}>
+              You have not analysed any photos yet. Upload one from the dashboard to start your
+              history.
+            </p>
+          ) : (
+            <>
+              <ul className={styles.list}>
+                {items.map((item) => (
+                  <li key={item.id} className={styles.item}>
+                    <img
+                      src={item.image_url}
+                      alt={`Photo analysed on ${formatDate(item.created_at)}`}
+                      className={styles.thumbnail}
+                      loading="lazy"
+                    />
+                    <div className={styles.itemBody}>
+                      <p className={styles.itemDate}>{formatDate(item.created_at)}</p>
+                      <p className={styles.itemScore}>{describeScore(item)}</p>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+
+              {nextCursor !== null && (
+                <button
+                  className={cx('button', 'buttonSecondary')}
+                  onClick={() => void loadMore()}
+                  disabled={loadingMore}
+                >
+                  {loadingMore ? 'Loading…' : 'Load more'}
+                </button>
+              )}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  )
+}
+
+function describeScore(item: AnalysisListItem): string {
+  if (!item.pose_detected) return 'No person detected'
+  if (item.overall_score === null) return 'Not enough was visible to score'
+  return `${Math.round(item.overall_score)} / 100`
+}
+
+function formatDate(isoTimestamp: string): string {
+  return new Date(isoTimestamp).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  })
+}

--- a/apps/web/src/views/Sparkline.module.css
+++ b/apps/web/src/views/Sparkline.module.css
@@ -1,0 +1,37 @@
+.sparkline {
+  width: 100%;
+  height: 6rem;
+}
+
+.line {
+  fill: none;
+  stroke: var(--color-accent);
+  stroke-width: 2;
+  stroke-linecap: round;
+  stroke-linejoin: round;
+}
+
+.point {
+  fill: var(--color-accent);
+}
+
+/* Hollow and muted rather than solid and on-brand — a gap must never be mistaken for a
+   measurement at a glance. */
+.gapMarker {
+  fill: var(--color-surface);
+  stroke: var(--color-text-muted);
+  stroke-width: 1.5;
+}
+
+.versionBoundary {
+  stroke: var(--color-border-strong);
+  stroke-width: 1;
+  stroke-dasharray: 4 3;
+}
+
+.empty {
+  padding: var(--space-4);
+  color: var(--color-text-muted);
+  font-size: 0.9375rem;
+  text-align: center;
+}

--- a/apps/web/src/views/Sparkline.test.tsx
+++ b/apps/web/src/views/Sparkline.test.tsx
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import Sparkline from './Sparkline'
+import type { TrendPoint } from '../api/types'
+
+/** A point as the API returns it, newest first, with sensible defaults for what a test ignores. */
+function point(overrides: Partial<TrendPoint>): TrendPoint {
+  return {
+    created_at: '2026-01-01T00:00:00Z',
+    value: 12.0,
+    status: 'ok',
+    rules_version: '1.0.0',
+    ...overrides,
+  }
+}
+
+describe('Sparkline', () => {
+  it('shows an empty state instead of a broken chart for no history', () => {
+    render(<Sparkline points={[]} />)
+
+    expect(screen.getByText(/No trend yet/)).toBeInTheDocument()
+    expect(screen.queryByTestId('sparkline')).not.toBeInTheDocument()
+  })
+
+  it('renders a single point on its own, with no visible line', () => {
+    render(<Sparkline points={[point({ value: 15 })]} />)
+
+    expect(screen.getAllByTestId('trend-point')).toHaveLength(1)
+    // A polyline needs two coordinates to draw anything; one point alone leaves nothing visible,
+    // even though a degenerate single-coordinate `<polyline>` may still be present in the DOM.
+    for (const segment of screen.queryAllByTestId('trend-segment')) {
+      expect(segment.getAttribute('points')).not.toContain(' ')
+    }
+  })
+
+  it('breaks the line and marks a gap distinctly, never as a zero', () => {
+    // Newest first, as the API returns them. Reversed for rendering, the gap sits between one
+    // isolated point and a real two-point run — proving the line does not reach across it.
+    const points: TrendPoint[] = [
+      point({ created_at: '2026-01-04T00:00:00Z', value: 20 }),
+      point({ created_at: '2026-01-03T00:00:00Z', value: 18 }),
+      point({
+        created_at: '2026-01-02T00:00:00Z',
+        value: null,
+        status: 'insufficient_keypoints',
+      }),
+      point({ created_at: '2026-01-01T00:00:00Z', value: 10 }),
+    ]
+
+    render(<Sparkline points={points} />)
+
+    expect(screen.getAllByTestId('trend-point')).toHaveLength(3)
+    expect(screen.getAllByTestId('trend-gap')).toHaveLength(1)
+    // Two separate pieces, not one line spanning all three real points — the isolated point
+    // before the gap draws nothing, and the pair after it draws one real segment.
+    const segments = screen.getAllByTestId('trend-segment')
+    expect(segments).toHaveLength(2)
+    const withAVisibleLine = segments.filter((segment) =>
+      segment.getAttribute('points')?.includes(' '),
+    )
+    expect(withAVisibleLine).toHaveLength(1)
+  })
+
+  it('marks a rules_version boundary within the series', () => {
+    const points: TrendPoint[] = [
+      point({ created_at: '2026-01-02T00:00:00Z', value: 18, rules_version: '2.0.0' }),
+      point({ created_at: '2026-01-01T00:00:00Z', value: 10, rules_version: '1.0.0' }),
+    ]
+
+    render(<Sparkline points={points} />)
+
+    expect(screen.getByTestId('trend-version-boundary')).toBeInTheDocument()
+  })
+
+  it('draws no boundary when the ruleset never changes', () => {
+    const points: TrendPoint[] = [
+      point({ created_at: '2026-01-02T00:00:00Z', value: 18, rules_version: '1.0.0' }),
+      point({ created_at: '2026-01-01T00:00:00Z', value: 10, rules_version: '1.0.0' }),
+    ]
+
+    render(<Sparkline points={points} />)
+
+    expect(screen.queryByTestId('trend-version-boundary')).not.toBeInTheDocument()
+  })
+})

--- a/apps/web/src/views/Sparkline.tsx
+++ b/apps/web/src/views/Sparkline.tsx
@@ -1,0 +1,127 @@
+/**
+ * The trunk-inclination trend line, from a plain SVG — no charting library.
+ *
+ * A sparkline over a handful of points does not need one, and this project already has a rule
+ * against reaching for a dependency a hand-rolled fifty lines covers just as well.
+ *
+ * Two correctness rules from the ticket, both non-negotiable:
+ *
+ * **Gaps are not zeros.** An analysis with no measured value breaks the line rather than
+ * interpolating through it, and gets its own hollow marker on the baseline — plotting it as `0`
+ * would invent an upright posture the user never had, the original engine's central defect in
+ * chart form.
+ *
+ * **A `rules_version` change is marked, not hidden.** A dashed vertical guide appears at the
+ * boundary, because a step in the line at that point is a retuned threshold, not a change in the
+ * user's posture, and the two must not look the same.
+ */
+
+import type { TrendPoint } from '../api/types'
+import styles from './Sparkline.module.css'
+
+interface Props {
+  /** Newest first, as `GET /analyses/metrics/trunk-inclination` returns them. */
+  points: TrendPoint[]
+}
+
+const WIDTH = 320
+const HEIGHT = 96
+const PADDING_Y = 12
+
+export default function Sparkline({ points }: Props) {
+  if (points.length === 0) {
+    return <p className={styles.empty}>No trend yet — analyse a few more photos to see one.</p>
+  }
+
+  // The API orders newest first; a trend line reads left-to-right in time.
+  const ordered = [...points].reverse()
+
+  const values = ordered.map((p) => p.value).filter((v): v is number => v !== null)
+  const min = values.length > 0 ? Math.min(...values) : 0
+  const max = values.length > 0 ? Math.max(...values) : 0
+  // A flat or single-value series would divide by zero below; give it a nominal span instead.
+  const range = max - min || 1
+
+  const xStep = ordered.length > 1 ? WIDTH / (ordered.length - 1) : 0
+  const xFor = (i: number) => (ordered.length > 1 ? i * xStep : WIDTH / 2)
+  const yFor = (value: number) =>
+    HEIGHT - PADDING_Y - ((value - min) / range) * (HEIGHT - PADDING_Y * 2)
+
+  // Consecutive real values form one polyline; a gap ends the current one rather than being
+  // interpolated through, so the line itself never implies a value nobody measured.
+  const segments: { x: number; y: number }[][] = []
+  let current: { x: number; y: number }[] = []
+  for (const [i, point] of ordered.entries()) {
+    if (point.value === null) {
+      if (current.length > 0) segments.push(current)
+      current = []
+      continue
+    }
+    current.push({ x: xFor(i), y: yFor(point.value) })
+  }
+  if (current.length > 0) segments.push(current)
+
+  const versionBoundaries = ordered
+    .map((point, i) => ({ point, i }))
+    .filter(({ point, i }) => i > 0 && ordered[i - 1]?.rules_version !== point.rules_version)
+
+  return (
+    <svg
+      className={styles.sparkline}
+      viewBox={`0 0 ${WIDTH} ${HEIGHT}`}
+      role="img"
+      aria-label="Trunk inclination over time"
+      preserveAspectRatio="none"
+      data-testid="sparkline"
+    >
+      {versionBoundaries.map(({ point, i }) => (
+        <line
+          key={`boundary-${point.created_at}-${i}`}
+          data-testid="trend-version-boundary"
+          className={styles.versionBoundary}
+          x1={xFor(i)}
+          x2={xFor(i)}
+          y1={0}
+          y2={HEIGHT}
+        >
+          <title>{`Rules changed to ${point.rules_version} here.`}</title>
+        </line>
+      ))}
+
+      {segments.map((segment, i) => (
+        <polyline
+          key={`segment-${i}`}
+          data-testid="trend-segment"
+          className={styles.line}
+          points={segment.map((p) => `${p.x},${p.y}`).join(' ')}
+        />
+      ))}
+
+      {ordered.map((point, i) =>
+        point.value === null ? (
+          <circle
+            key={`gap-${point.created_at}-${i}`}
+            data-testid="trend-gap"
+            className={styles.gapMarker}
+            cx={xFor(i)}
+            cy={HEIGHT - PADDING_Y}
+            r={3}
+          >
+            <title>{`No trunk inclination measured (${point.status}).`}</title>
+          </circle>
+        ) : (
+          <circle
+            key={`point-${point.created_at}-${i}`}
+            data-testid="trend-point"
+            className={styles.point}
+            cx={xFor(i)}
+            cy={yFor(point.value)}
+            r={ordered.length === 1 ? 4 : 2.5}
+          >
+            <title>{`${Math.round(point.value)}°`}</title>
+          </circle>
+        ),
+      )}
+    </svg>
+  )
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
         target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8000',
         changeOrigin: true,
       },
+      // `StorageBackend.url_for` (D3) builds thumbnail URLs under this prefix by default —
+      // see `LocalDiskStorage`'s `base_url`. E10 is the first thing that renders one, and
+      // without this entry the browser requests `/media/...` from the Vite dev server itself,
+      // which has nothing there.
+      '/media': {
+        target: process.env.VITE_API_PROXY_TARGET ?? 'http://localhost:8000',
+        changeOrigin: true,
+      },
     },
   },
   resolve: {


### PR DESCRIPTION
## What

Backend:
- `AnalysisListItem.image_url`, built from `storage.url_for(object_key)` on every response — `url_for` existed since D3 but nothing had ever called it.
- `GET /api/v1/analyses/metrics/trunk-inclination` — a single indexed query (`AnalysisRepository.list_metric_trend`) returning the trunk-inclination trend for the authenticated user, newest first. Gaps come back with `value: null` and a status, never `0`.
- A `/media` static mount in `main.py` for the `local` storage backend, so `LocalDiskStorage`'s URLs are actually servable (the `s3` backend needs none — its `url_for` returns a presigned URL straight to the object store).

Frontend:
- `History` view: paginated list over the existing E6 cursor endpoint, with thumbnails, an empty state, and "Load more".
- `Sparkline`: hand-rolled inline SVG (no chart dependency) that breaks the line at gaps — rendered as a distinct hollow marker, never plotted as `0` — and draws a dashed marker at any `rules_version` boundary within the plotted range.
- `client.ts` gains a `getJson` GET counterpart to `postJson`, authenticating with `Authorization: Bearer` like `analysePosture` (not the auth-cookie flow), with the same single-retry-on-401 shape.
- `vite.config.ts` now proxies `/media` alongside `/api`.

## Why

The payoff for Epic E: past analyses become browsable, and the trend query is a plain indexed `SELECT` over `metrics` rather than an application-side loop over deserialized documents — the exact argument E2's model docstrings made for a table over a JSONB blob.

## Known limitation

An analysis where no person was detected has zero `Metric` rows at all (that branch never persists any, gap or otherwise), so it does not appear as a gap point in the sparkline — it's simply absent, rather than breaking the line or rendering a marker. `list_metric_trend`'s query matches the canonical SQL already documented in `Metric.__table_args__` (an inner join, metric-code filter in `WHERE`), and reviewing this against the ticket's gap rule surfaced the ambiguity: is a no-pose upload a "measurement that couldn't be computed," or not a measurement attempt at all? Left as documented pending a decision — noting it here rather than silently picking one.

## How tested

- Backend: `368 passed` (`uv run pytest tests/`), including 6 new repo-level integration tests against real Postgres (empty/tenant-isolation/code-filtering/ordering/gaps/version-boundary) and 3 new endpoint contract tests. `ruff check`/`format` and `mypy --strict` clean.
- Frontend: `108 passed` (`vitest run`), including 15 new component tests (Sparkline: empty/single-point/gapped/version-change; History: empty state, thumbnails, pagination, error). `tsc -b --noEmit` and `oxlint` clean.
- Manually verified end-to-end against the real `docker compose` stack: registered a user, uploaded two real fixture photos through actual MediaPipe inference, and confirmed in a headless-Chromium screenshot that both thumbnails load as real JPEGs (not broken images) and the sparkline renders a real two-point trend line. This caught two bugs no unit test did — see commit `7cd5e8c` (missing `/media` mount, nothing had ever served `LocalDiskStorage`'s URLs) and the `History.tsx` fix in `fae2b8e` (a `StrictMode`-only bug: a persistent "is mounted" ref latched to `false` on the dev-only mount→cleanup→remount cycle and never reset, freezing the view on "Loading…" — fixed by checking each request's own `AbortController.signal.aborted` instead, matching `Dashboard.tsx`'s existing pattern).