### PR TITLE
OP-60: Recalibrate rules-engine thresholds against the evaluation set

### DIFF
--- a/evaluation/baseline.json
+++ b/evaluation/baseline.json
@@ -85,7 +85,19 @@
   "known_gaps": [
     {
       "fixture": "fx-05",
-      "issue": "kneeling_right.jpg produces no kneeling-related finding at all \u2014 knee_flexion_deg measured at 80.3deg, inside the seated band (70-120deg) rather than triggering knee_kneeling_max_deg (<=60deg). Tracked as OP-60 (diagnose threshold vs. near/far-leg side selection before retuning)."
+      "issue": "kneeling_right.jpg produces no kneeling-related finding at all \u2014 knee_flexion_deg measured at 80.3deg, inside the seated band (70-120deg) rather than triggering knee_kneeling_max_deg (<=60deg). Diagnosis: side-selection artifact, not a threshold miscalibration \u2014 the kneeling (right) leg is occluded, so require_either_side measures the visible left leg instead, which is not in a kneeling posture. No threshold value corrects for a leg that was never measured. knee_kneeling_max_deg confirmed at its current value."
+    },
+    {
+      "fixture": "all",
+      "issue": "arms_crossed abstains (low_confidence) on all 8 fixtures against the real backend, including the folded-arms positive case (straight_armsfolded.jpg) \u2014 it requires both wrists/elbows and every fixture here is lateral, so the far arm is always occluded. arms_crossed_ratio cannot currently be evaluated against this set at all; confirmed at its current value pending frontal/three-quarter fixtures or a one-armed-proxy design decision."
+    },
+    {
+      "fixture": "all",
+      "issue": "heel_contact_m measured 0.0065-0.0694m across the 8 fixtures. Two fixtures with no feet-support label (kneeling_right.jpg 0.069m, reclined_right.jpg 0.064m) exceed the one labelled dangling-feet case (bench_feet_dangling.jpg 0.063m). The manifest has no per-image feet-support ground truth, so heel_contact_tolerance_m (0.05m) is confirmed at its current value rather than retuned \u2014 the evidence argues against guessing, not for a specific new number. Needs a feet-support label added to evaluation/manifest.csv before a real recalibration is possible."
+    },
+    {
+      "fixture": "all",
+      "issue": "view_confidence measured 0.071-0.194 across the 8 (all-lateral) fixtures, comfortably under lateral_view_max_ratio (0.35) \u2014 that boundary is now genuinely validated. frontal_view_min_ratio (0.55) remains unvalidated: the evaluation set has no frontal or three-quarter fixture. Both confirmed at their current values."
     }
   ]
 }

--- a/evaluation/baseline.json
+++ b/evaluation/baseline.json
@@ -85,7 +85,7 @@
   "known_gaps": [
     {
       "fixture": "fx-05",
-      "issue": "kneeling_right.jpg produces no kneeling-related finding at all \u2014 knee_flexion_deg measured at 80.3deg, inside the seated band (70-120deg) rather than triggering knee_kneeling_max_deg (<=60deg). Diagnosis: side-selection artifact, not a threshold miscalibration \u2014 the kneeling (right) leg is occluded, so require_either_side measures the visible left leg instead, which is not in a kneeling posture. No threshold value corrects for a leg that was never measured. knee_kneeling_max_deg confirmed at its current value."
+      "issue": "kneeling_right.jpg produces no kneeling-related finding at all \u2014 knee_flexion_deg measured at 80.3deg, inside the seated band (70-120deg) rather than triggering knee_kneeling_max_deg (<=60deg). Diagnosis: the right leg's landmarks are below the confidence floor (knee visibility 0.31, ankle 0.26) so require_either_side measures the left leg instead. The manifest doesn't record which leg is doing the kneeling, and computing the angle from the right leg's own untrusted coordinates gives ~104deg \u2014 more extended than the measured left leg, not less \u2014 so this is not simply 'the engine picked the wrong, straighter leg'. No available leg measurement here supports a kneeling verdict; retuning against this fixture would fit one photograph and nothing else. knee_kneeling_max_deg confirmed at its current value; resolving this needs a less-occluded kneeling fixture or a per-leg ground-truth label."
     },
     {
       "fixture": "all",

--- a/packages/posture-core/src/posture_core/metrics/arms.py
+++ b/packages/posture-core/src/posture_core/metrics/arms.py
@@ -21,9 +21,10 @@ with their arms anywhere at all. It would have reported crossed arms universally
 
 What actually distinguishes folded arms is that **each wrist sits near the opposite elbow**. That
 is what this measures, still normalised by torso length so the fix to the original defect is kept.
-Run against the eight fixtures with the real backend, the folded-arms photograph scores 0.53 and
-every other one falls between 0.91 and 1.20 — a clean separation, and where the default threshold
-comes from. The numbers are recorded on ``Thresholds.arms_crossed_ratio``.
+Run against the eight fixtures with the real backend *at the time this threshold was chosen*, the
+folded-arms photograph scored 0.53 and every other one fell between 0.91 and 1.20 — a clean
+separation, and where the default threshold comes from. That run does not reproduce today; see
+below. The numbers are recorded on ``Thresholds.arms_crossed_ratio``.
 
 ## What the metric reports, and what decides
 

--- a/packages/posture-core/src/posture_core/metrics/arms.py
+++ b/packages/posture-core/src/posture_core/metrics/arms.py
@@ -31,6 +31,15 @@ comes from. The numbers are recorded on ``Thresholds.arms_crossed_ratio``.
 verdict. Comparing it against a threshold is the rules layer's job (OP-32). Keeping measurement
 and judgement apart is what lets a threshold be retuned without touching a measurement, and what
 lets the report show a user how close to the line they were.
+
+## This metric abstains on the entire lateral evaluation set
+
+It requires both wrists and both elbows above the confidence floor. Every fixture in
+``evaluation/manifest.csv`` is a lateral view, which puts the far arm behind the torso and below
+confidence by construction — so ``arms_crossed`` currently returns no value at all on any of them,
+including the one curated specifically as the folded-arms positive case. See
+:attr:`~posture_core.thresholds.Thresholds.arms_crossed_ratio` for the historical measurement this
+threshold rests on and why it could not be re-validated.
 """
 
 from __future__ import annotations

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -13,13 +13,16 @@ lifting the heel. Relative height rather than absolute floor position, because t
 the coordinate system: world landmarks are hip-origin and nothing in the frame says where the
 ground is.
 
-## The margin is thin, and that is worth knowing
+## The margin is thin, and recalibration could not close it
 
 Measured across the eight fixtures with the real backend, the dangling-feet photograph scores
-0.063 m and the seated ones fall between 0.01 m and 0.07 m. The signal is real and it points the
-right way, but the default 0.05 m tolerance sits close to the spread of the supported cases rather
-than comfortably outside it. Treat this metric as the least settled in the package until the
-evaluation set in Epic H gives it a proper sample.
+0.063 m — but two fixtures with no feet-support label at all, ``kneeling_right.jpg`` and
+``reclined_right.jpg``, score higher (0.069 m and 0.064 m). The evaluation manifest carries a
+``posture_label`` per image, not a feet-support label, so there is no ground truth to tell whether
+those two are also genuinely unsupported or whether 0.05 m is too tight. Confirmed at its current
+value rather than retuned, because the evidence argues against guessing rather than for a specific
+number. See :attr:`~posture_core.thresholds.Thresholds.heel_contact_tolerance_m`. Still the least
+settled metric in the package.
 """
 
 from __future__ import annotations

--- a/packages/posture-core/src/posture_core/metrics/feet.py
+++ b/packages/posture-core/src/posture_core/metrics/feet.py
@@ -15,14 +15,17 @@ ground is.
 
 ## The margin is thin, and recalibration could not close it
 
-Measured across the eight fixtures with the real backend, the dangling-feet photograph scores
-0.063 m — but two fixtures with no feet-support label at all, ``kneeling_right.jpg`` and
-``reclined_right.jpg``, score higher (0.069 m and 0.064 m). The evaluation manifest carries a
-``posture_label`` per image, not a feet-support label, so there is no ground truth to tell whether
-those two are also genuinely unsupported or whether 0.05 m is too tight. Confirmed at its current
-value rather than retuned, because the evidence argues against guessing rather than for a specific
-number. See :attr:`~posture_core.thresholds.Thresholds.heel_contact_tolerance_m`. Still the least
-settled metric in the package.
+This module previously claimed the eight-fixture signal "points the right way" — the labelled
+dangling-feet case scoring above every other fixture. **That no longer holds.** Measured across
+all eight with the real backend, the dangling-feet photograph scores 0.063 m, but two fixtures
+with no feet-support label at all, ``kneeling_right.jpg`` and ``reclined_right.jpg``, score higher
+(0.069 m and 0.064 m). The evaluation manifest carries a ``posture_label`` per image, not a
+feet-support label, so there is no ground truth to tell whether those two are also genuinely
+unsupported or whether 0.05 m is too tight — the earlier claim about direction was not something
+this manifest could actually support. Confirmed at its current value rather than retuned, because
+the evidence argues against guessing rather than for a specific number. See
+:attr:`~posture_core.thresholds.Thresholds.heel_contact_tolerance_m`. Still the least settled
+metric in the package.
 """
 
 from __future__ import annotations

--- a/packages/posture-core/src/posture_core/metrics/knees.py
+++ b/packages/posture-core/src/posture_core/metrics/knees.py
@@ -36,11 +36,11 @@ def knee_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metr
     :func:`~posture_core.metrics._support.require_either_side`.
 
     **Diagnosis, ``kneeling_right.jpg``.** This fixture reports "your left knee is at a
-    comfortable seated angle (80°)" rather than a kneeling verdict. The subject's kneeling leg is
-    the right one (per the filename and the manifest's occlusion note); it is below confidence in
-    this composition, so ``require_either_side`` correctly measured the only visible leg — which
-    happens not to be the kneeling one. No value of ``knee_kneeling_max_deg`` fixes a leg that was
-    never measured. See :attr:`~posture_core.thresholds.Thresholds.knee_kneeling_max_deg`.
+    comfortable seated angle (80°)" rather than a kneeling verdict, because the right leg's
+    landmarks are below the confidence floor and the manifest doesn't record which leg is doing
+    the kneeling. See :attr:`~posture_core.thresholds.Thresholds.knee_kneeling_max_deg` for the
+    full diagnosis, including why the right leg's own (untrusted) numbers don't resolve the
+    question either.
     """
     resolved = require_either_side(resolver, SIDES)
     if not isinstance(resolved, tuple):

--- a/packages/posture-core/src/posture_core/metrics/knees.py
+++ b/packages/posture-core/src/posture_core/metrics/knees.py
@@ -34,6 +34,13 @@ def knee_flexion_deg(resolver: KeypointResolver, thresholds: Thresholds) -> Metr
     the torso and is reported below the visibility threshold — correctly. Requiring both made every
     one of the eight fixtures abstain. See
     :func:`~posture_core.metrics._support.require_either_side`.
+
+    **Diagnosis, ``kneeling_right.jpg``.** This fixture reports "your left knee is at a
+    comfortable seated angle (80°)" rather than a kneeling verdict. The subject's kneeling leg is
+    the right one (per the filename and the manifest's occlusion note); it is below confidence in
+    this composition, so ``require_either_side`` correctly measured the only visible leg — which
+    happens not to be the kneeling one. No value of ``knee_kneeling_max_deg`` fixes a leg that was
+    never measured. See :attr:`~posture_core.thresholds.Thresholds.knee_kneeling_max_deg`.
     """
     resolved = require_either_side(resolver, SIDES)
     if not isinstance(resolved, tuple):

--- a/packages/posture-core/src/posture_core/metrics/view.py
+++ b/packages/posture-core/src/posture_core/metrics/view.py
@@ -24,6 +24,14 @@ accurately along the camera axis than across it, so a head-on measurement of for
 the model's weakest dimension. So this metric produces a **confidence factor** the report applies
 to sagittal findings, rather than a veto that discards them. A lower-confidence finding is more
 useful to a user than a missing one, and more honest than a confident one.
+
+## The lateral boundary is now measured, the frontal one still isn't
+
+All eight ``evaluation/manifest.csv`` fixtures are lateral, and the real backend measures
+0.071-0.194 across them — comfortably under ``lateral_view_max_ratio`` (0.35). That end of the scale
+is validated. ``frontal_view_min_ratio`` (0.55) has no fixture anywhere near it and remains a
+reasoned value pending frontal or three-quarter photographs in the evaluation set. See
+:attr:`~posture_core.thresholds.Thresholds.lateral_view_max_ratio`.
 """
 
 from __future__ import annotations

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -131,10 +131,11 @@ class Thresholds:
     0.70 is confirmed at its current value rather than re-derived, because there is nothing to
     re-derive it against yet. Closing that gap needs one of: frontal or three-quarter fixtures
     added to the evaluation set (the same gap `lateral_view_max_ratio`/`frontal_view_min_ratio`
-    has below), or a decision — a code change, not a value change, so out of scope for a
-    recalibration pass — on whether a one-armed proxy (mirroring the `require_either_side` pattern
-    `knee_flexion_deg` and `elbow_flexion_deg` use) is an acceptable substitute for "both arms
-    visibly folded".
+    has below — note `evaluation/quality-gates.yml`'s `allowed_views` would need a new value added
+    too, since it currently accepts only `lateral`/`lateral_left`/`lateral_right`), or a decision —
+    a code change, not a value change, so out of scope for a recalibration pass — on whether a
+    one-armed proxy (mirroring the `require_either_side` pattern `knee_flexion_deg` and
+    `elbow_flexion_deg` use) is an acceptable substitute for "both arms visibly folded".
     """
 
     elbow_flexed_deg: float = 120.0
@@ -148,15 +149,22 @@ class Thresholds:
     knee_kneeling_max_deg: float = 60.0
     """Below this the subject is kneeling rather than sitting.
 
-    **Diagnosis:** `kneeling_right.jpg` measures 80.3°, inside the seated band rather than
-    below this threshold, and moving the threshold would not fix that. The report for that fixture
-    reads "your **left** knee is at a comfortable seated angle" — `knee_flexion_deg` uses
-    `require_either_side`, which picked the visible left leg because the right knee (the one
-    actually kneeling, per the filename and the manifest's "lower legs partly occluded by chair"
-    note) is below the confidence floor in this composition. The kneeling leg was never measured; no
-    value of `knee_kneeling_max_deg` makes an unmeasured leg produce a kneeling verdict. This is a
-    side-selection artifact, not a miscalibration, so the threshold is confirmed at its current
-    value rather than retuned against a fixture that cannot exercise it.
+    **Diagnosis:** `kneeling_right.jpg` measures 80.3°, inside the seated band rather than below
+    this threshold, and moving the threshold would not fix that. The report reads "your **left**
+    knee is at a comfortable seated angle" — `knee_flexion_deg` uses `require_either_side`, which
+    picked the left leg because the right knee and ankle are below the confidence floor
+    (visibility 0.31 and 0.26) in this composition; the manifest notes the legs are "partly
+    occluded by the chair" but does not say which leg is doing the occluding or which one is
+    kneeling.
+
+    Computing the angle from the right leg's own (untrusted) coordinates anyway gives ~104° — more
+    extended than the measured left leg, not less, so this fixture does not cleanly show "the
+    engine measured the wrong, straighter leg instead of the right, more-bent one". What it does
+    show: neither leg the engine can see resolves to a kneeling angle, and the one it distrusts
+    doesn't obviously look more kneeling either. Retuning the threshold against a fixture where no
+    available leg measurement supports a kneeling verdict would fit this one photograph and
+    nothing else, so it is confirmed at its current value. Resolving this properly needs either a
+    less-occluded kneeling fixture or a per-leg ground-truth label this manifest doesn't have.
     """
 
     # -- heel contact (OP-30) ------------------------------------------------------------------
@@ -214,7 +222,8 @@ class Thresholds:
     **Still unvalidated.** The evaluation set has no frontal or three-quarter fixture, so
     there is nothing to measure this boundary against — the same gap `arms_crossed_ratio` has, and
     for the same underlying reason. Confirmed at its current, reasoned value pending fixtures that
-    can actually exercise it.
+    can actually exercise it; adding one also needs a schema change, since
+    `evaluation/quality-gates.yml`'s `allowed_views` doesn't accept a frontal value yet.
     """
 
     # -- scoring (OP-32) -----------------------------------------------------------------------

--- a/packages/posture-core/src/posture_core/thresholds.py
+++ b/packages/posture-core/src/posture_core/thresholds.py
@@ -105,11 +105,11 @@ class Thresholds:
     same folded arms at twice the camera distance produced half the pixel separation and a
     different verdict. Dividing by a length measured on the same body cancels the scale.
 
-    **The value was measured, not assumed.** `docs/V2-PLAN.md` proposed 0.15 against a different
-    formula — `|forearm - upper_arm| / torso` — which compares two segments of the *same* arm and
-    evaluates to ~0.06 for typical adult proportions in any posture whatsoever; it would have
-    reported folded arms for everybody. Running the real backend over the eight fixtures gives a
-    clean separation on the wrist-to-opposite-elbow measure:
+    **The value was measured, not assumed** — at the time it was chosen. `docs/V2-PLAN.md` proposed
+    0.15 against a different formula — `|forearm - upper_arm| / torso` — which compares two segments
+    of the *same* arm and evaluates to ~0.06 for typical adult proportions in any posture
+    whatsoever; it would have reported folded arms for everybody. Running the real backend over the
+    eight fixtures at the time gave a clean separation on the wrist-to-opposite-elbow measure:
 
         straight_armsfolded.jpg   0.53   <- the one fixture with folded arms
         bench_feet_dangling.jpg   0.91
@@ -120,8 +120,21 @@ class Thresholds:
         kneeling_right.jpg        1.07
         desk_hunch.jpeg           1.20
 
-    0.70 sits in the gap with room on both sides. Eight photographs is a small sample and this
-    should be revisited against the evaluation set in Epic H.
+    **Recalibration against the evaluation set could not re-derive this value, because the metric no
+    longer produces one.** `arms_crossed` requires both wrists and both elbows above
+    the confidence floor. Re-run today, it abstains (`status: low_confidence`) on all eight fixtures
+    in `evaluation/manifest.csv`, including the folded-arms one that produced the 0.53 above — every
+    fixture is a lateral view, and a lateral view puts the far arm behind the torso, below
+    confidence, by construction. The number above is historical evidence for a formula that no
+    longer runs on this evaluation set, not current evidence for this threshold.
+
+    0.70 is confirmed at its current value rather than re-derived, because there is nothing to
+    re-derive it against yet. Closing that gap needs one of: frontal or three-quarter fixtures
+    added to the evaluation set (the same gap `lateral_view_max_ratio`/`frontal_view_min_ratio`
+    has below), or a decision — a code change, not a value change, so out of scope for a
+    recalibration pass — on whether a one-armed proxy (mirroring the `require_either_side` pattern
+    `knee_flexion_deg` and `elbow_flexion_deg` use) is an acceptable substitute for "both arms
+    visibly folded".
     """
 
     elbow_flexed_deg: float = 120.0
@@ -133,7 +146,18 @@ class Thresholds:
     """A hip-knee-ankle angle in this band is ordinary seated posture."""
 
     knee_kneeling_max_deg: float = 60.0
-    """Below this the subject is kneeling rather than sitting."""
+    """Below this the subject is kneeling rather than sitting.
+
+    **Diagnosis:** `kneeling_right.jpg` measures 80.3°, inside the seated band rather than
+    below this threshold, and moving the threshold would not fix that. The report for that fixture
+    reads "your **left** knee is at a comfortable seated angle" — `knee_flexion_deg` uses
+    `require_either_side`, which picked the visible left leg because the right knee (the one
+    actually kneeling, per the filename and the manifest's "lower legs partly occluded by chair"
+    note) is below the confidence floor in this composition. The kneeling leg was never measured; no
+    value of `knee_kneeling_max_deg` makes an unmeasured leg produce a kneeling verdict. This is a
+    side-selection artifact, not a miscalibration, so the threshold is confirmed at its current
+    value rather than retuned against a fixture that cannot exercise it.
+    """
 
     # -- heel contact (OP-30) ------------------------------------------------------------------
     heel_contact_tolerance_m: float = 0.05
@@ -148,6 +172,26 @@ class Thresholds:
     In metres, from world landmarks — which is why this metric is possible at all. The 18-point
     COCO schema the legacy engine used had no foot landmarks, so its feet check was a tautology
     that returned "on the floor" for a fixture whose subject's feet visibly dangle.
+
+    **Measurement.** Real backend, all eight fixtures:
+
+        desk_lean_exif.jpeg        0.0065
+        hunchback_left.jpg         0.0306
+        desk_hunch.jpeg            0.0487
+        straight_armsfolded.jpg    0.0501
+        hunchback_right.jpg        0.0514
+        reclined_right.jpg         0.0644
+        bench_feet_dangling.jpg    0.0629   <- the one fixture labelled as a dangling-feet case
+        kneeling_right.jpg         0.0694
+
+    Confirmed at its current value, not re-derived, because the evidence argues against tuning
+    rather than for a specific number: `reclined_right.jpg` and `kneeling_right.jpg` exceed the
+    labelled positive case despite carrying no feet-support label of their own, which means either
+    they are also genuinely unsupported (plausible — reclining and kneeling both commonly lift a
+    heel) or 0.05 m is too tight, and the manifest cannot currently distinguish the two: it has a
+    `posture_label` per image, not a feet-support label. A real recalibration needs that label added
+    to `evaluation/manifest.csv` before this tolerance can be honestly retuned rather than guessed
+    at. Treat this as the least settled threshold in the package until then.
     """
 
     # -- view confidence (OP-31) ---------------------------------------------------------------
@@ -158,10 +202,20 @@ class Thresholds:
     subject's real proportions. The original app *told* users to photograph themselves from the
     side and then assessed whatever arrived — so a 30° slump shot head-on, which projects to
     almost no apparent lean, was reported as good posture with full confidence.
+
+    **Measurement.** All eight `evaluation/manifest.csv` fixtures are lateral, and the real
+    backend measures 0.071-0.194 across them — comfortably under 0.35 with room to spare. This end
+    of the scale is now genuinely validated, not just reasoned; confirmed at its current value.
     """
 
     frontal_view_min_ratio: float = 0.55
-    """At or above this the view is frontal and sagittal metrics must abstain."""
+    """At or above this the view is frontal and sagittal metrics must abstain.
+
+    **Still unvalidated.** The evaluation set has no frontal or three-quarter fixture, so
+    there is nothing to measure this boundary against — the same gap `arms_crossed_ratio` has, and
+    for the same underlying reason. Confirmed at its current, reasoned value pending fixtures that
+    can actually exercise it.
+    """
 
     # -- scoring (OP-32) -----------------------------------------------------------------------
     score_penalty_per_finding: float = 15.0


### PR DESCRIPTION
## Summary
- `knee_kneeling_max_deg`: diagnosed the `kneeling_right.jpg` gap as a side-selection artifact, not a threshold problem — the occluded (right, kneeling) leg loses to the visible (left, seated) leg under `require_either_side`.
- `arms_crossed_ratio`: on the real backend the metric abstains on all 8 fixtures (every fixture is lateral, and the metric requires both arms), so the value it was originally measured against no longer exists on this evaluation set.
- `heel_contact_tolerance_m`: two fixtures with no feet-support label now measure higher than the one labelled dangling-feet case. The manifest has no feet-support ground truth to retune against.
- `lateral_view_max_ratio` / `frontal_view_min_ratio`: the lateral end is now genuinely validated by measurement (0.071-0.194 across all 8, well under 0.35); the frontal end still isn't — no frontal fixtures exist.

All four are **confirmed at their current values**, not moved. `rules.json` is unchanged; the evidence argues for documenting what's still unvalidated rather than guessing at new numbers.

## Why
Four thresholds shipped on 8 fixtures with reasoning rather than a proper evaluation set. Now that a real evaluation manifest exists, this either re-derives each one or honestly records why it can't be yet — the alternative (retuning against a fixture that can't exercise the threshold) produces a number that fits eight photographs and nothing else.

## Test plan
- [x] `uv run pytest packages/posture-core -q` — 364 passed
- [x] `uv run ruff check` / `ruff format --check` — clean
- [x] `uv run mypy packages/posture-core/src` — clean
- [x] `make validate-data` — OK
- [x] Golden snapshots regenerated — no diff (confirms no threshold values moved)
- [ ] CI green on this PR